### PR TITLE
feat(engineioxide): specific transport restrictions (fix issue #49)

### DIFF
--- a/engineioxide/src/config.rs
+++ b/engineioxide/src/config.rs
@@ -27,6 +27,8 @@ pub struct EngineIoConfig {
     /// Defaults to 100kb.
     pub max_payload: u64,
 
+    /// Allowed transports on this server
+    /// It is represented as a bitfield to allow to combine any number of transports easily
     pub transports: u8,
 }
 

--- a/engineioxide/src/config.rs
+++ b/engineioxide/src/config.rs
@@ -138,9 +138,7 @@ impl EngineIoConfigBuilder {
     /// The `transports` array should have a size of 1 or 2
     ///
     /// Defaults to :
-    /// ```
-    /// [TransportType::Polling, TransportType::Websocket]
-    /// ```
+    /// `[TransportType::Polling, TransportType::Websocket]`
     pub fn transports<const N: usize>(mut self, transports: [TransportType; N]) -> Self {
         assert!(N > 0 && N <= 2);
         self.config.transports = 0;

--- a/engineioxide/src/config.rs
+++ b/engineioxide/src/config.rs
@@ -47,6 +47,12 @@ impl EngineIoConfig {
     pub fn builder() -> EngineIoConfigBuilder {
         EngineIoConfigBuilder::new()
     }
+
+    /// Check if a [`TransportType`] is enabled in the [`EngineIoConfig`]
+    #[inline(always)]
+    pub fn allowed_transport(&self, transport: TransportType) -> bool {
+        self.transports & transport as u8 == transport as u8
+    }
 }
 pub struct EngineIoConfigBuilder {
     config: EngineIoConfig,
@@ -166,14 +172,18 @@ mod tests {
         let conf = EngineIoConfig::builder()
             .transports([TransportType::Polling])
             .build();
-        assert!(conf.transports == TransportType::Polling as u8);
+        assert!(conf.allowed_transport(TransportType::Polling));
+        assert!(!conf.allowed_transport(TransportType::Websocket));
+
         let conf = EngineIoConfig::builder()
             .transports([TransportType::Websocket])
             .build();
-        assert!(conf.transports == TransportType::Websocket as u8);
+        assert!(conf.allowed_transport(TransportType::Websocket));
+        assert!(!conf.allowed_transport(TransportType::Polling));
         let conf = EngineIoConfig::builder()
             .transports([TransportType::Polling, TransportType::Websocket])
             .build();
-        assert!(conf.transports == (TransportType::Polling as u8 | TransportType::Websocket as u8));
+        assert!(conf.allowed_transport(TransportType::Polling));
+        assert!(conf.allowed_transport(TransportType::Websocket));
     }
 }

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -204,10 +204,10 @@ where
 }
 
 /// The type of the transport used by the client.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TransportType {
-    Websocket,
-    Polling,
+    Polling = 0x01,
+    Websocket = 0x02,
 }
 
 impl FromStr for TransportType {

--- a/engineioxide/src/service.rs
+++ b/engineioxide/src/service.rs
@@ -1,11 +1,6 @@
 use crate::{
-    body::ResponseBody,
-    config::EngineIoConfig,
-    engine::EngineIo,
-    errors::{Error, Error::UnknownTransport},
-    futures::ResponseFuture,
-    handler::EngineIoHandler,
-    sid_generator::Sid,
+    body::ResponseBody, config::EngineIoConfig, engine::EngineIo, errors::Error,
+    futures::ResponseFuture, handler::EngineIoHandler, sid_generator::Sid,
 };
 use bytes::Bytes;
 use futures::future::{ready, Ready};
@@ -96,7 +91,7 @@ where
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         if req.uri().path().starts_with(&self.engine.config.req_path) {
             let engine = self.engine.clone();
-            match RequestInfo::parse(&req) {
+            match RequestInfo::parse(&req, &self.engine.config) {
                 Ok(RequestInfo {
                     protocol,
                     sid: None,
@@ -217,7 +212,7 @@ impl FromStr for TransportType {
         match s {
             "websocket" => Ok(TransportType::Websocket),
             "polling" => Ok(TransportType::Polling),
-            _ => Err(UnknownTransport),
+            _ => Err(Error::UnknownTransport),
         }
     }
 }
@@ -277,14 +272,14 @@ struct RequestInfo {
 
 impl RequestInfo {
     /// Parse the request URI to extract the [`TransportType`](crate::service::TransportType) and the socket id.
-    fn parse<B>(req: &Request<B>) -> Result<Self, Error> {
-        let query = req.uri().query().ok_or(UnknownTransport)?;
+    fn parse<B>(req: &Request<B>, config: &EngineIoConfig) -> Result<Self, Error> {
+        let query = req.uri().query().ok_or(Error::UnknownTransport)?;
 
         let protocol: ProtocolVersion = query
             .split('&')
             .find(|s| s.starts_with("EIO="))
             .and_then(|s| s.split('=').nth(1))
-            .ok_or(UnknownTransport)
+            .ok_or(Error::UnsupportedProtocolVersion)
             .and_then(|t| t.parse())?;
 
         let sid = query
@@ -297,8 +292,12 @@ impl RequestInfo {
             .split('&')
             .find(|s| s.starts_with("transport="))
             .and_then(|s| s.split('=').nth(1))
-            .ok_or(UnknownTransport)
+            .ok_or(Error::UnknownTransport)
             .and_then(|t| t.parse())?;
+
+        if !config.allowed_transport(transport) {
+            return Err(Error::TransportMismatch);
+        }
 
         #[cfg(feature = "v3")]
         let b64: bool = query
@@ -332,9 +331,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "v4")]
     fn request_info_polling() {
         let req = build_request("http://localhost:3000/socket.io/?EIO=4&transport=polling");
-        let info = RequestInfo::parse(&req).unwrap();
+        let info = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap();
         assert_eq!(info.sid, None);
         assert_eq!(info.transport, TransportType::Polling);
         assert_eq!(info.protocol, ProtocolVersion::V4);
@@ -342,9 +342,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "v4")]
     fn request_info_websocket() {
         let req = build_request("http://localhost:3000/socket.io/?EIO=4&transport=websocket");
-        let info = RequestInfo::parse(&req).unwrap();
+        let info = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap();
         assert_eq!(info.sid, None);
         assert_eq!(info.transport, TransportType::Websocket);
         assert_eq!(info.protocol, ProtocolVersion::V4);
@@ -352,11 +353,12 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "v3")]
     fn request_info_polling_with_sid() {
         let req = build_request(
             "http://localhost:3000/socket.io/?EIO=3&transport=polling&sid=AAAAAAAAAHs",
         );
-        let info = RequestInfo::parse(&req).unwrap();
+        let info = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap();
         assert_eq!(info.sid, Some(123i64.into()));
         assert_eq!(info.transport, TransportType::Polling);
         assert_eq!(info.protocol, ProtocolVersion::V3);
@@ -364,14 +366,15 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "v4")]
     fn request_info_websocket_with_sid() {
         let req = build_request(
-            "http://localhost:3000/socket.io/?EIO=3&transport=websocket&sid=AAAAAAAAAHs",
+            "http://localhost:3000/socket.io/?EIO=4&transport=websocket&sid=AAAAAAAAAHs",
         );
-        let info = RequestInfo::parse(&req).unwrap();
+        let info = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap();
         assert_eq!(info.sid, Some(123i64.into()));
         assert_eq!(info.transport, TransportType::Websocket);
-        assert_eq!(info.protocol, ProtocolVersion::V3);
+        assert_eq!(info.protocol, ProtocolVersion::V4);
         assert_eq!(info.method, Method::GET);
     }
 
@@ -379,7 +382,7 @@ mod tests {
     #[cfg(feature = "v3")]
     fn request_info_polling_with_bin_by_default() {
         let req = build_request("http://localhost:3000/socket.io/?EIO=3&transport=polling");
-        let req = RequestInfo::parse(&req).unwrap();
+        let req = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap();
         assert!(!req.b64);
     }
 
@@ -389,28 +392,56 @@ mod tests {
         assert!(cfg!(feature = "v3"));
 
         let req = build_request("http://localhost:3000/socket.io/?EIO=3&transport=polling&b64=1");
-        let req = RequestInfo::parse(&req).unwrap();
+        let req = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap();
         assert!(req.b64);
     }
 
     #[test]
+    #[cfg(feature = "v4")]
     fn transport_unknown_err() {
         let req = build_request("http://localhost:3000/socket.io/?EIO=4&transport=grpc");
-        let err = RequestInfo::parse(&req).unwrap_err();
+        let err = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap_err();
         assert!(matches!(err, Error::UnknownTransport));
     }
     #[test]
     fn unsupported_protocol_version() {
         let req = build_request("http://localhost:3000/socket.io/?EIO=2&transport=polling");
-        let err = RequestInfo::parse(&req).unwrap_err();
+        let err = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap_err();
         assert!(matches!(err, Error::UnsupportedProtocolVersion));
     }
     #[test]
+    #[cfg(feature = "v4")]
     fn bad_handshake_method() {
         let req = Request::post("http://localhost:3000/socket.io/?EIO=4&transport=polling")
             .body(())
             .unwrap();
-        let err = RequestInfo::parse(&req).unwrap_err();
+        let err = RequestInfo::parse(&req, &EngineIoConfig::default()).unwrap_err();
         assert!(matches!(err, Error::BadHandshakeMethod));
+    }
+
+    #[test]
+    #[cfg(feature = "v4")]
+    fn unsupported_transport() {
+        let req = build_request("http://localhost:3000/socket.io/?EIO=4&transport=polling");
+        let err = RequestInfo::parse(
+            &req,
+            &EngineIoConfig::builder()
+                .transports([TransportType::Websocket])
+                .build(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::TransportMismatch));
+
+        let req = build_request("http://localhost:3000/socket.io/?EIO=4&transport=websocket");
+        let err = RequestInfo::parse(
+            &req,
+            &EngineIoConfig::builder()
+                .transports([TransportType::Polling])
+                .build(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::TransportMismatch))
     }
 }


### PR DESCRIPTION
This PR adds a field in the `EngineIoConfig` struct so the user is able to specify a limited number of transports, by default all transports are allowed).

For example, only `websocket` requests will be allowed, but `polling` request will be denied with a `400 Bad Request` error.

```rust
let conf = EngineIoConfig::builder()
            .transports([TransportType::Websocket])
            .build();
```