### PR TITLE
fix(socketio/adapter): broadcast except current sid when no rooms

### DIFF
--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -311,7 +311,10 @@ impl LocalAdapter {
             let sockets = ns.get_sockets();
             sockets
                 .into_iter()
-                .filter(|socket| !except.contains(&socket.id))
+                .filter(|socket| {
+                    !except.contains(&socket.id)
+                        && opts.sid.map(|s| s != socket.id).unwrap_or_default()
+                })
                 .collect()
         } else if let Some(sock) = opts.sid.and_then(|sid| ns.get_socket(sid).ok()) {
             vec![sock]
@@ -541,6 +544,13 @@ mod test {
         let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 1);
         assert_eq!(sockets[0].id, socket1);
+
+        let mut opts = BroadcastOptions::new(Some(socket2));
+        opts.flags.insert(BroadcastFlags::Broadcast);
+        let sockets = adapter.fetch_sockets(opts).unwrap();
+        assert_eq!(sockets.len(), 2);
+        assert_eq!(sockets[0].id, socket0);
+        assert_eq!(sockets[1].id, socket1);
 
         let mut opts = BroadcastOptions::new(Some(socket2));
         opts.flags.insert(BroadcastFlags::Broadcast);

--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -549,8 +549,9 @@ mod test {
         opts.flags.insert(BroadcastFlags::Broadcast);
         let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 2);
-        assert_eq!(sockets[0].id, socket0);
-        assert_eq!(sockets[1].id, socket1);
+        sockets.iter().for_each(|s| {
+            assert!(s.id == socket0 || s.id == socket1);
+        });
 
         let mut opts = BroadcastOptions::new(Some(socket2));
         opts.flags.insert(BroadcastFlags::Broadcast);


### PR DESCRIPTION
### When broadcasting to the entire namespace without rooms, the sender sid was not filtered.