### PR TITLE
chore(ci): migrating from official e2e to custom

### DIFF
--- a/.github/workflows/engineio-ci.yml
+++ b/.github/workflows/engineio-ci.yml
@@ -19,7 +19,7 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v3
         with:
-          repository: socketio/engine.io-protocol
+          repository: totodore/engine.io-protocol
           path: engine.io-protocol
           ref: v3
       - uses: actions/setup-node@v3
@@ -56,7 +56,7 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v3
         with:
-          repository: socketio/engine.io-protocol
+          repository: totodore/engine.io-protocol
           path: engine.io-protocol
           ref: main
       - uses: actions/setup-node@v3

--- a/.github/workflows/socketio-ci.yml
+++ b/.github/workflows/socketio-ci.yml
@@ -47,7 +47,7 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v3
         with:
-          repository: socketio/socket.io-protocol
+          repository: totodore/socket.io-protocol
           path: socket.io-protocol
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Use custom ci until PR https://github.com/socketio/socket.io-protocol/pull/33 is merged