### PR TITLE
feat(engineio/socket): make init http request available everywhere

### DIFF
--- a/engineioxide/src/engine.rs
+++ b/engineioxide/src/engine.rs
@@ -3,11 +3,13 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use http::request::Parts;
+
 use crate::{
     config::EngineIoConfig,
     handler::EngineIoHandler,
     service::TransportType,
-    socket::{DisconnectReason, Socket, SocketReq},
+    socket::{DisconnectReason, Socket},
 };
 use crate::{service::ProtocolVersion, sid::Sid};
 
@@ -42,7 +44,7 @@ impl<H: EngineIoHandler> EngineIo<H> {
         self: &Arc<Self>,
         protocol: ProtocolVersion,
         transport: TransportType,
-        req: SocketReq,
+        req: Parts,
         #[cfg(feature = "v3")] supports_binary: bool,
     ) -> Arc<Socket<H::Data>> {
         let engine = self.clone();
@@ -94,6 +96,7 @@ impl<H: EngineIoHandler> EngineIo<H> {
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
+    use http::Request;
 
     use super::*;
 
@@ -130,10 +133,7 @@ mod tests {
         let socket = engine.create_session(
             ProtocolVersion::V4,
             TransportType::Polling,
-            SocketReq {
-                headers: http::HeaderMap::new(),
-                uri: http::Uri::default(),
-            },
+            Request::<()>::default().into_parts().0,
             #[cfg(feature = "v3")]
             true,
         );
@@ -149,10 +149,7 @@ mod tests {
         let socket = engine.create_session(
             ProtocolVersion::V4,
             TransportType::Polling,
-            SocketReq {
-                headers: http::HeaderMap::new(),
-                uri: http::Uri::default(),
-            },
+            Request::<()>::default().into_parts().0,
             #[cfg(feature = "v3")]
             true,
         );
@@ -168,10 +165,7 @@ mod tests {
         let socket = engine.create_session(
             ProtocolVersion::V4,
             TransportType::Polling,
-            SocketReq {
-                headers: http::HeaderMap::new(),
-                uri: http::Uri::default(),
-            },
+            Request::<()>::default().into_parts().0,
             #[cfg(feature = "v3")]
             true,
         );

--- a/engineioxide/src/lib.rs
+++ b/engineioxide/src/lib.rs
@@ -1,8 +1,7 @@
 pub use async_trait::async_trait;
 
 pub use service::{ProtocolVersion, TransportType};
-/// A Packet type to use when sending data to the client
-pub use socket::{DisconnectReason, Socket, SocketReq};
+pub use socket::{DisconnectReason, Socket};
 
 pub mod config;
 pub mod errors;

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -126,7 +126,7 @@ where
         protocol: ProtocolVersion,
         transport: TransportType,
         config: &EngineIoConfig,
-        req_data: Parts,
+        req_parts: Parts,
         close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
         #[cfg(feature = "v3")] supports_binary: bool,
     ) -> Self {
@@ -147,7 +147,7 @@ where
             close_fn,
 
             data: D::default(),
-            req_parts: req_data.into(),
+            req_parts,
 
             #[cfg(feature = "v3")]
             supports_binary,

--- a/engineioxide/src/transport/polling/mod.rs
+++ b/engineioxide/src/transport/polling/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     service::{ProtocolVersion, TransportType},
     sid::Sid,
     transport::polling::payload::Payload,
-    DisconnectReason, SocketReq,
+    DisconnectReason,
 };
 
 mod payload;
@@ -52,11 +52,10 @@ where
     H: EngineIoHandler,
     B: Send + 'static,
 {
-    let req = SocketReq::from(req.into_parts().0);
     let socket = engine.create_session(
         protocol,
         TransportType::Polling,
-        req,
+        req.into_parts().0,
         #[cfg(feature = "v3")]
         supports_binary,
     );

--- a/engineioxide/src/transport/ws.rs
+++ b/engineioxide/src/transport/ws.rs
@@ -75,7 +75,7 @@ pub fn new_req<R, B, H: EngineIoHandler>(
         .version(parts.version)
         .body(())
         .unwrap();
-    req.headers_mut().extend(parts.headers.clone().into_iter());
+    req.headers_mut().extend(parts.headers.clone());
 
     tokio::spawn(async move {
         #[cfg(feature = "hyper-v1")]

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -556,6 +556,11 @@ impl<A: Adapter> Socket<A> {
         }
     }
 
+    /// Get the request info made by the client to connect
+    pub fn req_parts(&self) -> &http::request::Parts {
+        &self.esocket.req_parts
+    }
+
     fn recv_event(self: Arc<Self>, e: &str, data: Value, ack: Option<i64>) -> Result<(), Error> {
         if let Some(handler) = self.message_handlers.read().unwrap().get(e) {
             handler.call(self.clone(), data, vec![], ack);

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -557,6 +557,11 @@ impl<A: Adapter> Socket<A> {
     }
 
     /// Get the request info made by the client to connect
+    ///
+    /// Note that the `extensions` field will be empty and will not
+    /// contain extensions set in the previous http layers for requests initialized with ws transport.
+    ///
+    /// It is because [`http::Extensions`] is not cloneable and is needed for ws upgrade.
     pub fn req_parts(&self) -> &http::request::Parts {
         &self.esocket.req_parts
     }


### PR DESCRIPTION
## Add a `req_parts()` fn on the `Socket` struct to get the request data

Because extractors can't contain any reference, making a `Req` extractor would require to clone the `Req` data which is not ideal.