### PR TITLE
Set content-type and charset

### DIFF
--- a/engineioxide/src/errors.rs
+++ b/engineioxide/src/errors.rs
@@ -58,6 +58,7 @@ impl<B> From<Error> for Response<ResponseBody<B>> {
         let conn_err_resp = |message: &'static str| {
             Response::builder()
                 .status(400)
+                .header("Content-Type", "application/json")
                 .body(ResponseBody::custom_response(message.into()))
                 .unwrap()
         };

--- a/engineioxide/src/futures.rs
+++ b/engineioxide/src/futures.rs
@@ -24,6 +24,7 @@ where
 {
     Response::builder()
         .status(code)
+        .header("Content-Type", "text/plain")
         .body(ResponseBody::custom_response(data.into()))
 }
 

--- a/engineioxide/src/futures.rs
+++ b/engineioxide/src/futures.rs
@@ -24,7 +24,7 @@ where
 {
     Response::builder()
         .status(code)
-        .header("Content-Type", "text/plain")
+        .header("Content-Type", "text/plain; charset=UTF-8")
         .body(ResponseBody::custom_response(data.into()))
 }
 


### PR DESCRIPTION
set content type header.
it's better for client to decode response,  it's good also for debugging using sniffers