### PR TITLE
fix: use right example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
 <img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
 
 ## Examples :
-<details> <summary><code>Chat app 💬 (see full example <a href="./examples/src/chat">here</a>)</code></summary>
+<details> <summary><code>Chat app 💬 (see full example <a href="./examples/chat">here</a>)</code></summary>
 
 ```rust
 io.ns("/", |s: SocketRef| {

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 </details>
-<details><summary><code>Other examples are available in the <a href="./examples">example folder</a></code></summary></details>
+<summary><code>Other examples are available in the <a href="./examples">example folder</a></code></summary>
 
 <img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 </details>
-<summary><code>Other examples are available in the <a href="./examples">example folder</a></code></summary>
+<code>Other examples are available in the <a href="./examples">example folder</a></code>
 
 <img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/solar.png">
 


### PR DESCRIPTION
Small fix, about the URL of the `chat` example in `README.md`.