### PR TITLE
socket.io packet encoding with itoa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "http-body 1.0.0-rc.2",
  "hyper 0.14.27",
  "hyper 1.0.0-rc.4",
+ "itoa",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ http = "0.2.10"
 http-body = "0.4.5"
 thiserror = "1.0.40"
 tracing = "0.1.37"
+itoa = "1.0.9"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 # Hyper v0.1

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -23,6 +23,7 @@ tower.workspace = true
 http.workspace = true
 http-body.workspace = true
 thiserror.workspace = true
+itoa.workspace = true
 
 # Extensions
 dashmap = { version = "5.4.0", optional = true }
@@ -73,4 +74,9 @@ harness = false
 [[bench]]
 name = "packet_decode"
 path = "benches/packet_decode.rs"
+harness = false
+
+[[bench]]
+name = "itoa_bench"
+path = "benches/itoa_bench.rs"
 harness = false

--- a/socketioxide/benches/itoa_bench.rs
+++ b/socketioxide/benches/itoa_bench.rs
@@ -1,0 +1,38 @@
+//! # itoa_bench, used to compare best solutions related to this issue: https://github.com/Totodore/socketioxide/issues/143
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+/// This solution doesn't imply additional buffer or dependency call
+fn insert_number_reverse(mut v: u32, res: &mut String) {
+    let mut buf = [0u8; 10];
+    let mut i = 1;
+    while v > 0 {
+        let n = (v % 10) as u8;
+        buf[10 - i] = n + 0x30;
+        v /= 10;
+        i += 1;
+    }
+    res.push_str(unsafe { std::str::from_utf8_unchecked(&buf[10 - (i - 1)..]) });
+}
+
+/// This solution uses the itoa crate
+fn insert_number_itoa(v: u32, res: &mut String) {
+    let mut buffer = itoa::Buffer::new();
+    res.push_str(buffer.format(v));
+}
+
+fn bench_itoa(c: &mut Criterion) {
+    let mut group = c.benchmark_group("itoa");
+    for i in [u32::MAX / 200000, u32::MAX / 2, u32::MAX].iter() {
+        group.bench_with_input(BenchmarkId::new("number_reverse", i), i, |b, i| {
+            b.iter(|| insert_number_reverse(*i, &mut String::new()))
+        });
+        group.bench_with_input(BenchmarkId::new("number_itoa", i), i, |b, i| {
+            b.iter(|| insert_number_itoa(*i, &mut String::new()))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_itoa);
+criterion_main!(benches);

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -326,40 +326,42 @@ impl<'a> TryInto<String> for Packet<'a> {
             push_nsp(&mut res);
         }
 
+        let mut itoa_buf = itoa::Buffer::new();
+
         match self.inner {
             PacketData::Connect(Some(data)) => res.push_str(&data),
             PacketData::Disconnect | PacketData::Connect(None) => (),
             PacketData::Event(_, _, ack) => {
                 if let Some(ack) = ack {
-                    res.push_str(&ack.to_string());
+                    res.push_str(itoa_buf.format(ack));
                 }
 
                 res.push_str(&data.unwrap())
             }
             PacketData::EventAck(_, ack) => {
-                res.push_str(&ack.to_string());
+                res.push_str(itoa_buf.format(ack));
                 res.push_str(&data.unwrap())
             }
             PacketData::ConnectError => res.push_str("{\"message\":\"Invalid namespace\"}"),
             PacketData::BinaryEvent(_, bin, ack) => {
-                res.push_str(&bin.payload_count.to_string());
+                res.push_str(itoa_buf.format(bin.payload_count));
                 res.push('-');
 
                 push_nsp(&mut res);
 
                 if let Some(ack) = ack {
-                    res.push_str(&ack.to_string());
+                    res.push_str(itoa_buf.format(ack));
                 }
 
                 res.push_str(&data.unwrap())
             }
             PacketData::BinaryAck(packet, ack) => {
-                res.push_str(&packet.payload_count.to_string());
+                res.push_str(itoa_buf.format(packet.payload_count));
                 res.push('-');
 
                 push_nsp(&mut res);
 
-                res.push_str(&ack.to_string());
+                res.push_str(itoa_buf.format(ack));
                 res.push_str(&data.unwrap())
             }
         };


### PR DESCRIPTION
## Fix #143. Benchmark results : 
![image](https://github.com/Totodore/socketioxide/assets/26095587/1972586f-0537-4c1c-8b69-5d4c6447ac1a)
![image](https://github.com/Totodore/socketioxide/assets/26095587/ea0d3f00-a9de-4e90-9c01-1bcb634523a7)
