### PR TITLE
Revert "fix(socketio/socket): create a different socket id for each ns"

### DIFF
--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -399,12 +399,15 @@ impl<D> Socket<D>
 where
     D: Default + Send + Sync + 'static,
 {
-    pub fn new_dummy(close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>) -> Socket<D> {
+    pub fn new_dummy(
+        sid: Sid,
+        close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
+    ) -> Socket<D> {
         let (internal_tx, internal_rx) = mpsc::channel(200);
         let (heartbeat_tx, heartbeat_rx) = mpsc::channel(1);
 
         Self {
-            id: Sid::new(),
+            id: sid,
             protocol: ProtocolVersion::V4,
             transport: AtomicU8::new(TransportType::Websocket as u8),
 

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -60,13 +60,23 @@ impl<A: Adapter> Client<A> {
         auth: Option<String>,
         ns_path: String,
         esocket: &Arc<engineioxide::Socket<SocketData>>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), serde_json::Error> {
         debug!("auth: {:?}", auth);
         let sid = esocket.id;
         if let Some(ns) = self.get_ns(&ns_path) {
-            ns.connect(sid, esocket.clone(), auth, self.config.clone())?;
+            let protocol: ProtocolVersion = esocket.protocol.into();
 
             // cancel the connect timeout task for v5
+            #[cfg(feature = "v5")]
+            if let Some(tx) = esocket.data.connect_recv_tx.lock().unwrap().take() {
+                tx.send(()).unwrap();
+            }
+
+            let connect_packet = Packet::connect(ns_path, sid, protocol);
+            if let Err(err) = esocket.emit(connect_packet.try_into()?) {
+                debug!("sending error during socket connection: {err:?}");
+            }
+            ns.connect(sid, esocket.clone(), auth, self.config.clone())?;
             if let Some(tx) = esocket.data.connect_recv_tx.lock().unwrap().take() {
                 tx.send(()).unwrap();
             }
@@ -98,9 +108,12 @@ impl<A: Adapter> Client<A> {
 
     /// Propagate a packet to a its target namespace
     fn sock_propagate_packet(&self, packet: Packet, sid: Sid) -> Result<(), Error> {
-        self.get_ns(&packet.ns)
-            .ok_or(Error::InvalidNamespace(packet.ns))?
-            .recv(sid, packet.inner)
+        if let Some(ns) = self.get_ns(&packet.ns) {
+            ns.recv(sid, packet.inner)
+        } else {
+            debug!("invalid namespace requested: {}", packet.ns);
+            Ok(())
+        }
     }
 
     /// Spawn a task that will close the socket if it is not connected to a namespace

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -19,13 +19,10 @@ pub enum Error {
     InvalidEventName,
 
     #[error("invalid namespace")]
-    InvalidNamespace(String),
+    InvalidNamespace,
 
     #[error("cannot find socketio socket")]
     SocketGone(Sid),
-
-    #[error("send error: {0}")]
-    SendError(#[from] SendError),
 
     /// An engineio error
     #[error("engineio error: {0}")]
@@ -47,7 +44,7 @@ impl From<&Error> for Option<EIoDisconnectReason> {
             Error::SerializeError(_) | Error::InvalidPacketType | Error::InvalidEventName => {
                 Some(PacketParsingError)
             }
-            Error::Adapter(_) | Error::InvalidNamespace(_) | Error::SendError(_) => None,
+            Error::Adapter(_) | Error::InvalidNamespace => None,
         }
     }
 }

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use engineioxide::{sid::Sid, socket::DisconnectReason as EIoDisconnectReason, ProtocolVersion};
+use engineioxide::{sid::Sid, socket::DisconnectReason as EIoDisconnectReason};
 use futures::{future::BoxFuture, Future};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
@@ -110,22 +110,18 @@ pub struct Socket<A: Adapter> {
 
 impl<A: Adapter> Socket<A> {
     pub(crate) fn new(
+        sid: Sid,
         ns: Arc<Namespace<A>>,
         esocket: Arc<engineioxide::Socket<SocketData>>,
         config: Arc<SocketIoConfig>,
     ) -> Self {
-        let id = if esocket.protocol == ProtocolVersion::V3 {
-            esocket.id
-        } else {
-            Sid::new()
-        };
         Self {
             ns,
             message_handlers: RwLock::new(HashMap::new()),
             disconnect_handler: Mutex::new(None),
             ack_message: Mutex::new(HashMap::new()),
             ack_counter: AtomicI64::new(0),
-            id,
+            id: sid,
             extensions: Extensions::new(),
             config,
             esocket,
@@ -587,16 +583,11 @@ impl<A: Adapter> Debug for Socket<A> {
 impl<A: Adapter> Socket<A> {
     pub fn new_dummy(sid: Sid, ns: Arc<Namespace<A>>) -> Socket<A> {
         let close_fn = Box::new(move |_, _| ());
-        Socket {
-            id: sid,
+        Socket::new(
+            sid,
             ns,
-            ack_counter: AtomicI64::new(0),
-            ack_message: Mutex::new(HashMap::new()),
-            message_handlers: RwLock::new(HashMap::new()),
-            disconnect_handler: Mutex::new(None),
-            config: Arc::new(SocketIoConfig::default()),
-            extensions: Extensions::new(),
-            esocket: engineioxide::Socket::new_dummy(close_fn).into(),
-        }
+            engineioxide::Socket::new_dummy(sid, close_fn).into(),
+            Arc::new(SocketIoConfig::default()),
+        )
     }
 }


### PR DESCRIPTION
Reverts Totodore/socketioxide#123

It appears that solving this issue implies a big refactoring. Indeed referencing socketio socket with custom sid instead is impossible because of the following architecture : 
`client recv data from engine socket -> route to corresponding namespace -> route to corresponding socket with <Engine id -> socket> hashmap`

Because the socket id is not in the request it is impossible to map socket by their socket id (and not their engine id).
The solution would be to refactor the code to match the official architecture : 
`client wraps an engine socket and holds a map of the ns -> socket`.