### PR TITLE
Add Warp usage example & split examples and e2e testing

### DIFF
--- a/.github/workflows/socketio-ci.yml
+++ b/.github/workflows/socketio-ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Install deps & run tests 
         run: |
           cd socket.io-protocol/test-suite && npm install && cd ../..
-          cargo build --example socketio-axum-echo --release
-          cargo run --example socketio-axum-echo --release > server.txt & npm --prefix socket.io-protocol/test-suite test > client.txt
+          cargo build --bin socketioxide-e2e --release
+          cargo run --bin socketioxide-e2e --release > server.txt & npm --prefix socket.io-protocol/test-suite test > client.txt
       - name: Server output
         if: always()
         run: cat server.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "socketioxide-e2e"
+version = "0.3.0"
+dependencies = [
+ "engineioxide",
+ "futures",
+ "hyper",
+ "serde_json",
+ "socketioxide",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "socketioxide-examples"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -336,11 +342,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "engineioxide"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.21.0",
  "base64id",
  "bytes",
  "criterion",
@@ -354,7 +369,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.19.0",
  "tower",
  "tracing",
 ]
@@ -535,6 +550,31 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -756,6 +796,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +815,24 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1027,6 +1095,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1123,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1196,7 +1279,14 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "warp",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
@@ -1313,6 +1403,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.18.0",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,7 +1434,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.19.0",
 ]
 
 [[package]]
@@ -1455,6 +1568,25 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
@@ -1477,6 +1609,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -1546,6 +1687,37 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "rustls-pemfile",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.18.0",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["engineioxide", "socketioxide", "examples"]
+members = ["engineioxide", "socketioxide", "examples", "e2e"]

--- a/Readme.md
+++ b/Readme.md
@@ -2,9 +2,9 @@
 [![SocketIO CI](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml/badge.svg)](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml)
 ### Socket.IO server implementation as a [tower layer](https://docs.rs/tower/latest/tower/) in Rust
 It integrates with any framework based on tower/hyper, such as:
-* [axum](https://docs.rs/axum/latest/axum/)
-* [warp](https://docs.rs/warp/latest/warp/)
-* [hyper](https://docs.rs/hyper/latest/hyper/)
+* [axum](https://docs.rs/axum/latest/axum/): [echo implementation](./examples/src/socketio-echo/axum_echo.rs)
+* [warp](https://docs.rs/warp/latest/warp/): [echo implementation](./examples/src/socketio-echo/warp_echo.rs)
+* [hyper](https://docs.rs/hyper/latest/hyper/): [echo implementation](./examples/src/socketio-echo/hyper_echo.rs)
 
 It takes full advantage of the [tower](https://docs.rs/tower/latest/tower/) and [tower-http](https://docs.rs/tower-http/latest/tower_http/) ecosystem of middleware, services, and utilities.
 
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/", get(|| async { "Hello, World!" }))
         .layer(SocketIoLayer::new(ns));
 
-    Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    Server::bind(&"127.0.0.1:3000".parse().unwrap())
         .serve(app.into_make_service())
         .await?;
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "socketioxide-e2e"
+version = "0.3.0"
+edition = "2021"
+
+[dependencies]
+engineioxide = { path = "../engineioxide" }
+socketioxide = { path = "../socketioxide" }
+hyper = { version = "0.14.26" }
+tokio = { version = "1.13.0", features = ["full"] }
+tower = { version = "0.4.13" }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing = "0.1.37"
+serde_json = "1.0.95"
+futures = "0.3.27"
+
+[[bin]]
+name = "socketioxide-e2e"
+path = "src/socketioxide.rs"
+
+[[bin]]
+name = "engineioxide-e2e"
+path = "src/engineioxide.rs"

--- a/e2e/src/engineioxide.rs
+++ b/e2e/src/engineioxide.rs
@@ -1,0 +1,63 @@
+//! This a end to end test server used with this [test suite](https://github.com/socketio/engine.io-protocol)
+
+use std::{sync::Arc, time::Duration};
+
+use engineioxide::{
+    config::EngineIoConfig, handler::EngineIoHandler, service::EngineIoService, socket::Socket,
+};
+use hyper::Server;
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+#[derive(Debug, Clone)]
+struct MyHandler;
+
+#[engineioxide::async_trait]
+impl EngineIoHandler for MyHandler {
+    type Data = ();
+
+    fn on_connect(&self, socket: &Socket<Self>) {
+        println!("socket connect {}", socket.sid);
+    }
+    fn on_disconnect(&self, socket: &Socket<Self>) {
+        println!("socket disconnect {}", socket.sid);
+    }
+
+    fn on_message(&self, msg: String, socket: &Socket<Self>) {
+        println!("Ping pong message {:?}", msg);
+        socket.emit(msg).ok();
+    }
+
+    fn on_binary(&self, data: Vec<u8>, socket: &Socket<Self>) {
+        println!("Ping pong binary message {:?}", data);
+        socket.emit_binary(data).ok();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = FmtSubscriber::builder()
+        .with_line_number(true)
+        .with_max_level(Level::DEBUG)
+        .finish();
+
+    let config = EngineIoConfig::builder()
+        .ping_interval(Duration::from_millis(300))
+        .ping_timeout(Duration::from_millis(200))
+        .max_payload(1e6 as u64)
+        .build();
+
+
+    let addr = &"127.0.0.1:3000".parse().unwrap();
+    let handler = Arc::new(MyHandler);
+    let svc = EngineIoService::with_config(handler, config);
+
+    let server = Server::bind(&addr).serve(svc.into_make_service());
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    info!("Starting server");
+
+    server.await?;
+
+    Ok(())
+}

--- a/e2e/src/engineioxide.rs
+++ b/e2e/src/engineioxide.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handler = Arc::new(MyHandler);
     let svc = EngineIoService::with_config(handler, config);
 
-    let server = Server::bind(&addr).serve(svc.into_make_service());
+    let server = Server::bind(addr).serve(svc.into_make_service());
     tracing::subscriber::set_global_default(subscriber)?;
 
     info!("Starting server");

--- a/e2e/src/socketioxide.rs
+++ b/e2e/src/socketioxide.rs
@@ -1,0 +1,55 @@
+//! This a end to end test server used with this [test suite](https://github.com/socketio/socket.io-protocol)
+
+use std::time::Duration;
+
+use hyper::Server;
+use serde_json::Value;
+use socketioxide::{Namespace, SocketIoConfig, SocketIoService};
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = FmtSubscriber::builder()
+        .with_line_number(true)
+        .with_max_level(Level::DEBUG)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    let config = SocketIoConfig::builder()
+        .ping_interval(Duration::from_millis(300))
+        .ping_timeout(Duration::from_millis(200))
+        .max_payload(1e6 as u64)
+        .build();
+    info!("Starting server");
+
+    let ns = Namespace::builder()
+        .add("/", |socket| async move {
+            info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.sid);
+            let data: Value = socket.handshake.data().unwrap();
+            socket.emit("auth", data).ok();
+
+            socket.on("message", |socket, data: Value, bin, _| async move {
+                info!("Received event: {:?} {:?}", data, bin);
+                socket.bin(bin).emit("message-back", data).ok();
+            });
+
+            socket.on("message-with-ack", |_, data: Value, bin, ack| async move {
+                info!("Received event: {:?} {:?}", data, bin);
+                ack.bin(bin).send(data).ok();
+            });
+        })
+        .add("/custom", |socket| async move {
+            info!("Socket.IO connected on: {:?} {:?}", socket.ns(), socket.sid);
+            let data: Value = socket.handshake.data().unwrap();
+            socket.emit("auth", data).ok();
+        })
+        .build();
+
+    let svc = SocketIoService::with_config(ns, config);
+    Server::bind(&"127.0.0.1:3000".parse().unwrap())
+        .serve(svc.into_make_service())
+        .await?;
+
+    Ok(())
+}

--- a/engineioxide/src/config.rs
+++ b/engineioxide/src/config.rs
@@ -17,6 +17,8 @@ pub struct EngineIoConfig {
     /// The maximum number of packets that can be buffered per connection before being emitted to the client.
     ///
     /// If the buffer if full the `emit()` method will return an error
+    /// 
+    /// Defaults to 128 packets
     pub max_buffer_size: usize,
 
     /// The maximum number of bytes that can be received per http request.

--- a/engineioxide/src/engine.rs
+++ b/engineioxide/src/engine.rs
@@ -44,13 +44,8 @@ impl<H> EngineIo<H>
 where
     H: EngineIoHandler + ?Sized,
 {
-    /// Create a new Engine.IO server with default config
-    pub fn new(handler: Arc<H>) -> Self {
-        Self::from_config(handler, EngineIoConfig::default())
-    }
-
-    /// Create a new Engine.IO server with a custom config
-    pub fn from_config(handler: Arc<H>, config: EngineIoConfig) -> Self {
+    /// Create a new Engine.IO server with a handler and a config
+    pub fn new(handler: Arc<H>, config: EngineIoConfig) -> Self {
         Self {
             sockets: RwLock::new(HashMap::new()),
             config,

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -63,7 +63,7 @@ where
     pub fn with_config_inner(inner: S, handler: Arc<H>, config: EngineIoConfig) -> Self {
         EngineIoService {
             inner,
-            engine: Arc::new(EngineIo::from_config(handler, config)),
+            engine: Arc::new(EngineIo::new(handler, config)),
         }
     }
 

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -42,17 +42,11 @@ where
     /// Create a new [`EngineIoService`] with a [`NotFoundService`] as the inner service.
     /// If the request is not an `EngineIo` request, it will always return a 404 response.
     pub fn new(handler: Arc<H>) -> Self {
-        EngineIoService {
-            inner: NotFoundService,
-            engine: Arc::new(EngineIo::new(handler)),
-        }
+        EngineIoService::with_config(handler, EngineIoConfig::default())
     }
     /// Create a new [`EngineIoService`] with a custom config
     pub fn with_config(handler: Arc<H>, config: EngineIoConfig) -> Self {
-        EngineIoService {
-            inner: NotFoundService,
-            engine: Arc::new(EngineIo::from_config(handler, config)),
-        }
+        EngineIoService::with_config_inner(NotFoundService, handler, config)
     }
 }
 impl<S, H> EngineIoService<H, S>
@@ -60,6 +54,11 @@ where
     H: EngineIoHandler + ?Sized,
     S: Clone,
 {
+    /// Create a new [`EngineIoService`] with a custom inner service.
+    pub fn with_inner(inner: S, handler: Arc<H>) -> Self {
+        EngineIoService::with_config_inner(inner, handler, EngineIoConfig::default())
+    }
+
     /// Create a new [`EngineIoService`] with a custom inner service and a custom config.
     pub fn with_config_inner(inner: S, handler: Arc<H>, config: EngineIoConfig) -> Self {
         EngineIoService {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 engineioxide = { path = "../engineioxide" }
 socketioxide = { path = "../socketioxide" }
 axum = { version = "0.6.10" }
+warp = { version = "0.3.1" }
 hyper = { version = "0.14.26" }
 tokio = { version = "1.13.0", features = ["full"] }
 tower = { version = "0.4.13" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,12 +29,20 @@ name = "engineio-hyper-echo"
 path = "src/engineio-echo/hyper_echo.rs"
 
 [[example]]
+name = "engineio-warp-echo"
+path = "src/engineio-echo/warp_echo.rs"
+
+[[example]]
 name = "socketio-axum-echo"
 path = "src/socketio-echo/axum_echo.rs"
 
 [[example]]
 name = "socketio-hyper-echo"
 path = "src/socketio-echo/hyper_echo.rs"
+
+[[example]]
+name = "socketio-warp-echo"
+path = "src/socketio-echo/warp_echo.rs"
 
 [[example]]
 name = "chat"

--- a/examples/src/engineio-echo/hyper_echo.rs
+++ b/examples/src/engineio-echo/hyper_echo.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handler = Arc::new(MyHandler);
     let svc = EngineIoService::new(handler);
 
-    let server = Server::bind(&addr).serve(svc.into_make_service());
+    let server = Server::bind(addr).serve(svc.into_make_service());
 
     info!("Starting server");
 

--- a/examples/src/engineio-echo/hyper_echo.rs
+++ b/examples/src/engineio-echo/hyper_echo.rs
@@ -1,10 +1,8 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use engineioxide::{
-    config::EngineIoConfig, handler::EngineIoHandler, service::EngineIoService, socket::Socket,
-};
+use engineioxide::{handler::EngineIoHandler, service::EngineIoService, socket::Socket};
 use hyper::Server;
-use tracing::{info, Level};
+use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
 #[derive(Debug, Clone)]
@@ -34,24 +32,14 @@ impl EngineIoHandler for MyHandler {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = FmtSubscriber::builder()
-        .with_line_number(true)
-        .with_max_level(Level::INFO)
-        .finish();
-
-    let config = EngineIoConfig::builder()
-        .ping_interval(Duration::from_millis(300))
-        .ping_timeout(Duration::from_millis(200))
-        .max_payload(1e6 as u64)
-        .build();
+    tracing::subscriber::set_global_default(FmtSubscriber::default())?;
 
     // We'll bind to 127.0.0.1:3000
-    let addr = &"0.0.0.0:3000".parse().unwrap();
+    let addr = &"127.0.0.1:3000".parse().unwrap();
     let handler = Arc::new(MyHandler);
-    let svc = EngineIoService::with_config(handler, config);
+    let svc = EngineIoService::new(handler);
 
     let server = Server::bind(&addr).serve(svc.into_make_service());
-    tracing::subscriber::set_global_default(subscriber)?;
 
     info!("Starting server");
 

--- a/examples/src/engineio-echo/warp_echo.rs
+++ b/examples/src/engineio-echo/warp_echo.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handler = Arc::new(MyHandler);
     let svc = EngineIoService::with_inner(warp_svc, handler);
 
-    let server = Server::bind(&addr).serve(svc.into_make_service());
+    let server = Server::bind(addr).serve(svc.into_make_service());
 
     info!("Starting server");
 

--- a/examples/src/engineio-echo/warp_echo.rs
+++ b/examples/src/engineio-echo/warp_echo.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use engineioxide::{handler::EngineIoHandler, service::EngineIoService, socket::Socket};
+use hyper::Server;
+use tracing::info;
+use tracing_subscriber::FmtSubscriber;
+use warp::Filter;
+
+#[derive(Debug, Clone)]
+struct MyHandler;
+
+#[engineioxide::async_trait]
+impl EngineIoHandler for MyHandler {
+    type Data = ();
+
+    fn on_connect(&self, socket: &Socket<Self>) {
+        println!("socket connect {}", socket.sid);
+    }
+    fn on_disconnect(&self, socket: &Socket<Self>) {
+        println!("socket disconnect {}", socket.sid);
+    }
+
+    fn on_message(&self, msg: String, socket: &Socket<Self>) {
+        println!("Ping pong message {:?}", msg);
+        socket.emit(msg).ok();
+    }
+
+    fn on_binary(&self, data: Vec<u8>, socket: &Socket<Self>) {
+        println!("Ping pong binary message {:?}", data);
+        socket.emit_binary(data).ok();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing::subscriber::set_global_default(FmtSubscriber::default())?;
+
+    let filter = warp::any().map(|| "Hello From Warp!");
+    let warp_svc = warp::service(filter);
+
+    // We'll bind to 127.0.0.1:3000
+    let addr = &"0.0.0.0:3000".parse().unwrap();
+    let handler = Arc::new(MyHandler);
+    let svc = EngineIoService::with_inner(warp_svc, handler);
+
+    let server = Server::bind(&addr).serve(svc.into_make_service());
+
+    info!("Starting server");
+
+    server.await?;
+
+    Ok(())
+}

--- a/examples/src/engineio-echo/warp_echo.rs
+++ b/examples/src/engineio-echo/warp_echo.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let warp_svc = warp::service(filter);
 
     // We'll bind to 127.0.0.1:3000
-    let addr = &"0.0.0.0:3000".parse().unwrap();
+    let addr = &"127.0.0.1:3000".parse().unwrap();
     let handler = Arc::new(MyHandler);
     let svc = EngineIoService::with_inner(warp_svc, handler);
 

--- a/examples/src/socketio-echo/axum_echo.rs
+++ b/examples/src/socketio-echo/axum_echo.rs
@@ -1,26 +1,14 @@
-use std::time::Duration;
-
 use axum::routing::get;
 use axum::Server;
 use serde_json::Value;
-use socketioxide::{Namespace, SocketIoConfig, SocketIoLayer};
-use tracing::{info, Level};
+use socketioxide::{Namespace, SocketIoLayer};
+use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = FmtSubscriber::builder()
-        .with_line_number(true)
-        .with_max_level(Level::DEBUG)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+    tracing::subscriber::set_global_default(FmtSubscriber::default())?;
 
-    let config = SocketIoConfig::builder()
-        .ping_interval(Duration::from_millis(300))
-        .ping_timeout(Duration::from_millis(200))
-        .max_payload(1e6 as u64)
-        .build();
-    info!("Starting server");
     let ns = Namespace::builder()
         .add("/", |socket| async move {
             info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.sid);
@@ -46,9 +34,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let app = axum::Router::new()
         .route("/", get(|| async { "Hello, World!" }))
-        .layer(SocketIoLayer::from_config(config, ns));
+        .layer(SocketIoLayer::new(ns));
 
-    Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    info!("Starting server");
+
+    Server::bind(&"127.0.0.1:3000".parse().unwrap())
         .serve(app.into_make_service())
         .await?;
 

--- a/examples/src/socketio-echo/hyper_echo.rs
+++ b/examples/src/socketio-echo/hyper_echo.rs
@@ -1,25 +1,12 @@
-use std::time::Duration;
-
 use hyper::Server;
 use serde_json::Value;
-use socketioxide::{Namespace, SocketIoConfig, SocketIoService};
-use tracing::{info, Level};
+use socketioxide::{Namespace, SocketIoService};
+use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = FmtSubscriber::builder()
-        .with_line_number(true)
-        .with_max_level(Level::DEBUG)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
-
-    let config = SocketIoConfig::builder()
-        .ping_interval(Duration::from_millis(300))
-        .ping_timeout(Duration::from_millis(200))
-        .max_payload(1e6 as u64)
-        .build();
-    info!("Starting server");
+    tracing::subscriber::set_global_default(FmtSubscriber::default())?;
 
     let ns = Namespace::builder()
         .add("/", |socket| async move {
@@ -44,8 +31,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .build();
 
-    let svc = SocketIoService::with_config(ns, config);
-    Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    info!("Starting server");
+
+    let svc = SocketIoService::new(ns);
+    Server::bind(&"127.0.0.1:3000".parse().unwrap())
         .serve(svc.into_make_service())
         .await?;
 

--- a/examples/src/socketio-echo/warp_echo.rs
+++ b/examples/src/socketio-echo/warp_echo.rs
@@ -1,0 +1,46 @@
+use hyper::Server;
+use serde_json::Value;
+use socketioxide::{Namespace, SocketIoService};
+use tracing::info;
+use tracing_subscriber::FmtSubscriber;
+use warp::Filter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing::subscriber::set_global_default(FmtSubscriber::default())?;
+
+    info!("Starting server");
+
+    let ns = Namespace::builder()
+        .add("/", |socket| async move {
+            info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.sid);
+            let data: Value = socket.handshake.data().unwrap();
+            socket.emit("auth", data).ok();
+
+            socket.on("message", |socket, data: Value, bin, _| async move {
+                info!("Received event: {:?} {:?}", data, bin);
+                socket.bin(bin).emit("message-back", data).ok();
+            });
+
+            socket.on("message-with-ack", |_, data: Value, bin, ack| async move {
+                info!("Received event: {:?} {:?}", data, bin);
+                ack.bin(bin).send(data).ok();
+            });
+        })
+        .add("/custom", |socket| async move {
+            info!("Socket.IO connected on: {:?} {:?}", socket.ns(), socket.sid);
+            let data: Value = socket.handshake.data().unwrap();
+            socket.emit("auth", data).ok();
+        })
+        .build();
+
+    let filter = warp::any().map(|| "Hello From Warp!");
+    let warp_svc = warp::service(filter);
+
+    let svc = SocketIoService::with_inner(warp_svc, ns);
+    Server::bind(&"0.0.0.0:3000".parse().unwrap())
+        .serve(svc.into_make_service())
+        .await?;
+
+    Ok(())
+}

--- a/examples/src/socketio-echo/warp_echo.rs
+++ b/examples/src/socketio-echo/warp_echo.rs
@@ -9,8 +9,6 @@ use warp::Filter;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::subscriber::set_global_default(FmtSubscriber::default())?;
 
-    info!("Starting server");
-
     let ns = Namespace::builder()
         .add("/", |socket| async move {
             info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.sid);
@@ -37,8 +35,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let filter = warp::any().map(|| "Hello From Warp!");
     let warp_svc = warp::service(filter);
 
+    info!("Starting server");
+
     let svc = SocketIoService::with_inner(warp_svc, ns);
-    Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    Server::bind(&"127.0.0.1:3000".parse().unwrap())
         .serve(svc.into_make_service())
         .await?;
 

--- a/socketioxide/src/config.rs
+++ b/socketioxide/src/config.rs
@@ -8,6 +8,8 @@ pub struct SocketIoConfigBuilder {
 }
 
 impl SocketIoConfigBuilder {
+
+    /// Create a new config builder
     pub fn new() -> Self {
         Self {
             config: SocketIoConfig::default(),
@@ -15,6 +17,7 @@ impl SocketIoConfigBuilder {
     }
 
     /// The path to listen for socket.io requests on.
+    /// 
     /// Defaults to "/socket.io".
     pub fn req_path(mut self, req_path: String) -> Self {
         self.config.engine_config.req_path = req_path;
@@ -22,13 +25,15 @@ impl SocketIoConfigBuilder {
     }
 
     /// The interval at which the server will send a ping packet to the client.
+    /// 
     /// Defaults to 25 seconds.
     pub fn ping_interval(mut self, ping_interval: Duration) -> Self {
         self.config.engine_config.ping_interval = ping_interval;
         self
     }
 
-    // The amount of time the server will wait for a ping response from the client before closing the connection.
+    /// The amount of time the server will wait for a ping response from the client before closing the connection.
+    /// 
     /// Defaults to 20 seconds.
     pub fn ping_timeout(mut self, ping_timeout: Duration) -> Self {
         self.config.engine_config.ping_timeout = ping_timeout;
@@ -37,19 +42,24 @@ impl SocketIoConfigBuilder {
 
     /// The maximum number of packets that can be buffered per connection before being emitted to the client.
     /// If the buffer if full the `emit()` method will return an error
+    /// 
+    /// Defaults to 128 packets.
     pub fn max_buffer_size(mut self, max_buffer_size: usize) -> Self {
         self.config.engine_config.max_buffer_size = max_buffer_size;
         self
     }
 
     /// The maximum size of a payload in bytes.
-    /// If a payload is bigger than this value the `emit()` method will return an error
+    /// If a payload is bigger than this value the `emit()` method will return an error.
+    /// 
+    /// Defaults to 100 kb.
     pub fn max_payload(mut self, max_payload: u64) -> Self {
         self.config.engine_config.max_payload = max_payload;
         self
     }
 
     /// The amount of time the server will wait for an acknowledgement from the client before closing the connection.
+    /// 
     /// Defaults to 5 seconds.
     pub fn ack_timeout(mut self, ack_timeout: Duration) -> Self {
         self.config.ack_timeout = ack_timeout;
@@ -75,6 +85,8 @@ pub struct SocketIoConfig {
     pub(crate) engine_config: EngineIoConfig,
 
     /// The amount of time the server will wait for an acknowledgement from the client before closing the connection.
+    /// 
+    /// Defaults to 5 seconds.
     pub(crate) ack_timeout: Duration,
 }
 

--- a/socketioxide/src/service.rs
+++ b/socketioxide/src/service.rs
@@ -7,8 +7,8 @@ use tower::Service;
 use crate::{adapter::Adapter, client::Client, ns::NsHandlers, SocketIoConfig};
 
 /// The service for Socket.IO
-/// 
-/// It is a wrapper around the Engine.IO service. 
+///
+/// It is a wrapper around the Engine.IO service.
 /// Its main purpose is to be able to use it as standalone Socket.IO service
 pub struct SocketIoService<A: Adapter, S: Clone> {
     engine_svc: EngineIoService<Client<A>, S>,
@@ -44,9 +44,7 @@ impl<A: Adapter> SocketIoService<A, NotFoundService> {
 
     /// Create a new [`SocketIoService`] with a custom config
     pub fn with_config(ns_handlers: NsHandlers<A>, config: SocketIoConfig) -> Self {
-        let client = Client::new(config.clone(), ns_handlers.clone());
-        let svc = EngineIoService::with_config(client.into(), config.engine_config);
-        Self { engine_svc: svc }
+        SocketIoService::with_config_inner(NotFoundService, ns_handlers, config)
     }
 }
 
@@ -55,6 +53,12 @@ impl<A: Adapter, S: Clone> SocketIoService<A, S> {
     pub fn into_make_service(self) -> MakeEngineIoService<Client<A>, S> {
         self.engine_svc.into_make_service()
     }
+
+    /// Create a new [`EngineIoService`] with a custom inner service.
+    pub fn with_inner(inner: S, ns_handlers: NsHandlers<A>) -> Self {
+        SocketIoService::with_config_inner(inner, ns_handlers, SocketIoConfig::default())
+    }
+
     /// Create a new [`EngineIoService`] with a custom inner service and a custom config.
     pub fn with_config_inner(inner: S, ns_handlers: NsHandlers<A>, config: SocketIoConfig) -> Self {
         let client = Client::new(config.clone(), ns_handlers.clone());


### PR DESCRIPTION
* Adds [socketio-echo/warp_echo.rs](examples/src/socketio-echo/warp_echo.rs)
* Adds [engineio-echo/warp_echo.rs](examples/src/engineio-echo/warp_echo.rs)
* Removes all weird configurations used to test correct protocol implementation with test-suites.
* All test implementations are now in the `e2e` package
* Refactor some unused fn in Service struct