### PR TITLE
feat(socketio/ns): create a wrapper struct for NsHandlers and export it

### DIFF
--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -11,10 +11,11 @@ use tracing::error;
 
 use crate::adapter::Adapter;
 use crate::handshake::Handshake;
+use crate::NsHandlers;
 use crate::{
     config::SocketIoConfig,
     errors::Error,
-    ns::{EventCallback, Namespace},
+    ns::Namespace,
     packet::{Packet, PacketData},
 };
 
@@ -25,10 +26,11 @@ pub struct Client<A: Adapter> {
 }
 
 impl<A: Adapter> Client<A> {
-    pub fn new(config: SocketIoConfig, ns_handlers: HashMap<String, EventCallback<A>>) -> Self {
+    pub fn new(config: SocketIoConfig, ns_handlers: NsHandlers<A>) -> Self {
         Self {
             config: config.into(),
             ns: ns_handlers
+                .0
                 .into_iter()
                 .map(|(path, callback)| (path.clone(), Namespace::new(path, callback)))
                 .collect(),

--- a/socketioxide/src/ns.rs
+++ b/socketioxide/src/ns.rs
@@ -20,7 +20,17 @@ use tokio::sync::mpsc;
 pub type EventCallback<A> =
     Arc<dyn Fn(Arc<Socket<A>>) -> BoxFuture<'static, ()> + Send + Sync + 'static>;
 
-pub type NsHandlers<A> = HashMap<String, EventCallback<A>>;
+pub struct NsHandlers<A: Adapter>(pub(crate) HashMap<String, EventCallback<A>>);
+impl<A: Adapter> NsHandlers<A> {
+    fn new(map: HashMap<String, EventCallback<A>>) -> Self {
+        Self(map)
+    }
+}
+impl<A: Adapter> Clone for NsHandlers<A> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 pub struct Namespace<A: Adapter> {
     pub path: String,
@@ -150,7 +160,7 @@ impl<A: Adapter> NamespaceBuilder<A> {
     }
 
     pub fn build(self) -> NsHandlers<A> {
-        self.ns_handlers
+        NsHandlers::new(self.ns_handlers)
     }
 }
 


### PR DESCRIPTION
## Create a wrapper struct for `NsHandlers` rather than a type alias and export it.

This will allow to hide the underlying type : `HashMap<String, EventCallback<A>>`