### PR TITLE
Transport type and Protocol Version info for `Socket`

### DIFF
--- a/engineioxide/src/service/parser.rs
+++ b/engineioxide/src/service/parser.rs
@@ -164,6 +164,16 @@ pub enum TransportType {
     Websocket = 0x02,
 }
 
+impl From<u8> for TransportType {
+    fn from(t: u8) -> Self {
+        match t {
+            0x01 => TransportType::Polling,
+            0x02 => TransportType::Websocket,
+            _ => panic!("unknown transport type"),
+        }
+    }
+}
+
 impl FromStr for TransportType {
     type Err = ParseError;
 

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -343,6 +343,11 @@ where
             .store(TransportType::Websocket as u8, Ordering::Relaxed);
     }
 
+    /// Returns the current [`TransportType`] of the [`Socket`]
+    pub fn transport_type(&self) -> TransportType {
+        TransportType::from(self.transport.load(Ordering::Relaxed))
+    }
+
     /// Emits a message to the client.
     ///
     /// If the transport is in websocket mode, the message is directly sent as a text frame.

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -277,3 +277,39 @@ impl<A: Adapter> AckSender<A> {
         }
     }
 }
+
+impl<A: Adapter> FromConnectParts<A> for crate::ProtocolVersion {
+    type Error = Infallible;
+    fn from_connect_parts(s: &Arc<Socket<A>>, _: &Option<String>) -> Result<Self, Infallible> {
+        Ok(s.protocol())
+    }
+}
+impl<A: Adapter> FromMessageParts<A> for crate::ProtocolVersion {
+    type Error = Infallible;
+    fn from_message_parts(
+        s: &Arc<Socket<A>>,
+        _: &mut serde_json::Value,
+        _: &mut Vec<Vec<u8>>,
+        _: &Option<i64>,
+    ) -> Result<Self, Infallible> {
+        Ok(s.protocol())
+    }
+}
+
+impl<A: Adapter> FromConnectParts<A> for crate::TransportType {
+    type Error = Infallible;
+    fn from_connect_parts(s: &Arc<Socket<A>>, _: &Option<String>) -> Result<Self, Infallible> {
+        Ok(s.transport_type())
+    }
+}
+impl<A: Adapter> FromMessageParts<A> for crate::TransportType {
+    type Error = Infallible;
+    fn from_message_parts(
+        s: &Arc<Socket<A>>,
+        _: &mut serde_json::Value,
+        _: &mut Vec<Vec<u8>>,
+        _: &Option<i64>,
+    ) -> Result<Self, Infallible> {
+        Ok(s.transport_type())
+    }
+}

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -254,7 +254,10 @@ mod io;
 mod ns;
 mod packet;
 
-/// Socket.IO protocol version
+/// Socket.IO protocol version.
+/// It is accessible with the [`Socket::protocol`](socket::Socket) method or as an extractor
+///
+/// **Note**: The socket.io protocol version does not correspond to the engine.io protocol version.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ProtocolVersion {
     /// The socket.io protocol version 4, only available with the feature flag `v4`

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -616,6 +616,35 @@ impl<A: Adapter> Socket<A> {
         &self.esocket.req_parts
     }
 
+    /// Gets the [`TransportType`](crate::TransportType) used by the client to connect with this [`Socket`]
+    ///
+    /// It can also be accessed as an extractor:
+    /// ```
+    /// # use socketioxide::{SocketIo, TransportType, extract::*};
+    ///
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef, transport: TransportType| {
+    ///     assert_eq!(socket.transport_type(), transport);
+    /// });
+    pub fn transport_type(&self) -> crate::TransportType {
+        self.esocket.transport_type()
+    }
+
+    /// Gets the socket.io [`ProtocolVersion`](crate::ProtocolVersion) used by the client to connect with this [`Socket`]
+    ///
+    /// It can also be accessed as an extractor:
+    /// ## Example
+    /// ```
+    /// # use socketioxide::{SocketIo, ProtocolVersion, extract::*};
+    ///
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef, v: ProtocolVersion| {
+    ///     assert_eq!(socket.protocol(), v);
+    /// });
+    pub fn protocol(&self) -> crate::ProtocolVersion {
+        self.esocket.protocol.into()
+    }
+
     fn recv_event(self: Arc<Self>, e: &str, data: Value, ack: Option<i64>) -> Result<(), Error> {
         if let Some(handler) = self.message_handlers.read().unwrap().get(e) {
             handler.call(self.clone(), data, vec![], ack);


### PR DESCRIPTION
Adds the following function to the `Socket` struct:
* `transport_type` to get the current `TransportType` of the socket
* `protocol` to get the current `ProtocolVersion` of the socket in the case of multiple protocols enabled

Now handler extractors are implemented for `TransportType` and `ProtocolVersion` so now it is possible to use them as `Handler` arguments:
```rust
use socketioxide::{SocketIo, TransportType, ProtocolVersion, extract::*};

let (_, io) = SocketIo::new_svc();
io.ns("/", |socket: SocketRef, transport: TransportType| {
    assert_eq!(socket.transport_type(), transport);
});

io.ns("/", |socket: SocketRef, protocol: ProtocolVersion| {
    assert_eq!(socket.protocol(), transport);
});
```

Fix issue #177 