### PR TITLE
Removing arc from handler property in `Engine`

### DIFF
--- a/e2e/src/engineioxide.rs
+++ b/e2e/src/engineioxide.rs
@@ -1,6 +1,6 @@
 //! This a end to end test server used with this [test suite](https://github.com/socketio/engine.io-protocol)
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use engineioxide::{
     config::EngineIoConfig, handler::EngineIoHandler, service::EngineIoService, socket::Socket,
@@ -47,10 +47,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .max_payload(1e6 as u64)
         .build();
 
-
     let addr = &"127.0.0.1:3000".parse().unwrap();
-    let handler = Arc::new(MyHandler);
-    let svc = EngineIoService::with_config(handler, config);
+    let svc = EngineIoService::with_config(MyHandler, config);
 
     let server = Server::bind(addr).serve(svc.into_make_service());
     tracing::subscriber::set_global_default(subscriber)?;

--- a/engineioxide/src/engine.rs
+++ b/engineioxide/src/engine.rs
@@ -31,21 +31,17 @@ use tracing::debug;
 type SocketMap<T> = RwLock<HashMap<Sid, Arc<T>>>;
 /// Abstract engine implementation for Engine.IO server for http polling and websocket
 /// It handle all the connection logic and dispatch the packets to the socket
-pub struct EngineIo<H>
-where
-    H: EngineIoHandler + ?Sized,
+pub struct EngineIo<H: EngineIoHandler>
 {
     sockets: SocketMap<Socket<H>>,
-    handler: Arc<H>,
+    handler: H,
     pub config: EngineIoConfig,
 }
 
-impl<H> EngineIo<H>
-where
-    H: EngineIoHandler + ?Sized,
+impl<H: EngineIoHandler> EngineIo<H>
 {
     /// Create a new Engine.IO server with a handler and a config
-    pub fn new(handler: Arc<H>, config: EngineIoConfig) -> Self {
+    pub fn new(handler: H, config: EngineIoConfig) -> Self {
         Self {
             sockets: RwLock::new(HashMap::new()),
             config,
@@ -54,9 +50,7 @@ where
     }
 }
 
-impl<H> EngineIo<H>
-where
-    H: EngineIoHandler + ?Sized,
+impl<H: EngineIoHandler> EngineIo<H>
 {
     /// Handle Open request
     /// Create a new socket and add it to the socket map

--- a/engineioxide/src/handler.rs
+++ b/engineioxide/src/handler.rs
@@ -4,7 +4,7 @@ use crate::socket::Socket;
 
 /// An handler for engine.io events for each sockets.
 #[async_trait]
-pub trait EngineIoHandler: std::fmt::Debug + Send + Sync + 'static {
+pub trait EngineIoHandler: std::fmt::Debug + Send + Sync + Clone + 'static {
     /// Data associated with the socket.
     type Data: Default + Send + Sync + std::fmt::Debug + 'static;
 

--- a/engineioxide/src/layer.rs
+++ b/engineioxide/src/layer.rs
@@ -14,13 +14,13 @@ impl<H: EngineIoHandler> EngineIoLayer<H>
     pub fn new(handler: H) -> Self {
         Self {
             config: EngineIoConfig::default(),
-            handler: handler.into(),
+            handler,
         }
     }
     pub fn from_config(handler: H, config: EngineIoConfig) -> Self {
         Self {
             config,
-            handler: handler.into(),
+            handler,
         }
     }
 }

--- a/engineioxide/src/layer.rs
+++ b/engineioxide/src/layer.rs
@@ -1,20 +1,15 @@
 use tower::Layer;
 
 use crate::{config::EngineIoConfig, handler::EngineIoHandler, service::EngineIoService};
-use std::sync::Arc;
 
 #[derive(Debug, Clone)]
-pub struct EngineIoLayer<H>
-where
-    H: EngineIoHandler,
+pub struct EngineIoLayer<H: EngineIoHandler>
 {
     config: EngineIoConfig,
-    handler: Arc<H>,
+    handler: H,
 }
 
-impl<H> EngineIoLayer<H>
-where
-    H: EngineIoHandler,
+impl<H: EngineIoHandler> EngineIoLayer<H>
 {
     pub fn new(handler: H) -> Self {
         Self {
@@ -30,10 +25,7 @@ where
     }
 }
 
-impl<S, H> Layer<S> for EngineIoLayer<H>
-where
-    H: EngineIoHandler,
-    S: Clone,
+impl<S: Clone, H: EngineIoHandler> Layer<S> for EngineIoLayer<H>
 {
     type Service = EngineIoService<H, S>;
 

--- a/examples/src/engineio-echo/hyper_echo.rs
+++ b/examples/src/engineio-echo/hyper_echo.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use engineioxide::{handler::EngineIoHandler, service::EngineIoService, socket::Socket};
 use hyper::Server;
 use tracing::info;
@@ -36,8 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // We'll bind to 127.0.0.1:3000
     let addr = &"127.0.0.1:3000".parse().unwrap();
-    let handler = Arc::new(MyHandler);
-    let svc = EngineIoService::new(handler);
+    let svc = EngineIoService::new(MyHandler);
 
     let server = Server::bind(addr).serve(svc.into_make_service());
 

--- a/examples/src/engineio-echo/warp_echo.rs
+++ b/examples/src/engineio-echo/warp_echo.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use engineioxide::{handler::EngineIoHandler, service::EngineIoService, socket::Socket};
 use hyper::Server;
 use tracing::info;
@@ -40,8 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // We'll bind to 127.0.0.1:3000
     let addr = &"127.0.0.1:3000".parse().unwrap();
-    let handler = Arc::new(MyHandler);
-    let svc = EngineIoService::with_inner(warp_svc, handler);
+    let svc = EngineIoService::with_inner(warp_svc, MyHandler);
 
     let server = Server::bind(addr).serve(svc.into_make_service());
 

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -166,3 +166,12 @@ impl<A: Adapter> EngineIoHandler for Client<A> {
         }
     }
 }
+
+impl<A: Adapter> Clone for Client<A> {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            ns: self.ns.clone(),
+        }
+    }
+}

--- a/socketioxide/src/service.rs
+++ b/socketioxide/src/service.rs
@@ -62,7 +62,7 @@ impl<A: Adapter, S: Clone> SocketIoService<A, S> {
     /// Create a new [`EngineIoService`] with a custom inner service and a custom config.
     pub fn with_config_inner(inner: S, ns_handlers: NsHandlers<A>, config: SocketIoConfig) -> Self {
         let client = Client::new(config.clone(), ns_handlers.clone());
-        let svc = EngineIoService::with_config_inner(inner, client.into(), config.engine_config);
+        let svc = EngineIoService::with_config_inner(inner, client, config.engine_config);
         Self { engine_svc: svc }
     }
 }


### PR DESCRIPTION
The handler property is never used outside of the `Engine` struct and was behind an `Arc<H>`. 
This adds a layer of indirection for each calls to the handler.

Removing the Arc implies that the `Handler` (and therefore the `Client` struct in the `socketioxide` crate) is created multiple times at startup by the layer (if used with axum for example).