### PR TITLE
Disconnect dynamic handlers

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .ok();
         });
 
-        s.on_disconnect(move |s, _| async move {
+        s.on_disconnect(|s: SocketRef| {
             if let Some(username) = s.extensions.get::<Username>() {
                 let i = NUM_USERS.fetch_sub(1, std::sync::atomic::Ordering::SeqCst) - 1;
                 let res = Res::UserEvent {

--- a/examples/private-messaging/src/handlers.rs
+++ b/examples/private-messaging/src/handlers.rs
@@ -61,7 +61,7 @@ pub fn on_connection(s: SocketRef, TryData(auth): TryData<Auth>) {
         },
     );
 
-    s.on_disconnect(|s, _| async move {
+    s.on_disconnect(|s: SocketRef| {
         let mut session = s.extensions.get::<Session>().unwrap().clone();
         session.connected = false;
 

--- a/socketioxide/src/handler/disconnect.rs
+++ b/socketioxide/src/handler/disconnect.rs
@@ -1,0 +1,217 @@
+//! [`DisconnectHandler`] trait and implementations, used to handle the connect event.
+//! It has a flexible axum-like API, you can put any arguments as long as it implements the [`FromDisconnectParts`] trait.
+//!
+//! You can also implement the [`FromDisconnectParts`] trait for your own types.
+//! See the [`extract`](super::extract) module doc for more details on available extractors.
+//!
+//! Handlers can be _optionally_ async.
+//!
+//! ## Example with sync closures
+//! ```rust
+//! # use socketioxide::SocketIo;
+//! # use serde_json::Error;
+//! # use socketioxide::extract::*;
+//! let (svc, io) = SocketIo::new_svc();
+//! // Here the handler is sync,
+//! // if there is a serialization error, the handler is not called
+//! io.ns("/nsp", move |s: SocketRef, Data(auth): Data<String>| {
+//!     println!("Socket connected on /nsp namespace with id: {} and data: {}", s.id, auth);
+//! });
+//! ```
+//!
+//! ## Example with async closures
+//! ```rust
+//! # use socketioxide::SocketIo;
+//! # use serde_json::Error;
+//! # use socketioxide::extract::*;
+//! let (svc, io) = SocketIo::new_svc();
+//! // Here the handler is async and extract the current socket and the auth payload
+//! io.ns("/", move |s: SocketRef, TryData(auth): TryData<String>| async move {
+//!     println!("Socket connected on / namespace with id and auth data: {} {:?}", s.id, auth);
+//! });
+//! // Here the handler is async and only extract the current socket.
+//! // The auth payload won't be deserialized and will be dropped
+//! io.ns("/async_nsp", move |s: SocketRef| async move {
+//!     println!("Socket connected on /async_nsp namespace with id: {}", s.id);
+//! });
+//! ```
+//!
+//! ## Example with async non anonymous functions
+//! ```rust
+//! # use socketioxide::SocketIo;
+//! # use serde_json::Error;
+//! # use socketioxide::extract::*;
+//! async fn handler(s: SocketRef, TryData(auth): TryData<String>) {
+//!     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+//!     println!("Socket connected on {} namespace with id and auth data: {} {:?}", s.ns(), s.id, auth);
+//! }
+//!
+//! let (svc, io) = SocketIo::new_svc();
+//!
+//! // You can reuse the same handler for multiple namespaces
+//! io.ns("/", handler);
+//! io.ns("/admin", handler);
+//! ```
+use std::sync::Arc;
+
+use futures::Future;
+
+use crate::{
+    adapter::Adapter,
+    socket::{DisconnectReason, Socket},
+};
+
+use super::MakeErasedHandler;
+
+/// A Type Erased [`DisconnectHandler`] so it can be stored in a HashMap
+pub(crate) type BoxedDisconnectHandler<A> = Box<dyn ErasedDisconnectHandler<A>>;
+pub(crate) trait ErasedDisconnectHandler<A: Adapter>: Send + Sync + 'static {
+    fn call(&self, s: Arc<Socket<A>>, reason: DisconnectReason);
+}
+
+impl<A: Adapter, T, H> MakeErasedHandler<H, A, T>
+where
+    T: Send + Sync + 'static,
+    H: DisconnectHandler<A, T> + Send + Sync + 'static,
+{
+    pub fn new_disconnect_boxed(inner: H) -> Box<dyn ErasedDisconnectHandler<A>> {
+        Box::new(MakeErasedHandler::new(inner))
+    }
+}
+
+impl<A: Adapter, T, H> ErasedDisconnectHandler<A> for MakeErasedHandler<H, A, T>
+where
+    H: DisconnectHandler<A, T> + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+{
+    #[inline(always)]
+    fn call(&self, s: Arc<Socket<A>>, reason: DisconnectReason) {
+        self.handler.call(s, reason);
+    }
+}
+
+/// A trait used to extract the arguments from the connect event.
+/// The `Result` associated type is used to return an error if the extraction fails,
+/// in this case the [`DisconnectHandler`] is not called.
+///
+/// * See the [`connect`](super::connect) module doc for more details on connect handler.
+/// * See the [`extract`](super::extract) module doc for more details on available extractors.
+pub trait FromDisconnectParts<A: Adapter>: Sized {
+    /// The error type returned by the extractor
+    type Error: std::error::Error + 'static;
+
+    /// Extract the arguments from the connect event.
+    /// If it fails, the handler is not called
+    fn from_disconnect_parts(
+        s: &Arc<Socket<A>>,
+        reason: DisconnectReason,
+    ) -> Result<Self, Self::Error>;
+}
+
+/// Define a handler for the connect event.
+/// It is implemented for closures with up to 16 arguments. They must implement the [`FromDisconnectParts`] trait.
+///
+/// * See the [`connect`](super::connect) module doc for more details on connect handler.
+/// * See the [`extract`](super::extract) module doc for more details on available extractors.
+pub trait DisconnectHandler<A: Adapter, T>: Send + Sync + 'static {
+    /// Call the handler with the given arguments.
+    fn call(&self, s: Arc<Socket<A>>, reason: DisconnectReason);
+
+    #[doc(hidden)]
+    fn phantom(&self) -> std::marker::PhantomData<T> {
+        std::marker::PhantomData
+    }
+}
+
+mod private {
+    #[derive(Debug, Copy, Clone)]
+    pub enum Sync {}
+    #[derive(Debug, Copy, Clone)]
+    pub enum Async {}
+}
+
+macro_rules! impl_handler_async {
+    (
+        [$($ty:ident),*]
+    ) => {
+        #[allow(non_snake_case, unused)]
+        impl<A, F, Fut, $($ty,)*> DisconnectHandler<A, (private::Async, $($ty,)*)> for F
+        where
+            F: FnOnce($($ty,)*) -> Fut + Send + Sync + Clone + 'static,
+            Fut: Future<Output = ()> + Send + 'static,
+            A: Adapter,
+            $( $ty: FromDisconnectParts<A> + Send, )*
+        {
+            fn call(&self, s: Arc<Socket<A>>, reason: DisconnectReason) {
+                $(
+                    let $ty = match $ty::from_disconnect_parts(&s, reason) {
+                        Ok(v) => v,
+                        Err(_e) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!("Error while extracting data: {}", _e);
+                            return;
+                        },
+                    };
+                )*
+
+                let fut = (self.clone())($($ty,)*);
+                tokio::spawn(fut);
+
+            }
+        }
+    };
+}
+
+macro_rules! impl_handler {
+    (
+        [$($ty:ident),*]
+    ) => {
+        #[allow(non_snake_case, unused)]
+        impl<A, F, $($ty,)*> DisconnectHandler<A, (private::Sync, $($ty,)*)> for F
+        where
+            F: FnOnce($($ty,)*) + Send + Sync + Clone + 'static,
+            A: Adapter,
+            $( $ty: FromDisconnectParts<A> + Send, )*
+        {
+            fn call(&self, s: Arc<Socket<A>>, reason: DisconnectReason) {
+                $(
+                    let $ty = match $ty::from_disconnect_parts(&s, reason) {
+                        Ok(v) => v,
+                        Err(_e) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!("Error while extracting data: {}", _e);
+                            return;
+                        },
+                    };
+                )*
+
+                (self.clone())($($ty,)*);
+            }
+        }
+    };
+}
+#[rustfmt::skip]
+macro_rules! all_the_tuples {
+    ($name:ident) => {
+        $name!([]);
+        $name!([T1]);
+        $name!([T1, T2]);
+        $name!([T1, T2, T3]);
+        $name!([T1, T2, T3, T4]);
+        $name!([T1, T2, T3, T4, T5]);
+        $name!([T1, T2, T3, T4, T5, T6]);
+        $name!([T1, T2, T3, T4, T5, T6, T7]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]);
+    };
+}
+
+all_the_tuples!(impl_handler_async);
+all_the_tuples!(impl_handler);

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -1,4 +1,5 @@
-//! ### Extractors for [`ConnectHandler`](super::ConnectHandler) and [`MessageHandler`](super::MessageHandler).
+//! ### Extractors for [`ConnectHandler`](super::ConnectHandler), [`MessageHandler`](super::MessageHandler)
+//! and [`DisconnectHandler`](super::DisconnectHandler).
 //!
 //! They can be used to extract data from the context of the handler and get specific params. Here are some examples of extractors:
 //! * [`Data`]: extracts and deserialize to json any data, if a deserialization error occurs the handler won't be called:
@@ -10,8 +11,10 @@
 //! * [`SocketRef`]: extracts a reference to the [`Socket`]
 //! * [`Bin`]: extract a binary payload for a given message. Because it consumes the event it should be the last argument
 //! * [`AckSender`]: Can be used to send an ack response to the current message event
+//! * [`ProtocolVersion`](crate::ProtocolVersion): extracts the protocol version
+//! * [`TransportType`](crate::TransportType): extracts the transport type
 //!
-//! ### You can also implement your own Extractor with the [`FromConnectParts`]and [`FromMessageParts`] traits
+//! ### You can also implement your own Extractor with the [`FromConnectParts`], [`FromMessageParts`] and [`FromDisconnectParts`] traits
 //! When implementing these traits, if you clone the [`Arc<Socket>`] make sure that it is dropped at least when the socket is disconnected.
 //! Otherwise it will create a memory leak. It is why the [`SocketRef`] extractor is used instead of cloning the socket for common usage.
 //!

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -81,7 +81,9 @@ use std::convert::Infallible;
 use std::sync::Arc;
 
 use super::message::FromMessageParts;
+use super::FromDisconnectParts;
 use super::{connect::FromConnectParts, message::FromMessage};
+use crate::socket::DisconnectReason;
 use crate::{
     adapter::{Adapter, LocalAdapter},
     packet::Packet,
@@ -185,6 +187,12 @@ impl<A: Adapter> FromMessageParts<A> for SocketRef<A> {
         _: &mut Vec<Vec<u8>>,
         _: &Option<i64>,
     ) -> Result<Self, Infallible> {
+        Ok(SocketRef(s.clone()))
+    }
+}
+impl<A: Adapter> FromDisconnectParts<A> for SocketRef<A> {
+    type Error = Infallible;
+    fn from_disconnect_parts(s: &Arc<Socket<A>>, _: DisconnectReason) -> Result<Self, Infallible> {
         Ok(SocketRef(s.clone()))
     }
 }
@@ -295,6 +303,12 @@ impl<A: Adapter> FromMessageParts<A> for crate::ProtocolVersion {
         Ok(s.protocol())
     }
 }
+impl<A: Adapter> FromDisconnectParts<A> for crate::ProtocolVersion {
+    type Error = Infallible;
+    fn from_disconnect_parts(s: &Arc<Socket<A>>, _: DisconnectReason) -> Result<Self, Infallible> {
+        Ok(s.protocol())
+    }
+}
 
 impl<A: Adapter> FromConnectParts<A> for crate::TransportType {
     type Error = Infallible;
@@ -311,5 +325,21 @@ impl<A: Adapter> FromMessageParts<A> for crate::TransportType {
         _: &Option<i64>,
     ) -> Result<Self, Infallible> {
         Ok(s.transport_type())
+    }
+}
+impl<A: Adapter> FromDisconnectParts<A> for crate::TransportType {
+    type Error = Infallible;
+    fn from_disconnect_parts(s: &Arc<Socket<A>>, _: DisconnectReason) -> Result<Self, Infallible> {
+        Ok(s.transport_type())
+    }
+}
+
+impl<A: Adapter> FromDisconnectParts<A> for DisconnectReason {
+    type Error = Infallible;
+    fn from_disconnect_parts(
+        _: &Arc<Socket<A>>,
+        reason: DisconnectReason,
+    ) -> Result<Self, Infallible> {
+        Ok(reason)
     }
 }

--- a/socketioxide/src/handler/mod.rs
+++ b/socketioxide/src/handler/mod.rs
@@ -1,6 +1,6 @@
 //! Functions and types used to handle incoming connections and messages.
-//! There is two main types of handlers: [`ConnectHandler`] and [`MessageHandler`].
-//! Both handlers can be async or not.
+//! There is three main types of handlers: [`ConnectHandler`], [`MessageHandler`] and [`DisconnectHandler`].
+//! All handlers can be async or not.
 pub mod connect;
 pub mod disconnect;
 pub mod extract;

--- a/socketioxide/src/handler/mod.rs
+++ b/socketioxide/src/handler/mod.rs
@@ -2,11 +2,14 @@
 //! There is two main types of handlers: [`ConnectHandler`] and [`MessageHandler`].
 //! Both handlers can be async or not.
 pub mod connect;
+pub mod disconnect;
 pub mod extract;
 pub mod message;
 
 pub(crate) use connect::BoxedConnectHandler;
 pub use connect::{ConnectHandler, FromConnectParts};
+pub(crate) use disconnect::BoxedDisconnectHandler;
+pub use disconnect::{DisconnectHandler, FromDisconnectParts};
 pub(crate) use message::BoxedMessageHandler;
 pub use message::{FromMessage, FromMessageParts, MessageHandler};
 /// A struct used to erase the type of a [`ConnectHandler`] or [`MessageHandler`] so it can be stored in a map

--- a/socketioxide/src/layer.rs
+++ b/socketioxide/src/layer.rs
@@ -1,4 +1,4 @@
-//! ## A tower [`Layer`](tower::Layer) for socket.io so it can be used as a middleware with frameworks supporting layers.
+//! ## A tower [`Layer`] for socket.io so it can be used as a middleware with frameworks supporting layers.
 //!
 //! #### Example with axum :
 //! ```rust

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -139,17 +139,25 @@
 //! ```
 //!
 //! ## Handlers
-//! Handlers are functions or clonable closures that are given to the `io.ns` and the `socket.on` methods. They can be async or sync and can take from 0 to 16 arguments that implements the [`FromConnectParts`](handler::FromConnectParts) trait for the [`ConnectHandler`](handler::ConnectHandler) and the [`FromMessageParts`](handler::FromMessageParts) for the [`MessageHandler`](handler::MessageHandler). They are greatly inspired by the axum handlers.
+//! Handlers are functions or clonable closures that are given to the `io.ns`, the `socket.on` and the `socket.on_disconnect` fns.
+//! They can be async or sync and can take from 0 to 16 arguments that implements the [`FromConnectParts`](handler::FromConnectParts)
+//! trait for the [`ConnectHandler`](handler::ConnectHandler), the [`FromMessageParts`](handler::FromMessageParts) for
+//! the [`MessageHandler`](handler::MessageHandler) and the [`FromDisconnectParts`](handler::FromDisconnectParts) for
+//! the [`DisconnectHandler`](handler::DisconnectHandler).
+//! They are greatly inspired by the axum handlers.
 //!
 //! If they are async, a new task will be spawned for each incoming connection/message so it doesn't block the event management task.
 //!
 //! * Check the [`handler::connect`] module doc for more details on the connect handler
 //! * Check the [`handler::message`] module doc for more details on the message handler.
+//! * Check the [`handler::disconnect`] module doc for more details on the disconnect handler.
 //! * Check the [`handler::extract`] module doc for more details on the extractors.
 //!
 //! ## Extractors
 //! Handlers params are called extractors and are used to extract data from the incoming connection/message. They are inspired by the axum extractors.
-//! An extractor is a struct that implements the [`FromConnectParts`](handler::FromConnectParts) trait for the [`ConnectHandler`](handler::ConnectHandler) and the [`FromMessageParts`](handler::FromMessageParts) for the [`MessageHandler`](handler::MessageHandler).
+//! An extractor is a struct that implements the [`FromConnectParts`](handler::FromConnectParts) trait for the [`ConnectHandler`](handler::ConnectHandler)
+//! the [`FromMessageParts`](handler::FromMessageParts) for the [`MessageHandler`](handler::MessageHandler) and the
+//! [`FromDisconnectParts`](handler::FromDisconnectParts) for the [`DisconnectHandler`](handler::DisconnectHandler).
 //!
 //! Here are some examples of extractors:
 //! * [`Data`](extract::Data): extracts and deserialize to json any data, if a deserialize error occurs the handler won't be called
@@ -161,6 +169,8 @@
 //! * [`SocketRef`](extract::Data): extracts a reference to the [`Socket`](socket::Socket)
 //! * [`Bin`](extract::Data): extract a binary payload for a given message. Because it consumes the event it should be the last argument
 //! * [`AckSender`](extract::Data): Can be used to send an ack response to the current message event
+//! * [`ProtocolVersion`]: extracts the protocol version of the socket
+//! * [`TransportType`]: extracts the transport type of the socket
 //!
 //! ### Extractor order
 //! Extractors are run in the order of their declaration in the handler signature. If an extractor returns an error, the handler won't be called and a `tracing::error!` call will be emitted if the `tracing` feature is enabled.
@@ -173,7 +183,7 @@
 //! There are three types of events:
 //! * The connect event is emitted when a new connection is established. It can be handled with the [`ConnectHandler`](handler::ConnectHandler) and the `io.ns` method.
 //! * The message event is emitted when a new message is received. It can be handled with the [`MessageHandler`](handler::MessageHandler) and the `socket.on` method.
-//! * The disconnect event is emitted when a socket is closed. Contrary to the two previous events, the callback is not flexible, it *must* be async and have the following signature `async fn(SocketRef, DisconnectReason)`. It can be handled with the `socket.on_disconnect` method.
+//! * The disconnect event is emitted when a socket is closed. It can be handled with the [`DisconnectHandler`](handler::DisconnectHandler) and the `socket.on_disconnect` method.
 //!
 //! Only one handler can exist for an event so registering a new handler for an event will replace the previous one.
 //!

--- a/socketioxide/src/service.rs
+++ b/socketioxide/src/service.rs
@@ -1,4 +1,4 @@
-//! ## A tower [`Service`](tower::Service) for socket.io so it can be used with frameworks supporting tower services.
+//! ## A tower [`Service`] for socket.io so it can be used with frameworks supporting tower services.
 //!
 //! #### Example with a `Warp` inner service :
 //! ```rust

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -227,7 +227,7 @@ impl<A: Adapter> Socket<A> {
     /// A [`DisconnectReason`] is passed to the callback to indicate the reason for the disconnection.
     /// ### Example
     /// ```
-    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use socketioxide::{SocketIo, socket::DisconnectReason, extract::*};
     /// # use serde_json::Value;
     /// # use std::sync::Arc;
     /// let (_, io) = SocketIo::new_svc();

--- a/socketioxide/tests/disconnect_reason.rs
+++ b/socketioxide/tests/disconnect_reason.rs
@@ -26,10 +26,9 @@ fn attach_handler(io: &SocketIo, chan_size: usize) -> mpsc::Receiver<DisconnectR
     io.ns("/", move |socket: SocketRef| {
         println!("Socket connected on / namespace with id: {}", socket.id);
         let tx = tx.clone();
-        socket.on_disconnect(move |socket, reason| {
-            println!("Socket.IO disconnected: {} {}", socket.id, reason);
+        socket.on_disconnect(move |s: SocketRef, reason: DisconnectReason| {
+            println!("Socket.IO disconnected: {} {}", s.id, reason);
             tx.try_send(reason).unwrap();
-            async move {}
         });
     });
     rx
@@ -214,10 +213,9 @@ pub async fn server_ns_disconnect() {
             s.disconnect().unwrap();
         });
 
-        socket.on_disconnect(move |socket, reason| {
+        socket.on_disconnect(move |socket: SocketRef, reason: DisconnectReason| {
             println!("Socket.IO disconnected: {} {}", socket.id, reason);
             tx.try_send(reason).unwrap();
-            async move {}
         });
     });
 


### PR DESCRIPTION
## Add dynamic handlers for the `disconnect` event.

* It will improve API coherence in the socket.io API
* It will be possible to use global managed state provided with #187 