### PR TITLE
chore(versioning): v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "engineioxide"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "dashmap",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-e2e"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "engineioxide",
  "futures",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-examples"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "engineioxide",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socketioxide-e2e"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/engineioxide/Cargo.toml
+++ b/engineioxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engineioxide"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.60.0"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socketioxide-examples"
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socketioxide"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.60.0"
 
@@ -18,7 +18,7 @@ license = "MIT"
 readme = "../Readme.md"
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.3.0" }
+engineioxide = { path = "../engineioxide", version = "0.4.0" }
 futures = "0.3.27"
 tokio = "1.26.0"
 serde = { version = "1.0.155", features = ["derive"] }


### PR DESCRIPTION
## New version v0.4.0 🚀:

close error #64 and #62.



