### PR TITLE
Fix failing EngineIO CI configuration

### DIFF
--- a/.github/workflows/engineio-ci.yml
+++ b/.github/workflows/engineio-ci.yml
@@ -1,4 +1,3 @@
-
 name: EngineIO CI
 
 on:
@@ -30,6 +29,7 @@ jobs:
       - name: Install deps & run tests 
         run: |
           cd engine.io-protocol/test-suite && npm install && cd ../..
+          cargo build --bin engineioxide-e2e --release --features v3 --no-default-features
           cargo run --bin engineioxide-e2e --release --features v3 --no-default-features > v3_server.txt & npm --prefix engine.io-protocol/test-suite test > v3_client.txt
       - name: Server output
         if: always()


### PR DESCRIPTION
I was just missing the `build` command. I assumed `cargo run` would already build + run the binary, not sure why it doesn't seem to work that way though. Anyways, this commit should fix it.