### PR TITLE
Feature: Error Adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "criterion-plot",
  "futures",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -250,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -703,6 +703,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1252,7 +1261,7 @@ dependencies = [
  "futures",
  "http",
  "http-body",
- "itertools",
+ "itertools 0.11.0",
  "serde",
  "serde_json",
  "thiserror",

--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -138,8 +138,8 @@ pub struct LocalAdapter {
     ns: Weak<Namespace<Self>>,
 }
 
-impl Into<AdapterError> for Infallible {
-    fn into(self) -> AdapterError {
+impl From<Infallible> for AdapterError {
+    fn from(_: Infallible) -> AdapterError {
         unreachable!()
     }
 }

--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    convert::Infallible,
     sync::{Arc, RwLock, Weak},
     time::Duration,
 };
@@ -18,15 +19,12 @@ use itertools::Itertools;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    errors::{
-        AckError,
-        BroadcastError,
-    },
+    errors::{AckError, BroadcastError},
     handler::AckResponse,
     ns::Namespace,
     operators::RoomParam,
     packet::Packet,
-    socket::Socket
+    socket::Socket,
 };
 
 /// A room identifier
@@ -68,53 +66,64 @@ impl BroadcastOptions {
 
 //TODO: Make an AsyncAdapter trait
 pub trait Adapter: std::fmt::Debug + Send + Sync + 'static {
+    type Error: std::error::Error + Send + 'static;
+
     /// Create a new adapter and give the namespace ref to retrieve sockets.
     fn new(ns: Weak<Namespace<Self>>) -> Self
     where
         Self: Sized;
 
     /// Initialize the adapter.
-    fn init(&self);
+    fn init(&self) -> Result<(), Self::Error>;
     /// Close the adapter.
-    fn close(&self);
+    fn close(&self) -> Result<(), Self::Error>;
 
     /// Return the number of servers.
-    fn server_count(&self) -> u16;
+    fn server_count(&self) -> Result<u16, Self::Error>;
 
     /// Add the socket to all the rooms.
-    fn add_all(&self, sid: Sid, rooms: impl RoomParam);
+    fn add_all(&self, sid: Sid, rooms: impl RoomParam) -> Result<(), Self::Error>;
     /// Remove the socket from the rooms.
-    fn del(&self, sid: Sid, rooms: impl RoomParam);
+    fn del(&self, sid: Sid, rooms: impl RoomParam) -> Result<(), Self::Error>;
     /// Remove the socket from all the rooms.
-    fn del_all(&self, sid: Sid);
+    fn del_all(&self, sid: Sid) -> Result<(), Self::Error>;
 
     /// Broadcast the packet to the sockets that match the [`BroadcastOptions`].
-    fn broadcast(&self, packet: Packet, opts: BroadcastOptions) -> Result<(), BroadcastError>;
+    fn broadcast(
+        &self,
+        packet: Packet,
+        opts: BroadcastOptions,
+    ) -> Result<Result<(), BroadcastError<Self>>, Self::Error>;
 
     /// Broadcast the packet to the sockets that match the [`BroadcastOptions`] and return a stream of ack responses.
     fn broadcast_with_ack<V: DeserializeOwned>(
         &self,
         packet: Packet,
         opts: BroadcastOptions,
-    ) -> BoxStream<'static, Result<AckResponse<V>, AckError>>;
+    ) -> Result<BoxStream<'static, Result<AckResponse<V>, AckError>>, Self::Error>;
 
     /// Return the sockets ids that match the [`BroadcastOptions`].
-    fn sockets(&self, rooms: impl RoomParam) -> Vec<Sid>;
+    fn sockets(&self, rooms: impl RoomParam) -> Result<Vec<Sid>, Self::Error>;
 
     /// Return the rooms of the socket.
-    fn socket_rooms(&self, sid: Sid) -> Vec<Room>;
+    fn socket_rooms(&self, sid: Sid) -> Result<Vec<Room>, Self::Error>;
 
     /// Return the sockets that match the [`BroadcastOptions`].
-    fn fetch_sockets(&self, opts: BroadcastOptions) -> Vec<Arc<Socket<Self>>>
+    fn fetch_sockets(&self, opts: BroadcastOptions) -> Result<Vec<Arc<Socket<Self>>>, Self::Error>
     where
         Self: Sized;
 
     /// Add the sockets that match the [`BroadcastOptions`] to the rooms.
-    fn add_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam);
+    fn add_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam)
+        -> Result<(), Self::Error>;
     /// Remove the sockets that match the [`BroadcastOptions`] from the rooms.
-    fn del_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam);
+    fn del_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam)
+        -> Result<(), Self::Error>;
     /// Disconnect the sockets that match the [`BroadcastOptions`].
-    fn disconnect_socket(&self, opts: BroadcastOptions) -> Result<(), BroadcastError>;
+    fn disconnect_socket(
+        &self,
+        opts: BroadcastOptions,
+    ) -> Result<Result<(), BroadcastError<Self>>, Self::Error>;
 
     //TODO: implement
     // fn server_side_emit(&self, packet: Packet, opts: BroadcastOptions) -> Result<u64, Error>;
@@ -130,6 +139,8 @@ pub struct LocalAdapter {
 }
 
 impl Adapter for LocalAdapter {
+    type Error = Infallible;
+
     fn new(ns: Weak<Namespace<Self>>) -> Self {
         Self {
             rooms: HashMap::new().into(),
@@ -137,15 +148,15 @@ impl Adapter for LocalAdapter {
         }
     }
 
-    fn init(&self) {}
+    fn init(&self) -> Result<(), Infallible> { Ok(()) }
 
-    fn close(&self) {}
+    fn close(&self) -> Result<(), Infallible> { Ok(()) }
 
-    fn server_count(&self) -> u16 {
-        1
+    fn server_count(&self) -> Result<u16, Infallible> {
+        Ok(1)
     }
 
-    fn add_all(&self, sid: Sid, rooms: impl RoomParam) {
+    fn add_all(&self, sid: Sid, rooms: impl RoomParam) -> Result<(), Infallible> {
         let mut rooms_map = self.rooms.write().unwrap();
         for room in rooms.into_room_iter() {
             rooms_map
@@ -153,25 +164,28 @@ impl Adapter for LocalAdapter {
                 .or_insert_with(HashSet::new)
                 .insert(sid);
         }
+        Ok(())
     }
 
-    fn del(&self, sid: Sid, rooms: impl RoomParam) {
+    fn del(&self, sid: Sid, rooms: impl RoomParam) -> Result<(), Infallible> {
         let mut rooms_map = self.rooms.write().unwrap();
         for room in rooms.into_room_iter() {
             if let Some(room) = rooms_map.get_mut(&room) {
                 room.remove(&sid);
             }
         }
+        Ok(())
     }
 
-    fn del_all(&self, sid: Sid) {
+    fn del_all(&self, sid: Sid) -> Result<(), Infallible> {
         let mut rooms_map = self.rooms.write().unwrap();
         for room in rooms_map.values_mut() {
             room.remove(&sid);
         }
+        Ok(())
     }
 
-    fn broadcast(&self, packet: Packet, opts: BroadcastOptions) -> Result<(), BroadcastError> {
+    fn broadcast(&self, packet: Packet, opts: BroadcastOptions) -> Result<Result<(), BroadcastError<Self>>, Infallible> {
         let sockets = self.apply_opts(opts);
 
         tracing::debug!("broadcasting packet to {} sockets", sockets.len());
@@ -180,9 +194,9 @@ impl Adapter for LocalAdapter {
             .filter_map(|socket| socket.send(packet.clone()).err())
             .collect();
         if errors.is_empty() {
-            Ok(())
+            Ok(Ok(()))
         } else {
-            Err(errors.into())
+            Ok(Err(errors.into()))
         }
     }
 
@@ -190,7 +204,7 @@ impl Adapter for LocalAdapter {
         &self,
         packet: Packet,
         opts: BroadcastOptions,
-    ) -> BoxStream<'static, Result<AckResponse<V>, AckError>> {
+    ) -> Result<BoxStream<'static, Result<AckResponse<V>, AckError>>, Infallible> {
         let duration = opts.flags.iter().find_map(|flag| match flag {
             BroadcastFlags::Timeout(duration) => Some(*duration),
             _ => None,
@@ -206,56 +220,58 @@ impl Adapter for LocalAdapter {
             let packet = packet.clone();
             async move { socket.clone().send_with_ack(packet, duration).await }
         });
-        stream::iter(ack_futs).buffer_unordered(count).boxed()
+        Ok(stream::iter(ack_futs).buffer_unordered(count).boxed())
     }
 
-    fn sockets(&self, rooms: impl RoomParam) -> Vec<Sid> {
+    fn sockets(&self, rooms: impl RoomParam) -> Result<Vec<Sid>, Infallible> {
         let mut opts = BroadcastOptions::new(0i64.into());
         opts.rooms.extend(rooms.into_room_iter());
-        self.apply_opts(opts)
+        Ok(self.apply_opts(opts)
             .into_iter()
             .map(|socket| socket.sid)
-            .collect()
+            .collect())
     }
 
     //TODO: make this operation O(1)
-    fn socket_rooms(&self, sid: Sid) -> Vec<Room> {
+    fn socket_rooms(&self, sid: Sid) -> Result<Vec<String>, Infallible> {
         let rooms_map = self.rooms.read().unwrap();
-        rooms_map
+        Ok(rooms_map
             .iter()
             .filter(|(_, sockets)| sockets.contains(&sid))
             .map(|(room, _)| room.clone())
-            .collect()
+            .collect())
     }
 
-    fn fetch_sockets(&self, opts: BroadcastOptions) -> Vec<Arc<Socket<Self>>> {
-        self.apply_opts(opts)
+    fn fetch_sockets(&self, opts: BroadcastOptions) -> Result<Vec<Arc<Socket<LocalAdapter>>>, Infallible> {
+        Ok(self.apply_opts(opts))
     }
 
-    fn add_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam) {
+    fn add_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam) -> Result<(), Infallible> {
         let rooms: Vec<Room> = rooms.into_room_iter().collect();
         for socket in self.apply_opts(opts) {
             self.add_all(socket.sid, rooms.clone());
         }
+        Ok(())
     }
 
-    fn del_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam) {
+    fn del_sockets(&self, opts: BroadcastOptions, rooms: impl RoomParam) -> Result<(), Infallible> {
         let rooms: Vec<Room> = rooms.into_room_iter().collect();
         for socket in self.apply_opts(opts) {
             self.del(socket.sid, rooms.clone());
         }
+        Ok(())
     }
 
-    fn disconnect_socket(&self, opts: BroadcastOptions) -> Result<(), BroadcastError> {
+    fn disconnect_socket(&self, opts: BroadcastOptions) -> Result<Result<(), BroadcastError<Self>>, Infallible> {
         let errors: Vec<_> = self
             .apply_opts(opts)
             .into_iter()
             .filter_map(|socket| socket.disconnect().err())
             .collect();
         if errors.is_empty() {
-            Ok(())
+            Ok(Ok(()))
         } else {
-            Err(errors.into())
+            Ok(Err(errors.into()))
         }
     }
 }
@@ -313,7 +329,7 @@ mod test {
     async fn test_server_count() {
         let ns = Namespace::new_dummy([]);
         let adapter = LocalAdapter::new(Arc::downgrade(&ns));
-        assert_eq!(adapter.server_count(), 1);
+        assert_eq!(adapter.server_count().unwrap(), 1);
     }
 
     #[tokio::test]
@@ -361,10 +377,10 @@ mod test {
         adapter.add_all(1i64.into(), ["room1", "room2"]);
         adapter.add_all(2i64.into(), ["room1"]);
         adapter.add_all(3i64.into(), ["room2"]);
-        assert!(adapter.socket_rooms(1i64.into()).contains(&"room1".into()));
-        assert!(adapter.socket_rooms(1i64.into()).contains(&"room2".into()));
-        assert_eq!(adapter.socket_rooms(2i64.into()), ["room1"]);
-        assert_eq!(adapter.socket_rooms(3i64.into()), ["room2"]);
+        assert!(adapter.socket_rooms(1i64.into()).unwrap().contains(&"room1".into()));
+        assert!(adapter.socket_rooms(1i64.into()).unwrap().contains(&"room2".into()));
+        assert_eq!(adapter.socket_rooms(2i64.into()).unwrap(), ["room1"]);
+        assert_eq!(adapter.socket_rooms(3i64.into()).unwrap(), ["room2"]);
     }
 
     #[tokio::test]
@@ -427,17 +443,17 @@ mod test {
         adapter.add_all(socket1, ["room1", "room3"]);
         adapter.add_all(socket2, ["room2", "room3"]);
 
-        let sockets = adapter.sockets("room1");
+        let sockets = adapter.sockets("room1").unwrap();
         assert_eq!(sockets.len(), 2);
         assert!(sockets.contains(&socket0));
         assert!(sockets.contains(&socket1));
 
-        let sockets = adapter.sockets("room2");
+        let sockets = adapter.sockets("room2").unwrap();
         assert_eq!(sockets.len(), 2);
         assert!(sockets.contains(&socket0));
         assert!(sockets.contains(&socket2));
 
-        let sockets = adapter.sockets("room3");
+        let sockets = adapter.sockets("room3").unwrap();
         assert_eq!(sockets.len(), 2);
         assert!(sockets.contains(&socket1));
         assert!(sockets.contains(&socket2));
@@ -456,7 +472,7 @@ mod test {
 
         let mut opts = BroadcastOptions::new(socket0);
         opts.rooms = vec!["room5".to_string()];
-        match adapter.disconnect_socket(opts) {
+        match adapter.disconnect_socket(opts).unwrap() {
             // todo it returns Ok, in previous commits it also returns Ok
             Err(BroadcastError::SendError(_)) | Ok(_) => {}
             e => panic!(
@@ -465,7 +481,7 @@ mod test {
             ),
         }
 
-        let sockets = adapter.sockets("room2");
+        let sockets = adapter.sockets("room2").unwrap();
         assert_eq!(sockets.len(), 2);
         assert!(sockets.contains(&socket2));
         assert!(sockets.contains(&socket0));
@@ -488,23 +504,23 @@ mod test {
         let mut opts = BroadcastOptions::new(socket2);
         opts.rooms = vec!["room1".to_string()];
         opts.except = vec!["room2".to_string()];
-        let sockets = adapter.fetch_sockets(opts);
+        let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 1);
         assert_eq!(sockets[0].sid, socket1);
 
         let mut opts = BroadcastOptions::new(socket2);
         opts.flags.insert(BroadcastFlags::Broadcast);
         opts.except = vec!["room2".to_string()];
-        let sockets = adapter.fetch_sockets(opts);
+        let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 1);
 
         let opts = BroadcastOptions::new(socket2);
-        let sockets = adapter.fetch_sockets(opts);
+        let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 1);
         assert_eq!(sockets[0].sid, socket2);
 
         let opts = BroadcastOptions::new(10000i64.into());
-        let sockets = adapter.fetch_sockets(opts);
+        let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 0);
     }
 }

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -121,7 +121,9 @@ impl<A: Adapter> EngineIoHandler for Client<A> {
     fn on_disconnect(&self, socket: &EIoSocket<Self>) {
         debug!("eio socket disconnect {}", socket.sid);
         self.ns.values().for_each(|ns| {
-            ns.remove_socket(socket.sid);
+            if let Err(e) = ns.remove_socket(socket.sid) {
+                error!("Adapter error when disconnecting {}: {}, in a multiple server scenario it could leads to desyncronisation issues", socket.sid, e);
+            }
         });
     }
 

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -121,7 +121,7 @@ impl<A: Adapter> EngineIoHandler for Client<A> {
     fn on_disconnect(&self, socket: &EIoSocket<Self>) {
         debug!("eio socket disconnect {}", socket.sid);
         self.ns.values().for_each(|ns| {
-            ns.disconnect(socket.sid).ok();
+            ns.remove_socket(socket.sid);
         });
     }
 

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::{retryer::Retryer, adapter::Adapter};
+use crate::retryer::Retryer;
 use engineioxide::sid_generator::Sid;
 use std::fmt::{Debug, Display};
 use tokio::sync::oneshot;
@@ -93,7 +93,7 @@ pub enum SendError {
     RetryerError(#[from] RetryerError),
 
     #[error("Adapter error: {0}")]
-    AdapterError(#[from] Box<dyn std::error::Error>),
+    AdapterError(#[from] AdapterError),
 }
 
 /// Error type for the `Retryer` struct indicating various failure scenarios during the retry process.
@@ -107,8 +107,9 @@ pub enum RetryerError {
     Remaining(Retryer),
 }
 
+/// Error type for the [`Adapter`] trait.
 #[derive(Debug, thiserror::Error)]
-pub struct AdapterError(#[from] Box<dyn std::error::Error>);
+pub struct AdapterError(#[from] pub Box<dyn std::error::Error>);
 impl Display for AdapterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, f)

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::retryer::Retryer;
+use crate::{retryer::Retryer, adapter::Adapter};
 use engineioxide::sid_generator::Sid;
 use std::fmt::Debug;
 use tokio::sync::oneshot;
@@ -54,27 +54,30 @@ pub enum AckError {
 pub enum BroadcastError {
     /// An error occurred while sending packets.
     #[error("Sending error: {0:?}")]
-    SendError(Vec<SendError>),
+    SendError(#[from] Vec<SendError>),
 
     /// An error occurred while serializing the JSON packet.
     #[error("Error serializing JSON packet: {0:?}")]
     Serialize(#[from] serde_json::Error),
+
+    // #[error("Adapter error: {0}")]
+    // AdapterError(#[from] A::Error)
 }
 
-impl From<Vec<SendError>> for BroadcastError {
-    /// Converts a vector of `SendError` into a `BroadcastError`.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - A vector of `SendError` representing the sending errors.
-    ///
-    /// # Returns
-    ///
-    /// A `BroadcastError` containing the sending errors.
-    fn from(value: Vec<SendError>) -> Self {
-        Self::SendError(value)
-    }
-}
+// impl<A: Adapter> From<Vec<SendError>> for BroadcastError<A> {
+//     /// Converts a vector of `SendError` into a `BroadcastError`.
+//     ///
+//     /// # Arguments
+//     ///
+//     /// * `value` - A vector of `SendError` representing the sending errors.
+//     ///
+//     /// # Returns
+//     ///
+//     /// A `BroadcastError` containing the sending errors.
+//     fn from(value: Vec<SendError>) -> Self {
+//         Self::SendError(value)
+//     }
+// }
 
 /// Error type for sending operations.
 #[derive(thiserror::Error, Debug)]

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -64,7 +64,7 @@ pub enum BroadcastError {
     Serialize(#[from] serde_json::Error),
 
     #[error("Adapter error: {0}")]
-    AdapterError(#[from] Box<dyn std::error::Error>),
+    Adapter(#[from] AdapterError),
 }
 
 impl From<Vec<SendError>> for BroadcastError {
@@ -109,7 +109,7 @@ pub enum RetryerError {
 
 /// Error type for the [`Adapter`] trait.
 #[derive(Debug, thiserror::Error)]
-pub struct AdapterError(#[from] pub Box<dyn std::error::Error>);
+pub struct AdapterError(#[from] pub Box<dyn std::error::Error + Send>);
 impl Display for AdapterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, f)

--- a/socketioxide/src/ns.rs
+++ b/socketioxide/src/ns.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use crate::errors::{SendError, AdapterError};
+use crate::errors::{AdapterError, SendError};
 use crate::{
     adapter::{Adapter, LocalAdapter},
     errors::Error,
@@ -69,14 +69,18 @@ impl<A: Adapter> Namespace<A> {
 
     pub fn disconnect(&self, sid: Sid) -> Result<(), SendError> {
         if let Some(socket) = self.sockets.write().unwrap().remove(&sid) {
-            self.adapter.del_all(sid);
+            self.adapter
+                .del_all(sid)
+                .map_err(|err| AdapterError(Box::new(err)))?;
             socket.send(Packet::disconnect(self.path.clone()))?;
         }
         Ok(())
     }
     pub fn remove_socket(&self, sid: Sid) -> Result<(), AdapterError> {
         self.sockets.write().unwrap().remove(&sid);
-        self.adapter.del_all(sid).map_err(AdapterError::from)
+        self.adapter
+            .del_all(sid)
+            .map_err(|err| AdapterError(Box::new(err)))
     }
 
     pub fn has(&self, sid: Sid) -> bool {
@@ -90,9 +94,9 @@ impl<A: Adapter> Namespace<A> {
 
     pub fn recv(&self, sid: Sid, packet: PacketData) -> Result<(), Error> {
         match packet {
-            PacketData::Disconnect => {
-                self.remove_socket(sid)
-            }
+            PacketData::Disconnect => self
+                .remove_socket(sid)
+                .map_err(|err| AdapterError(Box::new(err)).into()),
             PacketData::Connect(_) => unreachable!("connect packets should be handled before"),
             PacketData::ConnectError(_) => Ok(()),
             packet => self.socket_recv(sid, packet),

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -230,7 +230,7 @@ impl<A: Adapter> Operators<A> {
         mut self,
         event: impl Into<String>,
         data: impl serde::Serialize,
-    ) -> Result<(), BroadcastError> {
+    ) -> Result<(), BroadcastError<A>> {
         let packet = self.get_packet(event, data)?;
         self.ns.adapter.broadcast(packet, self.opts)
     }

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -8,7 +8,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::errors::BroadcastError;
 use crate::{
     adapter::{Adapter, BroadcastFlags, BroadcastOptions, Room},
-    errors::{AckError, Error},
+    errors::AckError,
     handler::AckResponse,
     ns::Namespace,
     packet::Packet,
@@ -230,7 +230,7 @@ impl<A: Adapter> Operators<A> {
         mut self,
         event: impl Into<String>,
         data: impl serde::Serialize,
-    ) -> Result<(), BroadcastError<A>> {
+    ) -> Result<(), BroadcastError> {
         let packet = self.get_packet(event, data)?;
         self.ns.adapter.broadcast(packet, self.opts)
     }
@@ -263,9 +263,9 @@ impl<A: Adapter> Operators<A> {
         mut self,
         event: impl Into<String>,
         data: impl serde::Serialize,
-    ) -> Result<BoxStream<'static, Result<AckResponse<V>, AckError>>, Error> {
+    ) -> Result<BoxStream<'static, Result<AckResponse<V>, AckError>>, BroadcastError> {
         let packet = self.get_packet(event, data)?;
-        Ok(self.ns.adapter.broadcast_with_ack(packet, self.opts))
+        self.ns.adapter.broadcast_with_ack(packet, self.opts)
     }
 
     /// Get all sockets selected with the previous operators.
@@ -284,7 +284,7 @@ impl<A: Adapter> Operators<A> {
     ///     }
     ///   });
     /// });
-    pub fn sockets(self) -> Vec<Arc<Socket<A>>> {
+    pub fn sockets(self) -> Result<Vec<Arc<Socket<A>>>, A::Error> {
         self.ns.adapter.fetch_sockets(self.opts)
     }
 

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -278,7 +278,7 @@ impl<A: Adapter> Operators<A> {
     /// Namespace::builder().add("/", |socket| async move {
     ///   socket.on("test", |socket, _: (), _, _| async move {
     ///     // Find an extension data in each sockets in the room1 and room3 rooms, except for the room2
-    ///     let sockets = socket.within("room1").within("room3").except("room2").sockets();
+    ///     let sockets = socket.within("room1").within("room3").except("room2").sockets().unwrap();
     ///     for socket in sockets {
     ///         println!("Socket custom string: {:?}", socket.extensions.get::<String>());
     ///     }

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -179,22 +179,22 @@ impl<A: Adapter> Socket<A> {
     // Room actions
 
     /// Join the given rooms.
-    pub fn join(&self, rooms: impl RoomParam) {
-        self.ns.adapter.add_all(self.sid, rooms);
+    pub fn join(&self, rooms: impl RoomParam) -> Result<(), A::Error> {
+        self.ns.adapter.add_all(self.sid, rooms)
     }
 
     /// Leave the given rooms.
-    pub fn leave(&self, rooms: impl RoomParam) {
-        self.ns.adapter.del(self.sid, rooms);
+    pub fn leave(&self, rooms: impl RoomParam) -> Result<(), A::Error> {
+        self.ns.adapter.del(self.sid, rooms)
     }
 
     /// Leave all rooms where the socket is connected.
-    pub fn leave_all(&self) {
-        self.ns.adapter.del_all(self.sid);
+    pub fn leave_all(&self) -> Result<(), A::Error> {
+        self.ns.adapter.del_all(self.sid)
     }
 
     /// Get all rooms where the socket is connected.
-    pub fn rooms(&self) -> Vec<Room> {
+    pub fn rooms(&self) -> Result<Vec<Room>, A::Error> {
         self.ns.adapter.socket_rooms(self.sid)
     }
 


### PR DESCRIPTION
Currently the `Adapter` trait was not returning any error. However for future remote adapters it will be necessary.

Therefore the `Adapter` has now a bounded Error type.

For the `LocalAdapter` it is an `Infallible` error.

In order to handle these error without adding generic adapter to all the errors, there is now an error wrapper `AdapterError` which wraps a `Box<dyn std::error>`.