### PR TITLE
chore: prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## socketioxide
 * A [`on_disconnect`](https://docs.rs/socketioxide/latest/socketioxide/struct.Socket.html#method.on_disconnect) function is now available on the `Socket` instance. The provided callback will be called when the socket disconnects with the reasons for the disconnection. This is useful for logging or cleanup data.
 * A [`connect_timeout`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIoConfigBuilder.html#method.connect_timeout) option is now available in the config options. It is the maximum time to wait for a socket.io handshake before closing the connection. The default is 45 seconds.
-* A [`NsHandlers`](https://docs.rs/socketioxide/latest/socketioxide/struct.NsHandlers.html) struct describe namespace handlers passed to the SocketIoLayer/SocketIoService. Before, it was a type alias for a HashMap and it was containing types that were not supposed to be public.
+* A [`NsHandlers`](https://docs.rs/socketioxide/latest/socketioxide/struct.NsHandlers.html) struct was added. It describes namespace handlers passed to the SocketIoLayer/SocketIoService. Before, it was a type alias for a HashMap and it was containing types that were not supposed to be public.
 
 ## engineioxide
 * A [`DisconnectReason`](https://docs.rs/engineioxide/latest/engineioxide/enum.DisconnectReason.html) enum is passed to the `on_disconnect` callback of the engine handler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 * A [`on_disconnect`](https://docs.rs/socketioxide/latest/socketioxide/struct.Socket.html#method.on_disconnect) function is now available on the `Socket` instance. The provided callback will be called when the socket disconnects with the reasons for the disconnection. This is useful for logging or cleanup data.
 * A [`connect_timeout`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIoConfigBuilder.html#method.connect_timeout) option is now available in the config options. It is the maximum time to wait for a socket.io handshake before closing the connection. The default is 45 seconds.
 * A [`NsHandlers`](https://docs.rs/socketioxide/latest/socketioxide/struct.NsHandlers.html) struct describe namespace handlers passed to the SocketIoLayer/SocketIoService. Before, it was a type alias for a HashMap and it was containing types that were not supposed to be public.
+
+## engineioxide
+* A [`DisconnectReason`](https://docs.rs/engineioxide/latest/engineioxide/enum.DisconnectReason.html) enum is passed to the `on_disconnect` callback of the engine handler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 
 ## engineioxide
 * A [`DisconnectReason`](https://docs.rs/engineioxide/latest/engineioxide/enum.DisconnectReason.html) enum is passed to the `on_disconnect` callback of the engine handler.
+* Bump `tokio-tungstenite` to 0.20.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 0.5.0
+## socketioxide
+* A [`on_disconnect`](https://docs.rs/socketioxide/latest/socketioxide/struct.Socket.html#method.on_disconnect) function is now available on the `Socket` instance. The provided callback will be called when the socket disconnects with the reasons for the disconnection. This is useful for logging or cleanup data.
+* A [`connect_timeout`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIoConfigBuilder.html#method.connect_timeout) option is now available in the config options. It is the maximum time to wait for a socket.io handshake before closing the connection. The default is 45 seconds.
+* A [`NsHandlers`](https://docs.rs/socketioxide/latest/socketioxide/struct.NsHandlers.html) struct describe namespace handlers passed to the SocketIoLayer/SocketIoService. Before, it was a type alias for a HashMap and it was containing types that were not supposed to be public.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "engineioxide"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "axum",
  "dashmap",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-e2e"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "engineioxide",
  "futures",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-examples"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "engineioxide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.20.0",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -1270,7 +1270,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.20.0",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tower-http",
  "tracing",
@@ -1456,14 +1456,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.20.0",
+ "tungstenite 0.20.1",
 ]
 
 [[package]]
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
   * [Warp](https://docs.rs/warp/latest/warp/): [🏓echo example](./examples/src/socketio-echo/warp_echo.rs)
   * [Hyper](https://docs.rs/hyper/latest/hyper/): [🏓echo example](./examples/src/socketio-echo/hyper_echo.rs)
 * Out of the box support for any other middleware based on tower :
-  * [🔓CORS](https://docs.rs/tower-http/latest/tower_http/struct.CorsLayer.html)
-  * [🔐SSL](https://docs.rs/tower-http/latest/tower_http/struct.SslLayer.html)
-  * [📁Compression](https://docs.rs/tower-http/latest/tower_http/struct.CompressionLayer.html)
-  * [🕐Timeout](https://docs.rs/tower-http/latest/tower_http/struct.TimeoutLayer.html)
+  * [🔓CORS](https://docs.rs/tower-http/latest/tower_http/cors)
+  * [📁Compression](https://docs.rs/tower-http/latest/tower_http/compression)
+  * [🔐Authorization](https://docs.rs/tower-http/latest/tower_http/auth)
 * Namespaces
 * Rooms
 * Ack and emit with ack
@@ -205,3 +204,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 </details>
+
+<img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
+
+## Contributions and Feedback / Questions :
+Any contribution is welcome, feel free to open an issue or a PR. If you want to contribute but don't know where to start, you can check the [issues](https://github.com/totodore/socketioxide/issues).
+
+If you have any question or feedback, please open a thread on the [discussions](https://github.com/totodore/socketioxide/discussions) page.
+
+## License 🔐
+This project is licensed under the [MIT license](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
- <source media="(prefers-color-scheme: dark)" srcset="https://socket.io/images/logo-dark.svg" align="right" width=200>
+ <source media="(prefers-color-scheme: dark)" srcset="https://socket.io/images/logo-dark.svg" align="right" width=240>
 
- <img src="https://socket.io/images/logo.svg" align="right" width=200 />
+ <img src="https://socket.io/images/logo.svg" align="right" width=240 />
 </picture>
 
 # [`Socketioxide`](https://github.com/totodore/socketioxide) 🚀🦀

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
 <img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
 
 ## Examples :
-<details> <summary><code>Chat app 💬</code></summary>
+<details> <summary><code>Chat app 💬 (see full example <a href="./examples/src/chat">here</a>)</code></summary>
 
 ```rust
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,44 @@
-# Socket.io & Engine.io server Rust
-[![SocketIO CI](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml/badge.svg)](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml)
-[![EngineIO CI](https://github.com/Totodore/socketioxide/actions/workflows/engineio-ci.yml/badge.svg)](https://github.com/Totodore/socketioxide/actions/workflows/engineio-ci.yml)
+<img src="https://socket.io/images/logo-dark.svg" align="right" width=150 />
 
-### Socket.io server as a [tower layer](https://docs.rs/tower/latest/tower/) in Rust
-It integrates with any framework based on tower/hyper, such as:
-* [axum](https://docs.rs/axum/latest/axum/): [echo implementation](./examples/src/socketio-echo/axum_echo.rs)
-* [warp](https://docs.rs/warp/latest/warp/): [echo implementation](./examples/src/socketio-echo/warp_echo.rs)
-* [hyper](https://docs.rs/hyper/latest/hyper/): [echo implementation](./examples/src/socketio-echo/hyper_echo.rs)
+# [`Socketioxide`](https://github.com/totodore/socketioxide) 🚀🦀
 
-It takes full advantage of the [tower](https://docs.rs/tower/latest/tower/) and [tower-http](https://docs.rs/tower-http/latest/tower_http/) ecosystem of middleware, services, and utilities.
-
+A [***`socket.io`***](https://socket.io) server implementation in Rust that integrates with the [***`Tower`***](https://tokio.rs/#tk-lib-tower) ecosystem and the [***`Tokio stack`***](https://tokio.rs). Integrates with any server framework based on tower like [***`Axum`***](https://docs.rs/axum/latest/axum/), [***`Warp`***](https://docs.rs/warp/latest/warp/) or [***`Hyper`***](https://docs.rs/hyper/latest/hyper/). Add any other tower based middleware on top of socketioxide such as CORS, SSL, compression, etc with [***`tower-http`***](https://docs.rs/tower-http/latest/tower_http/).
 
 > ⚠️ This crate is under active development and the API is not yet stable.
 
-### Features :
+
+[![Crates.io](https://img.shields.io/crates/v/socketioxide.svg)](https://crates.io/crates/socketioxide)
+[![Documentation](https://docs.rs/socketioxide/badge.svg)](https://docs.rs/socketioxide)
+[![SocketIO CI](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml/badge.svg)](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml)
+[![EngineIO CI](https://github.com/Totodore/socketioxide/actions/workflows/engineio-ci.yml/badge.svg)](https://github.com/Totodore/socketioxide/actions/workflows/engineio-ci.yml)
+
+
+## Features :
+* Integrates with :
+  * [Axum](https://docs.rs/axum/latest/axum/): [echo example](./examples/src/socketio-echo/axum_echo.rs)
+  * [Warp](https://docs.rs/warp/latest/warp/): [echo example](./examples/src/socketio-echo/warp_echo.rs)
+  * [Hyper](https://docs.rs/hyper/latest/hyper/): [echo example](./examples/src/socketio-echo/hyper_echo.rs)
+* Out of the box support for any other middleware based on tower :
+  * [CORS](https://docs.rs/tower-http/latest/tower_http/struct.CorsLayer.html)
+  * [SSL](https://docs.rs/tower-http/latest/tower_http/struct.SslLayer.html)
+  * [Compression](https://docs.rs/tower-http/latest/tower_http/struct.CompressionLayer.html)
+  * [Timeout](https://docs.rs/tower-http/latest/tower_http/struct.TimeoutLayer.html)
 * Namespaces
 * Rooms
-* Handshake data
 * Ack and emit with ack
 * Binary packets
-* Polling & Websocket transport
+* Polling & Websocket transports
 * Extensions to add custom data to sockets
-* Memory efficient payload parsing with streams
+* Memory efficient http payload parsing with streams
 
-### Planned features :
+
+## Planned features :
 * Other adapter to share state between server instances (like redis adapter), currently only the in memory adapter is implemented
+* Better API ergonomics
 * State recovery when a socket reconnects
 * SocketIo v3 support (currently only v4 is supported)
 
-### Examples :
+## Examples :
 * [Chat app with Axum](./examples/src/chat)
 * Echo implementation with Axum :
 ```rust

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<picture>
- <source media="(prefers-color-scheme: dark)" srcset="https://socket.io/images/logo-dark.svg" align="right" width=200>
-
- <img src="https://socket.io/images/logo.svg" align="right" width=200 />
-</picture>
-
 # [`Socketioxide`](https://github.com/totodore/socketioxide) 🚀🦀
 
 A [***`socket.io`***](https://socket.io) server implementation in Rust that integrates with the [***`Tower`***](https://tokio.rs/#tk-lib-tower) ecosystem and the [***`Tokio stack`***](https://tokio.rs). Integrates with any server framework based on tower like [***`Axum`***](https://docs.rs/axum/latest/axum/), [***`Warp`***](https://docs.rs/warp/latest/warp/) or [***`Hyper`***](https://docs.rs/hyper/latest/hyper/). Add any other tower based middleware on top of socketioxide such as CORS, authorization, compression, etc with [***`tower-http`***](https://docs.rs/tower-http/latest/tower_http/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-<img src="https://socket.io/images/logo-dark.svg" align="right" width=200 />
+<picture>
+ <source media="(prefers-color-scheme: dark)" srcset="https://socket.io/images/logo-dark.svg" align="right" width=200>
+
+ <img src="https://socket.io/images/logo.svg" align="right" width=200 />
+</picture>
 
 # [`Socketioxide`](https://github.com/totodore/socketioxide) 🚀🦀
 
@@ -46,6 +50,11 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
 <details> <summary><code>Chat app 💬 (see full example <a href="./examples/src/chat">here</a>)</code></summary>
 
 ```rust
+use std::sync::Arc;
+
+use serde::Deserialize;
+use socketioxide::{adapter::LocalAdapter, Socket};
+use tracing::info;
 
 #[derive(Deserialize, Clone, Debug)]
 struct Nickname(String);

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # [`Socketioxide`](https://github.com/totodore/socketioxide) 🚀🦀
 
-A [***`socket.io`***](https://socket.io) server implementation in Rust that integrates with the [***`Tower`***](https://tokio.rs/#tk-lib-tower) ecosystem and the [***`Tokio stack`***](https://tokio.rs). Integrates with any server framework based on tower like [***`Axum`***](https://docs.rs/axum/latest/axum/), [***`Warp`***](https://docs.rs/warp/latest/warp/) or [***`Hyper`***](https://docs.rs/hyper/latest/hyper/). Add any other tower based middleware on top of socketioxide such as CORS, SSL, compression, etc with [***`tower-http`***](https://docs.rs/tower-http/latest/tower_http/).
+A [***`socket.io`***](https://socket.io) server implementation in Rust that integrates with the [***`Tower`***](https://tokio.rs/#tk-lib-tower) ecosystem and the [***`Tokio stack`***](https://tokio.rs). Integrates with any server framework based on tower like [***`Axum`***](https://docs.rs/axum/latest/axum/), [***`Warp`***](https://docs.rs/warp/latest/warp/) or [***`Hyper`***](https://docs.rs/hyper/latest/hyper/). Add any other tower based middleware on top of socketioxide such as CORS, authorization, compression, etc with [***`tower-http`***](https://docs.rs/tower-http/latest/tower_http/).
 
 > ⚠️ This crate is under active development and the API is not yet stable.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
- <source media="(prefers-color-scheme: dark)" srcset="https://socket.io/images/logo-dark.svg" align="right" width=240>
+ <source media="(prefers-color-scheme: dark)" srcset="https://socket.io/images/logo-dark.svg" align="right" width=200>
 
- <img src="https://socket.io/images/logo.svg" align="right" width=240 />
+ <img src="https://socket.io/images/logo.svg" align="right" width=200 />
 </picture>
 
 # [`Socketioxide`](https://github.com/totodore/socketioxide) 🚀🦀

--- a/README.md
+++ b/README.md
@@ -7,22 +7,24 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
 > ⚠️ This crate is under active development and the API is not yet stable.
 
 
+
 [![Crates.io](https://img.shields.io/crates/v/socketioxide.svg)](https://crates.io/crates/socketioxide)
 [![Documentation](https://docs.rs/socketioxide/badge.svg)](https://docs.rs/socketioxide)
 [![SocketIO CI](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml/badge.svg)](https://github.com/Totodore/socketioxide/actions/workflows/socketio-ci.yml)
 [![EngineIO CI](https://github.com/Totodore/socketioxide/actions/workflows/engineio-ci.yml/badge.svg)](https://github.com/Totodore/socketioxide/actions/workflows/engineio-ci.yml)
 
+<img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
 
 ## Features :
 * Integrates with :
-  * [Axum](https://docs.rs/axum/latest/axum/): [echo example](./examples/src/socketio-echo/axum_echo.rs)
-  * [Warp](https://docs.rs/warp/latest/warp/): [echo example](./examples/src/socketio-echo/warp_echo.rs)
-  * [Hyper](https://docs.rs/hyper/latest/hyper/): [echo example](./examples/src/socketio-echo/hyper_echo.rs)
+  * [Axum](https://docs.rs/axum/latest/axum/): [🏓echo example](./examples/src/socketio-echo/axum_echo.rs)
+  * [Warp](https://docs.rs/warp/latest/warp/): [🏓echo example](./examples/src/socketio-echo/warp_echo.rs)
+  * [Hyper](https://docs.rs/hyper/latest/hyper/): [🏓echo example](./examples/src/socketio-echo/hyper_echo.rs)
 * Out of the box support for any other middleware based on tower :
-  * [CORS](https://docs.rs/tower-http/latest/tower_http/struct.CorsLayer.html)
-  * [SSL](https://docs.rs/tower-http/latest/tower_http/struct.SslLayer.html)
-  * [Compression](https://docs.rs/tower-http/latest/tower_http/struct.CompressionLayer.html)
-  * [Timeout](https://docs.rs/tower-http/latest/tower_http/struct.TimeoutLayer.html)
+  * [🔓CORS](https://docs.rs/tower-http/latest/tower_http/struct.CorsLayer.html)
+  * [🔐SSL](https://docs.rs/tower-http/latest/tower_http/struct.SslLayer.html)
+  * [📁Compression](https://docs.rs/tower-http/latest/tower_http/struct.CompressionLayer.html)
+  * [🕐Timeout](https://docs.rs/tower-http/latest/tower_http/struct.TimeoutLayer.html)
 * Namespaces
 * Rooms
 * Ack and emit with ack
@@ -31,6 +33,7 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
 * Extensions to add custom data to sockets
 * Memory efficient http payload parsing with streams
 
+<img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
 
 ## Planned features :
 * Other adapter to share state between server instances (like redis adapter), currently only the in memory adapter is implemented
@@ -38,9 +41,112 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
 * State recovery when a socket reconnects
 * SocketIo v3 support (currently only v4 is supported)
 
+<img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
+
 ## Examples :
-* [Chat app with Axum](./examples/src/chat)
-* Echo implementation with Axum :
+<details> <summary><code>Chat app 💬</code></summary>
+
+```rust
+
+#[derive(Deserialize, Clone, Debug)]
+struct Nickname(String);
+
+#[derive(Deserialize)]
+struct Auth {
+    pub nickname: Nickname,
+}
+
+pub async fn handler(socket: Arc<Socket<LocalAdapter>>) {
+    info!("Socket connected on / with id: {}", socket.sid);
+    if let Ok(data) = socket.handshake.data::<Auth>() {
+        info!("Nickname: {:?}", data.nickname);
+        socket.extensions.insert(data.nickname);
+        socket.emit("message", "Welcome to the chat!").ok();
+        socket.join("default").unwrap();
+    } else {
+        info!("No nickname provided, disconnecting...");
+        socket.disconnect().ok();
+        return;
+    }
+
+    socket.on(
+        "message",
+        |socket, (room, message): (String, String), _, _| async move {
+            let Nickname(ref nickname) = *socket.extensions.get().unwrap();
+            info!("transfering message from {nickname} to {room}: {message}");
+            info!("Sockets in room: {:?}", socket.local().sockets().unwrap());
+            if let Some(dest) = socket.to("default").sockets().unwrap().iter().find(|s| {
+                s.extensions
+                    .get::<Nickname>()
+                    .map(|n| n.0 == room)
+                    .unwrap_or_default()
+            }) {
+                info!("Sending message to {}", room);
+                dest.emit("message", format!("{}: {}", nickname, message))
+                    .ok();
+            }
+
+            socket
+                .to(room)
+                .emit("message", format!("{}: {}", nickname, message))
+                .ok();
+        },
+    );
+
+    socket.on("join", |socket, room: String, _, _| async move {
+        info!("Joining room {}", room);
+        socket.join(room).unwrap();
+    });
+
+    socket.on("leave", |socket, room: String, _, _| async move {
+        info!("Leaving room {}", room);
+        socket.leave(room).unwrap();
+    });
+
+    socket.on("list", |socket, room: Option<String>, _, _| async move {
+        if let Some(room) = room {
+            info!("Listing sockets in room {}", room);
+            let sockets = socket
+                .within(room)
+                .sockets()
+                .unwrap()
+                .iter()
+                .filter_map(|s| s.extensions.get::<Nickname>())
+                .fold("".to_string(), |a, b| a + &b.0 + ", ")
+                .trim_end_matches(", ")
+                .to_string();
+            socket.emit("message", sockets).ok();
+        } else {
+            let rooms = socket.rooms().unwrap();
+            info!("Listing rooms: {:?}", &rooms);
+            socket.emit("message", rooms).ok();
+        }
+    });
+
+    socket.on("nickname", |socket, nickname: Nickname, _, _| async move {
+        let previous = socket.extensions.insert(nickname.clone());
+        info!("Nickname changed from {:?} to {:?}", &previous, &nickname);
+        let msg = format!(
+            "{} changed his nickname to {}",
+            previous.map(|n| n.0).unwrap_or_default(),
+            nickname.0
+        );
+        socket.to("default").emit("message", msg).ok();
+    });
+
+    socket.on_disconnect(|socket, reason| async move {
+        info!("Socket disconnected: {} {}", socket.sid, reason);
+        let Nickname(ref nickname) = *socket.extensions.get().unwrap();
+        let msg = format!("{} left the chat", nickname);
+        socket.to("default").emit("message", msg).ok();
+    });
+}
+
+```
+
+</details>
+<details> <summary><code> Echo implementation with Axum 🏓 </code></summary>
+
 ```rust
 use axum::routing::get;
 use axum::Server;
@@ -98,3 +204,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+</details>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://socket.io/images/logo-dark.svg" align="right" width=150 />
+<img src="https://socket.io/images/logo-dark.svg" align="right" width=200 />
 
 # [`Socketioxide`](https://github.com/totodore/socketioxide) 🚀🦀
 
@@ -145,7 +145,7 @@ pub async fn handler(socket: Arc<Socket<LocalAdapter>>) {
 ```
 
 </details>
-<details> <summary><code> Echo implementation with Axum 🏓 </code></summary>
+<details> <summary><code>Echo implementation with Axum 🏓</code></summary>
 
 ```rust
 use axum::routing::get;

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socketioxide-e2e"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/engineioxide/Cargo.toml
+++ b/engineioxide/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "engineioxide"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 
 authors = ["Théodore Prévot <"]
 description = "Engine IO server implementation in rust as a Tower Service."

--- a/engineioxide/Cargo.toml
+++ b/engineioxide/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0.155", features = ["derive"] }
 serde_json = "1.0.94"
 thiserror = "1.0.40"
 tokio = "1.26.0"
-tokio-tungstenite = "0.20.0"
+tokio-tungstenite = "0.20.1"
 tower = "0.4.13"
 tracing = "0.1.37"
 rand = "0.8.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socketioxide-examples"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "socketioxide"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 
 authors = ["Théodore Prévot <"]
 description = "Socket IO server implementation in rust as a Tower Service."
@@ -18,7 +18,7 @@ license = "MIT"
 readme = "../Readme.md"
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.4.1" }
+engineioxide = { path = "../engineioxide", version = "0.5.0" }
 futures = "0.3.27"
 tokio = "1.26.0"
 serde = { version = "1.0.155", features = ["derive"] }


### PR DESCRIPTION
# Bump version to v0.5.0

## socketioxide
* A [`on_disconnect`](https://docs.rs/socketioxide/latest/socketioxide/struct.Socket.html#method.on_disconnect) function is now available on the `Socket` instance. The provided callback will be called when the socket disconnects with the reasons for the disconnection. This is useful for logging or cleanup data.
* A [`connect_timeout`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIoConfigBuilder.html#method.connect_timeout) option is now available in the config options. It is the maximum time to wait for a socket.io handshake before closing the connection. The default is 45 seconds.
* A [`NsHandlers`](https://docs.rs/socketioxide/latest/socketioxide/struct.NsHandlers.html) struct was added. It describes namespace handlers passed to the SocketIoLayer/SocketIoService. Before, it was a type alias for a HashMap and it was containing types that were not supposed to be public.

## engineioxide
* A [`DisconnectReason`](https://docs.rs/engineioxide/latest/engineioxide/enum.DisconnectReason.html) enum is passed to the `on_disconnect` callback of the engine handler.
* Bump `tokio-tungstenite` to 0.20.1.