### PR TITLE
fix(engineio/packet): array expand for packet event only when not empty

### DIFF
--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -289,14 +289,7 @@ impl<'a> TryInto<String> for Packet<'a> {
         // pre-serializing allows to preallocate the buffer
         let data = match &mut self.inner {
             Event(e, data, _) | BinaryEvent(e, BinaryPacket { data, .. }, _) => {
-                // Expand the packet if it is an array -> ["event", ...data]
-                let packet = match data {
-                    Value::Array(ref mut v) => {
-                        v.insert(0, Value::String(e.to_string()));
-                        serde_json::to_string(&v)
-                    }
-                    _ => serde_json::to_string(&(e, data)),
-                }?;
+                let packet = serde_json::to_string(&(e, data))?;
                 Some(packet)
             }
             EventAck(data, _) | BinaryAck(BinaryPacket { data, .. }, _) => {

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -613,7 +613,7 @@ mod test {
 
         // Encode with NS
         let payload = format!("2/admin™,{}", json!(["event", { "data": "value™" }]));
-        let packet: String = Packet::event("/admin™", "event", json!([{"data": "value™"}]))
+        let packet: String = Packet::event("/admin™", "event", json!({"data": "value™"}))
             .try_into()
             .unwrap();
 
@@ -621,7 +621,7 @@ mod test {
 
         // Encode with NS and ack ID
         let payload = format!("2/admin™,1{}", json!(["event", { "data": "value™" }]));
-        let mut packet = Packet::event("/admin™", "event", json!([{"data": "value™"}]));
+        let mut packet = Packet::event("/admin™", "event", json!({"data": "value™"}));
         packet.inner.set_ack_id(1);
         let packet: String = packet.try_into().unwrap();
         assert_eq!(packet, payload);
@@ -668,7 +668,7 @@ mod test {
     // BinaryEvent(String, BinaryPacket, Option<i64>),
     #[test]
     fn packet_encode_binary_event() {
-        let json = json!(["event", { "data": "value™" }, { "_placeholder": true, "num": 0}]);
+        let json = json!(["event", [{ "data": "value™" }, { "_placeholder": true, "num": 0}]]);
 
         let payload = format!("51-{}", json);
         let packet: String =

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -291,7 +291,7 @@ impl<'a> TryInto<String> for Packet<'a> {
             Event(e, data, _) | BinaryEvent(e, BinaryPacket { data, .. }, _) => {
                 // Expand the packet if it is an array with data -> ["event", ...data]
                 let packet = match data {
-                    Value::Array(ref mut v) if v.len() > 0 => {
+                    Value::Array(ref mut v) if !v.is_empty() => {
                         v.insert(0, Value::String(e.to_string()));
                         serde_json::to_string(&v)
                     }


### PR DESCRIPTION
When encoding packet, array should be expanded only when it is not empty. If the array is empty it should be specified like this : `["event", []]` and not `["event"]`