### PR TITLE
fix: apply max payload option when encoding (fix #113)

### DIFF
--- a/engineioxide/src/lib.rs
+++ b/engineioxide/src/lib.rs
@@ -19,4 +19,5 @@ mod body;
 mod engine;
 mod futures;
 mod packet;
+mod peekable;
 mod transport;

--- a/engineioxide/src/peekable.rs
+++ b/engineioxide/src/peekable.rs
@@ -1,0 +1,79 @@
+use tokio::sync::mpsc::{error::TryRecvError, Receiver};
+
+/// Peekable receiver for polling transport
+/// It is a thin wrapper around a [`Receiver`](tokio::sync::mpsc::Receiver) that allows to peek the next packet without consuming it
+///
+/// Its main goal is to be able to peek the next packet without consuming it to calculate the
+/// packet length when using polling transport to check if it fits according to the max_payload setting
+#[derive(Debug)]
+pub struct PeekableReceiver<T> {
+    rx: Receiver<T>,
+    next: Option<T>,
+}
+impl<T> PeekableReceiver<T> {
+    pub fn new(rx: Receiver<T>) -> Self {
+        Self { rx, next: None }
+    }
+    pub fn peek(&mut self) -> Option<&T> {
+        if self.next.is_none() {
+            self.next = self.rx.try_recv().ok();
+        }
+        self.next.as_ref()
+    }
+    pub async fn recv(&mut self) -> Option<T> {
+        if self.next.is_none() {
+            self.rx.recv().await
+        } else {
+            self.next.take()
+        }
+    }
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        if self.next.is_none() {
+            self.rx.try_recv()
+        } else {
+            Ok(self.next.take().unwrap())
+        }
+    }
+
+    pub fn close(&mut self) {
+        self.rx.close()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn peek() {
+        use super::PeekableReceiver;
+        use crate::packet::Packet;
+        use tokio::sync::mpsc::channel;
+
+        let (tx, rx) = channel(1);
+        let rx = Mutex::new(PeekableReceiver::new(rx));
+        let mut rx = rx.lock().await;
+
+        assert!(rx.peek().is_none());
+
+        tx.send(Packet::Ping).await.unwrap();
+        assert_eq!(rx.peek(), Some(&Packet::Ping));
+        assert_eq!(rx.recv().await, Some(Packet::Ping));
+        assert!(rx.peek().is_none());
+
+        tx.send(Packet::Pong).await.unwrap();
+        assert_eq!(rx.peek(), Some(&Packet::Pong));
+        assert_eq!(rx.recv().await, Some(Packet::Pong));
+        assert!(rx.peek().is_none());
+
+        tx.send(Packet::Close).await.unwrap();
+        assert_eq!(rx.peek(), Some(&Packet::Close));
+        assert_eq!(rx.recv().await, Some(Packet::Close));
+        assert!(rx.peek().is_none());
+
+        tx.send(Packet::Close).await.unwrap();
+        assert_eq!(rx.peek(), Some(&Packet::Close));
+        assert_eq!(rx.recv().await, Some(Packet::Close));
+        assert!(rx.peek().is_none());
+    }
+}

--- a/engineioxide/src/transport/polling/payload/encoder.rs
+++ b/engineioxide/src/transport/polling/payload/encoder.rs
@@ -220,12 +220,7 @@ pub async fn v3_string_encoder(
     let max_packet_size_len = max_payload.checked_ilog10().unwrap_or(0) as usize + 1;
     // Current size of the payload
     let current_size = data.len() + PUNCTUATION_LEN + max_packet_size_len;
-    while let Some(packet) = try_recv_packet(
-        &mut rx,
-        current_size,
-        max_payload,
-        true,
-    ) {
+    while let Some(packet) = try_recv_packet(&mut rx, current_size, max_payload, true) {
         v3_string_packet_encoder(packet, &mut data)?;
     }
 
@@ -352,10 +347,9 @@ mod tests {
     async fn max_payload_v3_binary() {
         const MAX_PAYLOAD: u64 = 25;
 
-        #[rustfmt::skip]
         const PAYLOAD: [u8; 23] = [
-            0, 1, 1, 255, 52, 104, 101, 108, 108, 111, 111, 111, 226, 130, 172, 
-            1, 5, 255, 4, 1, 2, 3, 4,
+            0, 1, 1, 255, 52, 104, 101, 108, 108, 111, 111, 111, 226, 130, 172, 1, 5, 255, 4, 1, 2,
+            3, 4,
         ];
         let (tx, rx) = tokio::sync::mpsc::channel::<Packet>(10);
         let mutex = Mutex::new(PeekableReceiver::new(rx));

--- a/engineioxide/src/transport/polling/payload/encoder.rs
+++ b/engineioxide/src/transport/polling/payload/encoder.rs
@@ -7,29 +7,51 @@
 //!    * binary encoder (used when there is binary packets and the client supports binary)
 //!
 
-use tokio::sync::{mpsc::Receiver, MutexGuard};
+use tokio::sync::MutexGuard;
 use tracing::debug;
 
-use crate::{errors::Error, packet::Packet};
+use crate::{
+    errors::Error, packet::Packet, peekable::PeekableReceiver, transport::polling::payload::Payload,
+};
 
-/// Try to immediately poll a new packet from the rx channel and return a encoded string version
+/// Try to immediately poll a new packet from the rx channel and check that the new packet can be added to the payload
 ///
 /// Manually close the channel if the packet is a close packet
 /// It will allow to notify the [`Socket`](crate::socket::Socket) that the session is closed
-fn try_recv_packet(rx: &mut MutexGuard<'_, Receiver<Packet>>) -> Option<Packet> {
-    let packet = rx.try_recv();
-    if let Ok(Packet::Close) = packet {
+///
+/// ## Arguments
+/// * `rx` - The channel to poll
+/// * `payload_len` - The current payload length
+/// * `max_payload` - The maximum payload length
+/// * `b64` - If binary packets should be encoded in base64
+fn try_recv_packet(
+    rx: &mut MutexGuard<'_, PeekableReceiver<Packet>>,
+    payload_len: usize,
+    max_payload: u64,
+    b64: bool,
+) -> Option<Packet> {
+    if let Some(packet) = rx.peek() {
+        if (payload_len + packet.get_size_hint(b64)) as u64 > max_payload {
+            debug!("payload too big, stopping encoding for this payload");
+            return None;
+        }
+    }
+
+    let packet = rx.try_recv().ok();
+
+    if let Some(Packet::Close) = packet {
         debug!("Received close packet, closing channel");
+        rx.try_recv().ok();
         rx.close();
     }
 
     debug!("sending packet: {:?}", packet);
-    packet.ok()
+    packet
 }
 
-/// Same as [`try_poll_packet`](crate::payload::encoder::try_poll_packet)
+/// Same as [`try_recv_packet`]
 /// but wait for a new packet if there is no packet in the buffer
-async fn recv_packet(rx: &mut MutexGuard<'_, Receiver<Packet>>) -> Result<Packet, Error> {
+async fn recv_packet(rx: &mut MutexGuard<'_, PeekableReceiver<Packet>>) -> Result<Packet, Error> {
     let packet = rx.recv().await.ok_or(Error::Aborted)?;
     if packet == Packet::Close {
         debug!("Received close packet, closing channel");
@@ -43,16 +65,20 @@ async fn recv_packet(rx: &mut MutexGuard<'_, Receiver<Packet>>) -> Result<Packet
 /// Encode multiple packets into a string payload according to the
 /// [engine.io v4 protocol](https://socket.io/fr/docs/v4/engine-io-protocol/#http-long-polling-1)
 #[cfg(feature = "v4")]
-pub async fn v4_encoder(mut rx: MutexGuard<'_, Receiver<Packet>>) -> Result<Vec<u8>, Error> {
-    use payload::PACKET_SEPARATOR_V4;
-
-    use crate::transport::polling::payload;
+pub async fn v4_encoder(
+    mut rx: MutexGuard<'_, PeekableReceiver<Packet>>,
+    max_payload: u64,
+) -> Result<Payload, Error> {
+    use crate::transport::polling::payload::PACKET_SEPARATOR_V4;
 
     debug!("encoding payload with v4 encoder");
     let mut data: String = String::new();
 
     // Send all packets in the buffer
-    while let Some(packet) = try_recv_packet(&mut rx) {
+    const PUNCTUATION_LEN: usize = 1;
+    while let Some(packet) =
+        try_recv_packet(&mut rx, data.len() + PUNCTUATION_LEN, max_payload, true)
+    {
         let packet: String = packet.try_into()?;
 
         if !data.is_empty() {
@@ -67,7 +93,8 @@ pub async fn v4_encoder(mut rx: MutexGuard<'_, Receiver<Packet>>) -> Result<Vec<
         let packet: String = packet.try_into()?;
         data.push_str(&packet);
     }
-    Ok(data.into())
+
+    Ok(Payload::new(data, false))
 }
 
 /// Encode one packet into a *binary* payload according to the
@@ -119,18 +146,20 @@ pub fn v3_string_packet_encoder(packet: Packet, data: &mut Vec<u8>) -> Result<()
 }
 
 /// Encode multiple packet packet into a *string* payload if there is no binary packet or into a *binary* payload if there is binary packets
-/// according to the [engine.io v4 protocol](https://socket.io/fr/docs/v4/engine-io-protocol/#http-long-polling-1)
+/// according to the [engine.io v3 protocol](https://github.com/socketio/engine.io-protocol/tree/v3#payload)
 #[cfg(feature = "v3")]
 pub async fn v3_binary_encoder(
-    mut rx: MutexGuard<'_, Receiver<Packet>>,
-) -> Result<(Vec<u8>, bool), Error> {
+    mut rx: MutexGuard<'_, PeekableReceiver<Packet>>,
+    max_payload: u64,
+) -> Result<Payload, Error> {
     let mut data: Vec<u8> = Vec::new();
     let mut packet_buffer: Vec<Packet> = Vec::new();
 
     debug!("encoding payload with v3 binary encoder");
     // buffer all packets to find if there is binary packets
     let mut has_binary = false;
-    while let Some(packet) = try_recv_packet(&mut rx) {
+
+    while let Some(packet) = try_recv_packet(&mut rx, data.len(), max_payload, false) {
         if packet.is_binary() {
             has_binary = true;
         }
@@ -139,7 +168,7 @@ pub async fn v3_binary_encoder(
 
     if has_binary {
         for packet in packet_buffer {
-            v3_bin_packet_encoder(packet, &mut data)?
+            v3_bin_packet_encoder(packet, &mut data)?;
         }
     } else {
         for packet in packet_buffer {
@@ -161,18 +190,23 @@ pub async fn v3_binary_encoder(
             }
         };
     }
+
     debug!("sending packet: {:?}", &data);
-    Ok((data, has_binary))
+    Ok(Payload::new(data, has_binary))
 }
 
 /// Encode multiple packet packet into a *string* payload according to the
 /// [engine.io v3 protocol](https://github.com/socketio/engine.io-protocol/tree/v3#payload)
 #[cfg(feature = "v3")]
-pub async fn v3_string_encoder(mut rx: MutexGuard<'_, Receiver<Packet>>) -> Result<Vec<u8>, Error> {
+pub async fn v3_string_encoder(
+    mut rx: MutexGuard<'_, PeekableReceiver<Packet>>,
+    max_payload: u64,
+) -> Result<Payload, Error> {
     let mut data: Vec<u8> = Vec::new();
 
     debug!("encoding payload with v3 string encoder");
-    while let Some(packet) = try_recv_packet(&mut rx) {
+
+    while let Some(packet) = try_recv_packet(&mut rx, data.len(), max_payload, true) {
         v3_string_packet_encoder(packet, &mut data)?;
     }
 
@@ -182,7 +216,7 @@ pub async fn v3_string_encoder(mut rx: MutexGuard<'_, Receiver<Packet>>) -> Resu
         v3_string_packet_encoder(packet, &mut data)?;
     }
 
-    Ok(data)
+    Ok(Payload::new(data, false))
 }
 
 #[cfg(test)]
@@ -191,20 +225,47 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
+    const MAX_PAYLOAD: u64 = 100_000;
 
     #[cfg(feature = "v4")]
     #[tokio::test]
     async fn encode_v4_payload() {
         const PAYLOAD: &str = "4hello€\x1ebAQIDBA==\x1e4hello€";
         let (tx, rx) = tokio::sync::mpsc::channel::<Packet>(10);
-        let mutex = Mutex::new(rx);
-        let rx = mutex.lock().await;
-
+        let rx = Mutex::new(PeekableReceiver::new(rx));
+        let rx = rx.lock().await;
         tx.try_send(Packet::Message("hello€".into())).unwrap();
         tx.try_send(Packet::Binary(vec![1, 2, 3, 4])).unwrap();
         tx.try_send(Packet::Message("hello€".into())).unwrap();
-        let res = v4_encoder(rx).await.unwrap();
-        assert_eq!(res, PAYLOAD.as_bytes());
+        let Payload { data, .. } = v4_encoder(rx, MAX_PAYLOAD).await.unwrap();
+        assert_eq!(data, PAYLOAD.as_bytes());
+    }
+
+    #[cfg(feature = "v4")]
+    #[tokio::test]
+    async fn max_payload_v4() {
+        const MAX_PAYLOAD: u64 = 10;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Packet>(10);
+        let mutex = Mutex::new(PeekableReceiver::new(rx));
+        tx.try_send(Packet::Message("hello€".into())).unwrap();
+        tx.try_send(Packet::Binary(vec![1, 2, 3, 4])).unwrap();
+        tx.try_send(Packet::Message("hello€".into())).unwrap();
+        tx.try_send(Packet::Message("hello€".into())).unwrap();
+        {
+            let rx = mutex.lock().await;
+            let Payload { data, .. } = v4_encoder(rx, MAX_PAYLOAD).await.unwrap();
+            assert_eq!(data, "4hello€".as_bytes());
+        }
+        {
+            let rx = mutex.lock().await;
+            let Payload { data, .. } = v4_encoder(rx, MAX_PAYLOAD + 10).await.unwrap();
+            assert_eq!(data, "bAQIDBA==\x1e4hello€".as_bytes());
+        }
+        {
+            let rx = mutex.lock().await;
+            let Payload { data, .. } = v4_encoder(rx, MAX_PAYLOAD + 10).await.unwrap();
+            assert_eq!(data, "4hello€".as_bytes());
+        }
     }
 
     #[cfg(feature = "v3")]
@@ -212,14 +273,17 @@ mod tests {
     async fn encode_v3b64_payload() {
         const PAYLOAD: &str = "7:4hello€10:b4AQIDBA==7:4hello€";
         let (tx, rx) = tokio::sync::mpsc::channel::<Packet>(10);
-        let mutex = Mutex::new(rx);
+        let mutex = Mutex::new(PeekableReceiver::new(rx));
         let rx = mutex.lock().await;
 
         tx.try_send(Packet::Message("hello€".into())).unwrap();
         tx.try_send(Packet::BinaryV3(vec![1, 2, 3, 4])).unwrap();
         tx.try_send(Packet::Message("hello€".into())).unwrap();
-        let res = v3_string_encoder(rx).await.unwrap();
-        assert_eq!(res, PAYLOAD.as_bytes());
+        let Payload {
+            data, has_binary, ..
+        } = v3_string_encoder(rx, MAX_PAYLOAD).await.unwrap();
+        assert_eq!(data, PAYLOAD.as_bytes());
+        assert!(!has_binary);
     }
 
     #[cfg(feature = "v3")]
@@ -229,13 +293,50 @@ mod tests {
             0, 9, 255, 52, 104, 101, 108, 108, 111, 226, 130, 172, 1, 5, 255, 4, 1, 2, 3, 4,
         ];
         let (tx, rx) = tokio::sync::mpsc::channel::<Packet>(10);
-        let mutex = Mutex::new(rx);
+        let mutex = Mutex::new(PeekableReceiver::new(rx));
         let rx = mutex.lock().await;
 
         tx.try_send(Packet::Message("hello€".into())).unwrap();
         tx.try_send(Packet::BinaryV3(vec![1, 2, 3, 4])).unwrap();
-        let (res, is_binary) = v3_binary_encoder(rx).await.unwrap();
-        assert_eq!(res, PAYLOAD);
-        assert!(is_binary);
+        let Payload {
+            data, has_binary, ..
+        } = v3_binary_encoder(rx, MAX_PAYLOAD).await.unwrap();
+        assert_eq!(data, PAYLOAD);
+        assert!(has_binary);
+    }
+
+    #[cfg(feature = "v3")]
+    #[tokio::test]
+    async fn max_payload_v3_binary() {
+        const MAX_PAYLOAD: u64 = 15;
+
+        #[rustfmt::skip]
+        const PAYLOAD: [u8; 47] = [
+            0, 1, 1, 255, 52, 104, 101, 108, 108, 111, 111, 111, 226, 130, 172, 
+            1, 5, 255, 4, 1, 2, 3, 4,
+            0, 9, 255, 52, 104, 101, 108, 108, 111, 226, 130, 172, 
+            0, 9, 255, 52, 104, 101, 108, 108, 111, 226, 130, 172, 
+        ];
+        let (tx, rx) = tokio::sync::mpsc::channel::<Packet>(10);
+        let mutex = Mutex::new(PeekableReceiver::new(rx));
+        tx.try_send(Packet::Message("hellooo€".into())).unwrap();
+        tx.try_send(Packet::Binary(vec![1, 2, 3, 4])).unwrap();
+        tx.try_send(Packet::Message("hello€".into())).unwrap();
+        tx.try_send(Packet::Message("hello€".into())).unwrap();
+        {
+            let rx = mutex.lock().await;
+            let Payload { data, .. } = v3_binary_encoder(rx, MAX_PAYLOAD).await.unwrap();
+            assert_eq!(data, PAYLOAD[..15]);
+        }
+        {
+            let rx = mutex.lock().await;
+            let Payload { data, .. } = v3_binary_encoder(rx, MAX_PAYLOAD + 10).await.unwrap();
+            assert_eq!(data, "bAQIDBA==\x1e4hello€".as_bytes());
+        }
+        {
+            let rx = mutex.lock().await;
+            let Payload { data, .. } = v3_binary_encoder(rx, MAX_PAYLOAD + 10).await.unwrap();
+            assert_eq!(data, "4hello€".as_bytes());
+        }
     }
 }


### PR DESCRIPTION
This PR apply the `max_payload_size` option to the encoding process for polling. Before, it was only applied when decoding.
In order to calculate the size of the payload with the next packet **without** polling it from the channel, a `PeekableReceiver` struct was made to `peek` the next element without polling it.

For the v3 protocol the current payload computed size is not accurate because the size in `chars` of the packet is included in the payload. And getting that information *before* adding the packet is not possible (also it is a O(n) operation). Therefore the max  packet size length is apply, it is the number of digit of the maximum payload size.