### PR TITLE
feat(socketio): connect timeout implementation

### DIFF
--- a/e2e/src/socketioxide.rs
+++ b/e2e/src/socketioxide.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = SocketIoConfig::builder()
         .ping_interval(Duration::from_millis(300))
         .ping_timeout(Duration::from_millis(200))
-        .connect_timeout(Duration::from_millis(700))
+        .connect_timeout(Duration::from_millis(1000))
         .max_payload(1e6 as u64)
         .build();
     info!("Starting server");

--- a/e2e/src/socketioxide.rs
+++ b/e2e/src/socketioxide.rs
@@ -19,6 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = SocketIoConfig::builder()
         .ping_interval(Duration::from_millis(300))
         .ping_timeout(Duration::from_millis(200))
+        .connect_timeout(Duration::from_millis(700))
         .max_payload(1e6 as u64)
         .build();
     info!("Starting server");

--- a/engineioxide/src/packet.rs
+++ b/engineioxide/src/packet.rs
@@ -2,6 +2,7 @@ use base64::{engine::general_purpose, Engine};
 use serde::{de::Error, Deserialize, Serialize};
 
 use crate::sid_generator::Sid;
+use crate::socket::DisconnectReason;
 use crate::{config::EngineIoConfig, service::TransportType};
 
 /// A Packet type to use when sending data to the client from the public API
@@ -11,6 +12,7 @@ use crate::{config::EngineIoConfig, service::TransportType};
 pub enum SendPacket {
     Message(String),
     Binary(Vec<u8>),
+    Close(DisconnectReason),
 }
 
 /// A Packet type to use when receiving and sending data from the client
@@ -141,6 +143,7 @@ impl From<SendPacket> for Packet {
         match value {
             SendPacket::Message(msg) => Packet::Message(msg),
             SendPacket::Binary(data) => Packet::Binary(data),
+            SendPacket::Close(_) => Packet::Close,
         }
     }
 }

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -156,13 +156,14 @@ where
         config: &EngineIoConfig,
         req_data: SocketReq,
         close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
+        tx_map_fn: impl Fn(SendPacket) -> Packet + Send + Sync + 'static,
         #[cfg(feature = "v3")] supports_binary: bool,
     ) -> Self {
         let (internal_tx, internal_rx) = mpsc::channel(config.max_buffer_size);
         let (tx, rx) = mpsc::channel(config.max_buffer_size);
         let (heartbeat_tx, heartbeat_rx) = mpsc::channel(1);
 
-        tokio::spawn(forward_map_chan(rx, internal_tx.clone(), SendPacket::into));
+        tokio::spawn(forward_map_chan(rx, internal_tx.clone(), tx_map_fn));
 
         Self {
             sid,

--- a/socketioxide/src/config.rs
+++ b/socketioxide/src/config.rs
@@ -85,6 +85,14 @@ impl SocketIoConfigBuilder {
         self
     }
 
+    /// The amount of time before disconnecting a client that has not successfully joined a namespace.
+    ///
+    /// Defaults to 45 seconds.
+    pub fn connect_timeout(mut self, connect_timeout: Duration) -> Self {
+        self.config.connect_timeout = connect_timeout;
+        self
+    }
+
     /// Build the config
     pub fn build(mut self) -> SocketIoConfig {
         // `req_path` default is different between engine.io && socket.io
@@ -109,6 +117,11 @@ pub struct SocketIoConfig {
     ///
     /// Defaults to 5 seconds.
     pub(crate) ack_timeout: Duration,
+
+    /// The amount of time before disconnecting a client that has not successfully joined a namespace.
+    ///
+    /// Defaults to 45 seconds.
+    pub(crate) connect_timeout: Duration,
 }
 
 impl Default for SocketIoConfig {
@@ -119,6 +132,7 @@ impl Default for SocketIoConfig {
                 ..Default::default()
             },
             ack_timeout: Duration::from_secs(5),
+            connect_timeout: Duration::from_secs(45),
         }
     }
 }

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -217,7 +217,9 @@ impl PacketSender {
                     self.bin_payload_buffer.as_mut().unwrap().push_front(p);
                     return Err(TransportError::SendFailedBinPayloads(None));
                 }
-                Err(TrySendError::Full(EnginePacket::Message(_))) => unreachable!(),
+                Err(TrySendError::Full(EnginePacket::Message(_) | EnginePacket::Close(_))) => {
+                    unreachable!()
+                }
                 Err(TrySendError::Closed(_)) => return Err(TransportError::SocketClosed),
                 Ok(()) => {}
             }


### PR DESCRIPTION
### In socket.io v4 a [`connect_timeout`](https://socket.io/fr/docs/v4/server-options/#connecttimeout) parameter should be provided in the config. 
It is used to drop the engine.io connexion if the client **did not send a CONNECT request** to any namespace after the engine.io handshake.

A PR to add this feature to the test-suite has been issued : https://github.com/socketio/socket.io-protocol/pull/31
