### PR TITLE
connection error handling: unsupported version, unsupported transport, bad handshake method

### DIFF
--- a/engineioxide/src/errors.rs
+++ b/engineioxide/src/errors.rs
@@ -3,6 +3,7 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite;
 use tracing::debug;
 
+use crate::sid_generator::Sid;
 use crate::{body::ResponseBody, packet::Packet};
 
 #[derive(thiserror::Error, Debug)]
@@ -39,8 +40,12 @@ pub enum Error {
 
     #[error("transport unknown")]
     UnknownTransport,
+    #[error("unknown session id")]
+    UnknownSessionID(Sid),
     #[error("bad handshake method")]
     BadHandshakeMethod,
+    #[error("transport mismatch")]
+    TransportMismatch,
     #[error("unsupported protocol version")]
     UnsupportedProtocolVersion,
 }
@@ -68,8 +73,14 @@ impl<B> From<Error> for Response<ResponseBody<B>> {
             Error::UnknownTransport => {
                 conn_err_resp("{\"code\":\"0\",\"message\":\"Transport unknown\"}")
             }
+            Error::UnknownSessionID(_) => {
+                conn_err_resp("{\"code\":\"1\",\"message\":\"Session ID unknown\"}")
+            }
             Error::BadHandshakeMethod => {
                 conn_err_resp("{\"code\":\"2\",\"message\":\"Bad handshake method\"}")
+            }
+            Error::TransportMismatch => {
+                conn_err_resp("{\"code\":\"3\",\"message\":\"Bad request\"}")
             }
             Error::UnsupportedProtocolVersion => {
                 conn_err_resp("{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}")

--- a/engineioxide/src/errors.rs
+++ b/engineioxide/src/errors.rs
@@ -36,6 +36,10 @@ pub enum Error {
 
     #[error("http error response: {0:?}")]
     HttpErrorResponse(StatusCode),
+    #[error("unsupported protocol version")]
+    UnsupportedProtocolVersion,
+    #[error("transport unknown")]
+    UnknownTransport,
 }
 
 /// Convert an error into an http response
@@ -51,6 +55,14 @@ impl<B> From<Error> for Response<ResponseBody<B>> {
             Error::BadPacket(_) => Response::builder()
                 .status(400)
                 .body(ResponseBody::empty_response())
+                .unwrap(),
+            Error::UnsupportedProtocolVersion => Response::builder()
+                .status(400)
+                .body(ResponseBody::custom_response("{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}".into()))
+                .unwrap(),
+            Error::UnknownTransport => Response::builder()
+                .status(400)
+                .body(ResponseBody::custom_response("{\"code\":\"0\",\"message\":\"Transport unknown\"}".into()))
                 .unwrap(),
             e => {
                 debug!("uncaught error {e:?}");

--- a/engineioxide/src/errors.rs
+++ b/engineioxide/src/errors.rs
@@ -36,10 +36,13 @@ pub enum Error {
 
     #[error("http error response: {0:?}")]
     HttpErrorResponse(StatusCode),
-    #[error("unsupported protocol version")]
-    UnsupportedProtocolVersion,
+
     #[error("transport unknown")]
     UnknownTransport,
+    #[error("bad handshake method")]
+    BadHandshakeMethod,
+    #[error("unsupported protocol version")]
+    UnsupportedProtocolVersion,
 }
 
 /// Convert an error into an http response
@@ -56,16 +59,22 @@ impl<B> From<Error> for Response<ResponseBody<B>> {
                 .status(400)
                 .body(ResponseBody::empty_response())
                 .unwrap(),
-            Error::UnsupportedProtocolVersion => Response::builder()
-                .status(400)
-                .body(ResponseBody::custom_response(
-                    "{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}".into(),
-                ))
-                .unwrap(),
             Error::UnknownTransport => Response::builder()
                 .status(400)
                 .body(ResponseBody::custom_response(
                     "{\"code\":\"0\",\"message\":\"Transport unknown\"}".into(),
+                ))
+                .unwrap(),
+            Error::BadHandshakeMethod => Response::builder()
+                .status(400)
+                .body(ResponseBody::custom_response(
+                    "{\"code\":\"2\",\"message\":\"Bad handshake method\"}".into(),
+                ))
+                .unwrap(),
+            Error::UnsupportedProtocolVersion => Response::builder()
+                .status(400)
+                .body(ResponseBody::custom_response(
+                    "{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}".into(),
                 ))
                 .unwrap(),
             e => {

--- a/engineioxide/src/errors.rs
+++ b/engineioxide/src/errors.rs
@@ -58,11 +58,15 @@ impl<B> From<Error> for Response<ResponseBody<B>> {
                 .unwrap(),
             Error::UnsupportedProtocolVersion => Response::builder()
                 .status(400)
-                .body(ResponseBody::custom_response("{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}".into()))
+                .body(ResponseBody::custom_response(
+                    "{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}".into(),
+                ))
                 .unwrap(),
             Error::UnknownTransport => Response::builder()
                 .status(400)
-                .body(ResponseBody::custom_response("{\"code\":\"0\",\"message\":\"Transport unknown\"}".into()))
+                .body(ResponseBody::custom_response(
+                    "{\"code\":\"0\",\"message\":\"Transport unknown\"}".into(),
+                ))
                 .unwrap(),
             e => {
                 debug!("uncaught error {e:?}");

--- a/engineioxide/src/errors.rs
+++ b/engineioxide/src/errors.rs
@@ -50,6 +50,12 @@ pub enum Error {
 /// Otherwise, return a 500
 impl<B> From<Error> for Response<ResponseBody<B>> {
     fn from(err: Error) -> Self {
+        let conn_err_resp = |message: &'static str| {
+            Response::builder()
+                .status(400)
+                .body(ResponseBody::custom_response(message.into()))
+                .unwrap()
+        };
         match err {
             Error::HttpErrorResponse(code) => Response::builder()
                 .status(code)
@@ -59,24 +65,15 @@ impl<B> From<Error> for Response<ResponseBody<B>> {
                 .status(400)
                 .body(ResponseBody::empty_response())
                 .unwrap(),
-            Error::UnknownTransport => Response::builder()
-                .status(400)
-                .body(ResponseBody::custom_response(
-                    "{\"code\":\"0\",\"message\":\"Transport unknown\"}".into(),
-                ))
-                .unwrap(),
-            Error::BadHandshakeMethod => Response::builder()
-                .status(400)
-                .body(ResponseBody::custom_response(
-                    "{\"code\":\"2\",\"message\":\"Bad handshake method\"}".into(),
-                ))
-                .unwrap(),
-            Error::UnsupportedProtocolVersion => Response::builder()
-                .status(400)
-                .body(ResponseBody::custom_response(
-                    "{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}".into(),
-                ))
-                .unwrap(),
+            Error::UnknownTransport => {
+                conn_err_resp("{\"code\":\"0\",\"message\":\"Transport unknown\"}")
+            }
+            Error::BadHandshakeMethod => {
+                conn_err_resp("{\"code\":\"2\",\"message\":\"Bad handshake method\"}")
+            }
+            Error::UnsupportedProtocolVersion => {
+                conn_err_resp("{\"code\":\"5\",\"message\":\"Unsupported protocol version\"}")
+            }
             e => {
                 debug!("uncaught error {e:?}");
                 Response::builder()

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -255,12 +255,17 @@ impl RequestInfo {
             .and_then(|s| s.split('=').nth(1))
             .ok_or(UnknownTransport)
             .and_then(|t| t.parse())?;
+        let method = req.method().clone();
 
-        Ok(RequestInfo {
-            sid,
-            transport,
-            method: req.method().clone(),
-        })
+        if !matches!(method, Method::GET) && sid.is_none() {
+            Err(Error::BadHandshakeMethod)
+        } else {
+            Ok(RequestInfo {
+                sid,
+                transport,
+                method,
+            })
+        }
     }
 }
 

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -1,7 +1,14 @@
-use crate::sid_generator::Sid;
 use crate::{
-    body::ResponseBody, config::EngineIoConfig, engine::EngineIo, futures::ResponseFuture,
-    handler::EngineIoHandler,
+    errors::{
+        Error,
+        Error::{UnknownTransport, UnsupportedProtocolVersion}
+    },
+    sid_generator::Sid,
+    body::ResponseBody,
+    config::EngineIoConfig,
+    engine::EngineIo,
+    futures::ResponseFuture,
+    handler::EngineIoHandler
 };
 use bytes::Bytes;
 use futures::future::{ready, Ready};
@@ -107,26 +114,27 @@ where
         if req.uri().path().starts_with(&self.engine.config.req_path) {
             let engine = self.engine.clone();
             match RequestInfo::parse(&req) {
-                Some(RequestInfo {
+                Ok(RequestInfo {
                     sid: None,
                     transport: TransportType::Polling,
                     method: Method::GET,
                 }) => ResponseFuture::ready(engine.on_open_http_req(req)),
-                Some(RequestInfo {
+                Ok(RequestInfo {
                     sid: Some(sid),
                     transport: TransportType::Polling,
                     method: Method::GET,
                 }) => ResponseFuture::async_response(Box::pin(engine.on_polling_http_req(sid))),
-                Some(RequestInfo {
+                Ok(RequestInfo {
                     sid: Some(sid),
                     transport: TransportType::Polling,
                     method: Method::POST,
                 }) => ResponseFuture::async_response(Box::pin(engine.on_post_http_req(sid, req))),
-                Some(RequestInfo {
+                Ok(RequestInfo {
                     sid,
                     transport: TransportType::Websocket,
                     method: Method::GET,
                 }) => ResponseFuture::ready(engine.on_ws_req(sid, req)),
+                Err(e) => ResponseFuture::ready(Ok(e.into())),
                 _ => ResponseFuture::empty_response(400),
             }
         } else {
@@ -206,13 +214,13 @@ pub enum TransportType {
 }
 
 impl FromStr for TransportType {
-    type Err = ();
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "websocket" => Ok(TransportType::Websocket),
             "polling" => Ok(TransportType::Polling),
-            _ => Err(()),
+            _ => Err(UnknownTransport),
         }
     }
 }
@@ -229,10 +237,10 @@ struct RequestInfo {
 
 impl RequestInfo {
     /// Parse the request URI to extract the [`TransportType`](crate::service::TransportType) and the socket id.
-    fn parse<B>(req: &Request<B>) -> Option<Self> {
-        let query = req.uri().query()?;
+    fn parse<B>(req: &Request<B>) -> Result<Self, Error> {
+        let query = req.uri().query().ok_or(UnknownTransport)?;
         if !query.contains("EIO=4") {
-            return None;
+            return Err(UnsupportedProtocolVersion);
         }
 
         let sid = query
@@ -241,15 +249,13 @@ impl RequestInfo {
             .and_then(|s| s.split('=').nth(1).map(|s1| s1.parse().ok()))
             .flatten();
 
-        let transport: TransportType = query
+        let transport = query
             .split('&')
-            .find(|s| s.starts_with("transport="))?
-            .split('=')
-            .nth(1)?
-            .parse()
-            .ok()?;
+            .find(|s| s.starts_with("transport="))
+            .and_then(|s| s.split('=').nth(1)).ok_or(UnknownTransport).map(|t| t.parse())??;
 
-        Some(RequestInfo {
+
+        Ok(RequestInfo {
             sid,
             transport,
             method: req.method().clone(),
@@ -285,7 +291,9 @@ mod tests {
 
     #[test]
     fn request_info_polling_with_sid() {
-        let req = build_request("http://localhost:3000/socket.io/?EIO=4&transport=polling&sid=AAAAAAAAAHs");
+        let req = build_request(
+            "http://localhost:3000/socket.io/?EIO=4&transport=polling&sid=AAAAAAAAAHs",
+        );
         let info = RequestInfo::parse(&req).unwrap();
         assert_eq!(info.sid, Some(123i64.into()));
         assert_eq!(info.transport, TransportType::Polling);
@@ -294,8 +302,9 @@ mod tests {
 
     #[test]
     fn request_info_websocket_with_sid() {
-        let req =
-            build_request("http://localhost:3000/socket.io/?EIO=4&transport=websocket&sid=AAAAAAAAAHs");
+        let req = build_request(
+            "http://localhost:3000/socket.io/?EIO=4&transport=websocket&sid=AAAAAAAAAHs",
+        );
         let info = RequestInfo::parse(&req).unwrap();
         assert_eq!(info.sid, Some(123i64.into()));
         assert_eq!(info.transport, TransportType::Websocket);

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -1,14 +1,14 @@
 use crate::{
-    errors::{
-        Error,
-        Error::{UnknownTransport, UnsupportedProtocolVersion}
-    },
-    sid_generator::Sid,
     body::ResponseBody,
     config::EngineIoConfig,
     engine::EngineIo,
+    errors::{
+        Error,
+        Error::{UnknownTransport, UnsupportedProtocolVersion},
+    },
     futures::ResponseFuture,
-    handler::EngineIoHandler
+    handler::EngineIoHandler,
+    sid_generator::Sid,
 };
 use bytes::Bytes;
 use futures::future::{ready, Ready};
@@ -252,8 +252,9 @@ impl RequestInfo {
         let transport = query
             .split('&')
             .find(|s| s.starts_with("transport="))
-            .and_then(|s| s.split('=').nth(1)).ok_or(UnknownTransport).map(|t| t.parse())??;
-
+            .and_then(|s| s.split('=').nth(1))
+            .ok_or(UnknownTransport)
+            .map(|t| t.parse())??;
 
         Ok(RequestInfo {
             sid,

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -249,12 +249,12 @@ impl RequestInfo {
             .and_then(|s| s.split('=').nth(1).map(|s1| s1.parse().ok()))
             .flatten();
 
-        let transport = query
+        let transport: TransportType = query
             .split('&')
             .find(|s| s.starts_with("transport="))
             .and_then(|s| s.split('=').nth(1))
             .ok_or(UnknownTransport)
-            .map(|t| t.parse())??;
+            .and_then(|t| t.parse())?;
 
         Ok(RequestInfo {
             sid,


### PR DESCRIPTION
In case of request contains unsupported transport or version, the server replies with code and message according 
[protocol
](https://socket.io/docs/v4/server-instance/)

```
Code | Message
-- | --
0 | "Transport unknown"
1 | "Session ID unknown"
2 | "Bad handshake method"
3 | "Bad request"
5 | "Unsupported protocol version"

```