### PR TITLE
feat(socketio/state): global state implementation backed by a `state::TypeMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1171,21 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "matchers"
@@ -1918,6 +1946,7 @@ dependencies = [
  "salvo",
  "serde",
  "serde_json",
+ "state",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -1944,6 +1973,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "state"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "subtle"
@@ -2545,6 +2583,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/examples/angular-todomvc/Cargo.toml
+++ b/examples/angular-todomvc/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 
 [dependencies]
-socketioxide = { path = "../../socketioxide" }
+socketioxide = { path = "../../socketioxide", features = ["state"] }
 axum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tower-http = { version = "0.4.4", features = ["cors", "fs"] }

--- a/examples/basic-crud-application/Cargo.toml
+++ b/examples/basic-crud-application/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 
 [dependencies]
-socketioxide = { path = "../../socketioxide" }
+socketioxide = { path = "../../socketioxide", features = ["state"] }
 uuid = { version = "1.6.1", features = ["v4", "serde"] }
 axum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/examples/basic-crud-application/src/handlers/todo.rs
+++ b/examples/basic-crud-application/src/handlers/todo.rs
@@ -1,10 +1,7 @@
-use std::{
-    collections::HashMap,
-    sync::{OnceLock, RwLock},
-};
+use std::{collections::HashMap, sync::RwLock};
 
 use serde::{Deserialize, Serialize};
-use socketioxide::extract::{AckSender, Data, SocketRef};
+use socketioxide::extract::{AckSender, Data, SocketRef, State};
 use tracing::info;
 use uuid::Uuid;
 
@@ -24,16 +21,31 @@ pub struct PartialTodo {
     title: String,
 }
 
-static TODOS: OnceLock<RwLock<HashMap<Uuid, Todo>>> = OnceLock::new();
-fn get_store() -> &'static RwLock<HashMap<Uuid, Todo>> {
-    TODOS.get_or_init(|| RwLock::new(HashMap::new()))
+#[derive(Default)]
+pub struct Todos(RwLock<HashMap<Uuid, Todo>>);
+impl Todos {
+    fn insert(&self, id: Uuid, todo: Todo) {
+        self.0.write().unwrap().insert(id, todo);
+    }
+    fn get(&self, id: &Uuid) -> Option<Todo> {
+        self.0.read().unwrap().get(id).cloned()
+    }
+    fn get_mut(&self, id: &Uuid) -> Option<Todo> {
+        self.0.write().unwrap().get_mut(id).cloned()
+    }
+    fn remove(&self, id: &Uuid) -> Option<Todo> {
+        self.0.write().unwrap().remove(id)
+    }
+    fn get_all(&self) -> Vec<Todo> {
+        self.0.read().unwrap().values().cloned().collect()
+    }
 }
 
-pub fn create(s: SocketRef, Data(data): Data<PartialTodo>, ack: AckSender) {
+pub fn create(s: SocketRef, Data(data): Data<PartialTodo>, ack: AckSender, todos: State<Todos>) {
     let id = Uuid::new_v4();
     let todo = Todo { id, inner: data };
 
-    get_store().write().unwrap().insert(id, todo.clone());
+    todos.insert(id, todo.clone());
 
     let res: Response<_> = id.into();
     ack.send(res).ok();
@@ -41,25 +53,24 @@ pub fn create(s: SocketRef, Data(data): Data<PartialTodo>, ack: AckSender) {
     s.broadcast().emit("todo:created", todo).ok();
 }
 
-pub async fn read(Data(id): Data<Uuid>, ack: AckSender) {
-    let todos = get_store().read().unwrap();
-
+pub async fn read(Data(id): Data<Uuid>, ack: AckSender, todos: State<Todos>) {
     let todo = todos.get(&id).ok_or(Error::NotFound);
     ack.send(todo).ok();
 }
 
-pub async fn update(s: SocketRef, Data(data): Data<Todo>, ack: AckSender) {
-    let mut todos = get_store().write().unwrap();
-    let res = todos.get_mut(&data.id).ok_or(Error::NotFound).map(|todo| {
-        todo.inner = data.inner.clone();
-        s.broadcast().emit("todo:updated", data).ok();
-    });
+pub async fn update(s: SocketRef, Data(data): Data<Todo>, ack: AckSender, todos: State<Todos>) {
+    let res = todos
+        .get_mut(&data.id)
+        .ok_or(Error::NotFound)
+        .map(|mut todo| {
+            todo.inner = data.inner.clone();
+            s.broadcast().emit("todo:updated", data).ok();
+        });
 
     ack.send(res).ok();
 }
 
-pub async fn delete(s: SocketRef, Data(id): Data<Uuid>, ack: AckSender) {
-    let mut todos = get_store().write().unwrap();
+pub async fn delete(s: SocketRef, Data(id): Data<Uuid>, ack: AckSender, todos: State<Todos>) {
     let res = todos.remove(&id).ok_or(Error::NotFound).map(|_| {
         s.broadcast().emit("todo:deleted", id).ok();
     });
@@ -67,9 +78,8 @@ pub async fn delete(s: SocketRef, Data(id): Data<Uuid>, ack: AckSender) {
     ack.send(res).ok();
 }
 
-pub async fn list(ack: AckSender) {
-    let todos = get_store().read().unwrap();
-    let res: Response<_> = todos.values().cloned().collect::<Vec<_>>().into();
+pub async fn list(ack: AckSender, todos: State<Todos>) {
+    let res: Response<_> = todos.get_all().into();
     info!("Sending todos: {:?}", res);
     ack.send(res).ok();
 }

--- a/examples/basic-crud-application/src/main.rs
+++ b/examples/basic-crud-application/src/main.rs
@@ -6,6 +6,8 @@ use tower_http::{cors::CorsLayer, services::ServeDir};
 use tracing::{error, info};
 use tracing_subscriber::FmtSubscriber;
 
+use crate::handlers::todo::Todos;
+
 mod handlers;
 
 #[tokio::main]
@@ -16,7 +18,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting server");
 
-    let (layer, io) = SocketIo::new_layer();
+    let (layer, io) = SocketIo::builder()
+        .with_state(Todos::default())
+        .build_layer();
 
     io.ns("/", |s: SocketRef| {
         s.on("todo:create", handlers::todo::create);

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-socketioxide = { path = "../../socketioxide", features = ["extensions"] }
+socketioxide = { path = "../../socketioxide", features = [
+    "extensions",
+    "state",
+] }
 axum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tower-http = { version = "0.4.4", features = ["cors", "fs"] }

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -4,7 +4,7 @@ use axum::Server;
 
 use serde::{Deserialize, Serialize};
 use socketioxide::{
-    extract::{Data, SocketRef},
+    extract::{Data, SocketRef, State},
     SocketIo,
 };
 use tower::ServiceBuilder;
@@ -37,7 +37,18 @@ enum Res {
     },
 }
 
-static NUM_USERS: AtomicUsize = AtomicUsize::new(0);
+struct UserCnt(AtomicUsize);
+impl UserCnt {
+    fn new() -> Self {
+        Self(AtomicUsize::new(0))
+    }
+    fn add_user(&self) -> usize {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1
+    }
+    fn remove_user(&self) -> usize {
+        self.0.fetch_sub(1, std::sync::atomic::Ordering::SeqCst) - 1
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -47,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting server");
 
-    let (layer, io) = SocketIo::new_layer();
+    let (layer, io) = SocketIo::builder().with_state(UserCnt::new()).build_layer();
 
     io.ns("/", |s: SocketRef| {
         s.on("new message", |s: SocketRef, Data::<String>(msg)| {
@@ -59,20 +70,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             s.broadcast().emit("new message", msg).ok();
         });
 
-        s.on("add user", |s: SocketRef, Data::<String>(username)| {
-            if s.extensions.get::<Username>().is_some() {
-                return;
-            }
-            let i = NUM_USERS.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
-            s.extensions.insert(Username(username.clone()));
-            s.emit("login", Res::Login { num_users: i }).ok();
+        s.on(
+            "add user",
+            |s: SocketRef, Data::<String>(username), user_cnt: State<UserCnt>| {
+                if s.extensions.get::<Username>().is_some() {
+                    return;
+                }
+                let num_users = user_cnt.add_user();
+                s.extensions.insert(Username(username.clone()));
+                s.emit("login", Res::Login { num_users }).ok();
 
-            let res = Res::UserEvent {
-                num_users: i,
-                username: Username(username),
-            };
-            s.broadcast().emit("user joined", res).ok();
-        });
+                let res = Res::UserEvent {
+                    num_users,
+                    username: Username(username),
+                };
+                s.broadcast().emit("user joined", res).ok();
+            },
+        );
 
         s.on("typing", |s: SocketRef| {
             let username = s.extensions.get::<Username>().unwrap().clone();
@@ -88,11 +102,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .ok();
         });
 
-        s.on_disconnect(|s: SocketRef| {
+        s.on_disconnect(|s: SocketRef, user_cnt: State<UserCnt>| {
             if let Some(username) = s.extensions.get::<Username>() {
-                let i = NUM_USERS.fetch_sub(1, std::sync::atomic::Ordering::SeqCst) - 1;
+                let num_users = user_cnt.remove_user();
                 let res = Res::UserEvent {
-                    num_users: i,
+                    num_users,
                     username: username.clone(),
                 };
                 s.broadcast().emit("user left", res).ok();

--- a/examples/private-messaging/Cargo.toml
+++ b/examples/private-messaging/Cargo.toml
@@ -5,7 +5,10 @@ edition.workspace = true
 
 
 [dependencies]
-socketioxide = { path = "../../socketioxide", features = ["extensions"] }
+socketioxide = { path = "../../socketioxide", features = [
+    "extensions",
+    "state",
+] }
 axum.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tower-http = { version = "0.4.4", features = ["cors", "fs"] }

--- a/examples/private-messaging/src/handlers.rs
+++ b/examples/private-messaging/src/handlers.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use socketioxide::extract::{Data, SocketRef, TryData};
+use socketioxide::extract::{Data, SocketRef, State, TryData};
 use tracing::error;
 use uuid::Uuid;
 
-use crate::store::{get_sessions, Message, Session, MESSAGES};
+use crate::store::{Message, Messages, Session, Sessions};
 
 #[derive(Debug, Deserialize)]
 pub struct Auth {
@@ -38,8 +38,13 @@ struct PrivateMessageReq {
     content: String,
 }
 
-pub fn on_connection(s: SocketRef, TryData(auth): TryData<Auth>) {
-    if let Err(e) = session_connect(&s, auth) {
+pub fn on_connection(
+    s: SocketRef,
+    TryData(auth): TryData<Auth>,
+    sessions: State<Sessions>,
+    msgs: State<Messages>,
+) {
+    if let Err(e) = session_connect(&s, auth, sessions.0, msgs.0) {
         error!("Failed to connect: {:?}", e);
         s.disconnect().ok();
         return;
@@ -47,25 +52,25 @@ pub fn on_connection(s: SocketRef, TryData(auth): TryData<Auth>) {
 
     s.on(
         "private message",
-        |s: SocketRef, Data(PrivateMessageReq { to, content })| {
+        |s: SocketRef, Data(PrivateMessageReq { to, content }), State(Messages(msg))| {
             let user_id = s.extensions.get::<Session>().unwrap().user_id;
             let message = Message {
                 from: user_id,
                 to,
                 content,
             };
-            MESSAGES.write().unwrap().push(message.clone());
+            msg.write().unwrap().push(message.clone());
             s.within(to.to_string())
                 .emit("private message", message)
                 .ok();
         },
     );
 
-    s.on_disconnect(|s: SocketRef| {
+    s.on_disconnect(|s: SocketRef, State(Sessions(sessions))| {
         let mut session = s.extensions.get::<Session>().unwrap().clone();
         session.connected = false;
 
-        get_sessions()
+        sessions
             .write()
             .unwrap()
             .get_mut(&session.session_id)
@@ -88,9 +93,11 @@ enum ConnectError {
 fn session_connect(
     s: &SocketRef,
     auth: Result<Auth, serde_json::Error>,
+    Sessions(session_state): &Sessions,
+    Messages(msg_state): &Messages,
 ) -> Result<(), ConnectError> {
     let auth = auth.map_err(ConnectError::EncodeError)?;
-    let mut sessions = get_sessions().write().unwrap();
+    let mut sessions = session_state.write().unwrap();
     if let Some(session) = auth.session_id.and_then(|id| sessions.get_mut(&id)) {
         session.connected = true;
         s.extensions.insert(session.clone());
@@ -109,13 +116,13 @@ fn session_connect(
     s.emit("session", session.clone())
         .map_err(ConnectError::SocketError)?;
 
-    let users = get_sessions()
+    let users = session_state
         .read()
         .unwrap()
         .iter()
         .filter(|(id, _)| id != &&session.session_id)
         .map(|(_, session)| {
-            let messages = MESSAGES
+            let messages = msg_state
                 .read()
                 .unwrap()
                 .iter()

--- a/examples/private-messaging/src/main.rs
+++ b/examples/private-messaging/src/main.rs
@@ -6,6 +6,8 @@ use tower_http::{cors::CorsLayer, services::ServeDir};
 use tracing::{error, info};
 use tracing_subscriber::FmtSubscriber;
 
+use crate::store::{Messages, Sessions};
+
 mod handlers;
 mod store;
 
@@ -17,7 +19,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting server");
 
-    let (layer, io) = SocketIo::new_layer();
+    let (layer, io) = SocketIo::builder()
+        .with_state(Sessions::default())
+        .with_state(Messages::default())
+        .build_layer();
 
     io.ns("/", handlers::on_connection);
 

--- a/examples/private-messaging/src/store.rs
+++ b/examples/private-messaging/src/store.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{OnceLock, RwLock},
-};
+use std::{collections::HashMap, sync::RwLock};
 
 use serde::Serialize;
 use uuid::Uuid;
@@ -31,8 +28,7 @@ pub struct Message {
     pub content: String,
 }
 
-static SESSIONS: OnceLock<RwLock<HashMap<Uuid, Session>>> = OnceLock::new();
-pub fn get_sessions() -> &'static RwLock<HashMap<Uuid, Session>> {
-    SESSIONS.get_or_init(|| RwLock::new(HashMap::new()))
-}
-pub static MESSAGES: RwLock<Vec<Message>> = RwLock::new(vec![]);
+#[derive(Default)]
+pub struct Sessions(pub RwLock<HashMap<Uuid, Session>>);
+#[derive(Default)]
+pub struct Messages(pub RwLock<Vec<Message>>);

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -35,12 +35,16 @@ tracing = { workspace = true, optional = true }
 http-body-v1 = { workspace = true, optional = true }
 hyper-v1 = { workspace = true, optional = true }
 
+# State
+state = { version = "0.6.0", optional = true }
+
 [features]
 v4 = ["engineioxide/v3"]
 test-utils = []
 tracing = ["dep:tracing", "engineioxide/tracing"]
 extensions = ["dep:dashmap"]
 hyper-v1 = ["engineioxide/hyper-v1", "dep:http-body-v1", "dep:hyper-v1"]
+state = ["dep:state"]
 
 [dev-dependencies]
 engineioxide = { path = "../engineioxide", features = [

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -67,7 +67,7 @@ criterion.workspace = true
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]
-features = ["v4", "extensions", "hyper-v1", "tracing"]
+features = ["v4", "extensions", "hyper-v1", "tracing", "state"]
 # Special configuration for docs.rs build
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -27,6 +27,9 @@ pub struct Client<A: Adapter> {
 
 impl<A: Adapter> Client<A> {
     pub fn new(config: Arc<SocketIoConfig>) -> Self {
+        #[cfg(feature = "state")]
+        crate::state::freeze_state();
+
         Self {
             config,
             ns: RwLock::new(HashMap::new()),

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -387,13 +387,13 @@ mod state {
     ///     state.add_user();
     ///     println!("User count: {:?}", state.user_cnt());
     /// });
-    pub struct State<T: Send + Sync + 'static>(&'static T);
+    pub struct State<T: 'static>(pub &'static T);
     /// It was impossible to find the given state and therefore the handler won't be called.
     #[derive(Debug, thiserror::Error)]
     #[error("State not found")]
     pub struct StateNotFound;
 
-    impl<T: Send + Sync + 'static> std::ops::Deref for State<T> {
+    impl<T> std::ops::Deref for State<T> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
             self.0

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -98,7 +98,7 @@ use serde_json::Value;
 
 #[cfg(feature = "state")]
 #[cfg_attr(docsrs, doc(cfg(feature = "state")))]
-pub use state::*;
+pub use state_extract::*;
 
 /// Utility function to unwrap an array with a single element
 fn upwrap_array(v: &mut Value) {
@@ -352,7 +352,7 @@ impl<A: Adapter> FromDisconnectParts<A> for DisconnectReason {
 }
 
 #[cfg(feature = "state")]
-mod state {
+mod state_extract {
     use super::*;
     use crate::state::get_state;
 

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -385,7 +385,7 @@ mod state_extract {
     /// let (_, io) = SocketIo::builder().with_state(MyAppData::default()).build_svc();
     /// io.ns("/", |socket: SocketRef, state: State<MyAppData>| {
     ///     state.add_user();
-    ///     println!("User count: {:?}", state.user_cnt());
+    ///     println!("User count: {}", state.user_cnt.load(Ordering::SeqCst));
     /// });
     pub struct State<T: 'static>(pub &'static T);
     /// It was impossible to find the given state and therefore the handler won't be called.

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -96,6 +96,10 @@ use crate::{
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 
+#[cfg(feature = "state")]
+#[cfg_attr(docsrs, doc(cfg(feature = "state")))]
+pub use state::*;
+
 /// Utility function to unwrap an array with a single element
 fn upwrap_array(v: &mut Value) {
     match v {
@@ -344,5 +348,85 @@ impl<A: Adapter> FromDisconnectParts<A> for DisconnectReason {
         reason: DisconnectReason,
     ) -> Result<Self, Infallible> {
         Ok(reason)
+    }
+}
+
+#[cfg(feature = "state")]
+mod state {
+    use super::*;
+    use crate::state::get_state;
+
+    /// An Extractor that contains a reference to a state previously set with [`SocketIoBuilder::with_state`](crate::io::SocketIoBuilder).
+    /// It implements [`std::ops::Deref`] to access the inner type so you can use it as a normal reference.
+    ///  
+    /// The specified state type must be the same as the one set with [`SocketIoBuilder::with_state`](crate::io::SocketIoBuilder).
+    /// If it is not the case, the handler won't be called and an error log will be print if the `tracing` feature is enabled.
+    ///
+    /// The state is shared between the entire socket.io app context.
+    ///
+    /// ### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::{SocketRef, State}};
+    /// # use serde::{Serialize, Deserialize};
+    /// # use std::sync::atomic::AtomicUsize;
+    /// # use std::sync::atomic::Ordering;
+    /// #[derive(Default)]
+    /// struct MyAppData {
+    ///     user_cnt: AtomicUsize,
+    /// }
+    /// impl MyAppData {
+    ///     fn add_user(&self) {
+    ///         self.user_cnt.fetch_add(1, Ordering::SeqCst);
+    ///     }
+    ///     fn rm_user(&self) {
+    ///         self.user_cnt.fetch_sub(1, Ordering::SeqCst);
+    ///     }
+    /// }
+    /// let (_, io) = SocketIo::builder().with_state(MyAppData::default()).build_svc();
+    /// io.ns("/", |socket: SocketRef, state: State<MyAppData>| {
+    ///     state.add_user();
+    ///     println!("User count: {:?}", state.user_cnt());
+    /// });
+    pub struct State<T: Send + Sync + 'static>(&'static T);
+    /// It was impossible to find the given state and therefore the handler won't be called.
+    #[derive(Debug, thiserror::Error)]
+    #[error("State not found")]
+    pub struct StateNotFound;
+
+    impl<T: Send + Sync + 'static> std::ops::Deref for State<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            self.0
+        }
+    }
+
+    impl<A: Adapter, T: Send + Sync + 'static> FromConnectParts<A> for State<T> {
+        type Error = StateNotFound;
+        fn from_connect_parts(
+            _: &Arc<Socket<A>>,
+            _: &Option<String>,
+        ) -> Result<Self, StateNotFound> {
+            get_state::<T>().map(State).ok_or(StateNotFound)
+        }
+    }
+    impl<A: Adapter, T: Send + Sync + 'static> FromDisconnectParts<A> for State<T> {
+        type Error = StateNotFound;
+        fn from_disconnect_parts(
+            _: &Arc<Socket<A>>,
+            _: DisconnectReason,
+        ) -> Result<Self, StateNotFound> {
+            get_state::<T>().map(State).ok_or(StateNotFound)
+        }
+    }
+    impl<A: Adapter, T: Send + Sync + 'static> FromMessageParts<A> for State<T> {
+        type Error = StateNotFound;
+        fn from_message_parts(
+            _: &Arc<Socket<A>>,
+            _: &mut serde_json::Value,
+            _: &mut Vec<Vec<u8>>,
+            _: &Option<i64>,
+        ) -> Result<Self, StateNotFound> {
+            get_state::<T>().map(State).ok_or(StateNotFound)
+        }
     }
 }

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -162,6 +162,17 @@ impl<A: Adapter> SocketIoBuilder<A> {
         }
     }
 
+    /// Add a custom global state for the [`SocketIo`] instance.
+    /// This state will be accessible from every handler with the [`State`](crate::extract::State) extractor.
+    /// You can set any number of states as long as they have different types.
+    #[inline]
+    #[cfg_attr(docsrs, doc(cfg(feature = "state")))]
+    #[cfg(feature = "state")]
+    pub fn with_state<S: Send + Sync + 'static>(self, state: S) -> Self {
+        crate::state::set_state(state);
+        self
+    }
+
     /// Builds a [`SocketIoLayer`] and a [`SocketIo`] instance
     ///
     /// The layer can be used as a tower layer

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -241,6 +241,8 @@
 //! Because the global state is staticaly defined, beware that the state map will exist for the whole lifetime of the program even
 //! if you drop everything and close you socket.io server. This is a limitation because of the impossibility to have extractors with lifetimes,
 //! therefore state references must be `'static`.
+//! Another limitation is that because it is common to the whole server. If you build a second server, it will share the same state.
+//! Also if the first server is already started you won't be able to add new states because states are frozen at the start of the server.
 //!
 //! ## Adapters
 //! This library is designed to work with clustering. It uses the [`Adapter`](adapter::Adapter) trait to abstract the underlying storage.

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -231,7 +231,7 @@
 //! #### Per socket state
 //! You can enable the `extensions` feature and use the [`extensions`](socket::Socket::extensions) field on any socket to manage
 //! the state of each socket. It is backed by a [`dashmap`] so you can safely access it from multiple threads.
-//! Beware that deadlocks can easily access if you hold a value ref and try to remove it at the same time.
+//! Beware that deadlocks can easily occur if you hold a value ref and try to remove it at the same time.
 //! See the [`extensions`] module doc for more details.
 //!
 //! #### Global state
@@ -241,8 +241,9 @@
 //! Because the global state is staticaly defined, beware that the state map will exist for the whole lifetime of the program even
 //! if you drop everything and close you socket.io server. This is a limitation because of the impossibility to have extractors with lifetimes,
 //! therefore state references must be `'static`.
+//!
 //! Another limitation is that because it is common to the whole server. If you build a second server, it will share the same state.
-//! Also if the first server is already started you won't be able to add new states because states are frozen at the start of the server.
+//! Also if the first server is already started you won't be able to add new states because states are frozen at the start of the first server.
 //!
 //! ## Adapters
 //! This library is designed to work with clustering. It uses the [`Adapter`](adapter::Adapter) trait to abstract the underlying storage.
@@ -253,7 +254,8 @@
 //! * `hyper-v1`: enable support for hyper v1
 //! * `v4`: enable support for the socket.io protocol v4
 //! * `tracing`: enable logging with [`tracing`] calls
-//! * `extensions`: enable [`extensions`] module
+//! * `extensions`: enable per-socket state with the [`extensions`] module
+//! * `state`: enable global state management
 //!
 pub mod adapter;
 

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -43,6 +43,7 @@
 //! * [Events](#events)
 //! * [Emiting data](#emiting-data)
 //! * [Acknowledgements](#acknowledgements)
+//! * [State management](#state-management)
 //! * [Adapters](#adapters)
 //! * [Feature flags](#feature-flags)
 //!
@@ -224,6 +225,23 @@
 //! You can use the [`Socket::emit_with_ack`](socket::Socket) method to emit a message with an ack callback.
 //! It will return a [`Future`](futures::Future) that will resolve when the acknowledgement is received.
 //!
+//! ## [State management](#state-management)
+//! There are two ways to manage the state of the server:
+//!
+//! #### Per socket state
+//! You can enable the `extensions` feature and use the [`extensions`](socket::Socket::extensions) field on any socket to manage
+//! the state of each socket. It is backed by a [`dashmap`] so you can safely access it from multiple threads.
+//! Beware that deadlocks can easily access if you hold a value ref and try to remove it at the same time.
+//! See the [`extensions`] module doc for more details.
+//!
+//! #### Global state
+//! You can enable the `state` feature and use [`SocketIoBuilder::with_state`](SocketIoBuilder) method to set
+//! multiple global states for the server. You can then access them from any handler with the [`State`](extract::State) extractor.
+//!
+//! Because the global state is staticaly defined, beware that the state map will exist for the whole lifetime of the program even
+//! if you drop everything and close you socket.io server. This is a limitation because of the impossibility to have extractors with lifetimes,
+//! therefore state references must be `'static`.
+//!
 //! ## Adapters
 //! This library is designed to work with clustering. It uses the [`Adapter`](adapter::Adapter) trait to abstract the underlying storage.
 //! By default it uses the [`LocalAdapter`](adapter::LocalAdapter) which is a simple in-memory adapter.
@@ -243,6 +261,8 @@ pub mod extensions;
 #[cfg_attr(docsrs, doc(cfg(feature = "hyper-v1")))]
 #[cfg(feature = "hyper-v1")]
 pub mod hyper_v1;
+#[cfg(feature = "state")]
+mod state;
 
 pub mod handler;
 pub mod layer;

--- a/socketioxide/src/state.rs
+++ b/socketioxide/src/state.rs
@@ -22,16 +22,20 @@ pub(crate) fn set_state<T: Send + Sync + 'static>(value: T) {
     unsafe { STATE.set(value) };
 }
 
-mod tests {
+mod test {
     #[test]
-    fn test_state() {
-        use super::*;
-        set_state(1i32);
-        set_state("hello");
+    fn state_lifecycle() {
+        use super::TypeMap;
+        // Mimic the parent static state
+        static mut STATE: TypeMap![Send + Sync] = <TypeMap![Send + Sync]>::new();
 
-        freeze_state();
+        unsafe { STATE.set(1i32) };
+        unsafe { STATE.set("hello") };
 
-        assert_eq!(get_state::<i32>(), Some(&1));
-        assert_eq!(get_state::<&str>(), Some(&"hello"));
+        assert_eq!(unsafe { STATE.len() }, 2);
+        unsafe { STATE.freeze() }
+
+        assert_eq!(unsafe { STATE.try_get::<i32>() }, Some(&1));
+        assert_eq!(unsafe { STATE.try_get::<&str>() }, Some(&"hello"));
     }
 }

--- a/socketioxide/src/state.rs
+++ b/socketioxide/src/state.rs
@@ -27,11 +27,11 @@ mod tests {
     fn test_state() {
         use super::*;
         set_state(1i32);
-        set_state(2u8);
+        set_state("hello");
 
         freeze_state();
 
         assert_eq!(get_state::<i32>(), Some(&1));
-        assert_eq!(get_state::<u8>(), Some(&2));
+        assert_eq!(get_state::<&str>(), Some(&"hello"));
     }
 }

--- a/socketioxide/src/state.rs
+++ b/socketioxide/src/state.rs
@@ -1,0 +1,37 @@
+//! An optional global state for the server which is backed by a [`TypeMap`].
+//! The state is global and not part of the socketio instance because it is impossible
+//! to have extractors with lifetimes. Therefore the only way to propagate a `State` reference
+//! to a handler parameter is to make is `'static`.
+use state::TypeMap;
+static mut STATE: TypeMap![Send + Sync] = <TypeMap![Send + Sync]>::new();
+
+// SAFETY: even if the state is mut and therefeore not thread safe,
+// each of the following functions are called disctincly in different
+// step of the server lifecycle.
+
+// SAFETY: the `get_state` is called many times from extractors but never mutably and after the `freeze_state` call
+pub(crate) fn get_state<T: Send + Sync + 'static>() -> Option<&'static T> {
+    unsafe { STATE.try_get::<T>() }
+}
+// SAFETY: the `freeze_state` is only called once at the launch of the server
+pub(crate) fn freeze_state() {
+    unsafe { STATE.freeze() }
+}
+// SAFETY: the `set_state` is only called when building the server and can be called multiple times
+pub(crate) fn set_state<T: Send + Sync + 'static>(value: T) {
+    unsafe { STATE.set(value) };
+}
+
+mod tests {
+    #[test]
+    fn test_state() {
+        use super::*;
+        set_state(1i32);
+        set_state(2u8);
+
+        freeze_state();
+
+        assert_eq!(get_state::<i32>(), Some(&1));
+        assert_eq!(get_state::<u8>(), Some(&2));
+    }
+}

--- a/socketioxide/tests/extractors.rs
+++ b/socketioxide/tests/extractors.rs
@@ -1,0 +1,99 @@
+use futures::SinkExt;
+use socketioxide::extract::{Data, SocketRef, State};
+use tokio::sync::mpsc;
+
+mod fixture;
+use fixture::{create_server, create_server_with_state, create_ws_connection};
+use tokio_tungstenite::tungstenite::Message;
+
+#[tokio::test]
+pub async fn state_extractor() {
+    let state = 1112i32;
+    let io = create_server_with_state(2000, state);
+    let (tx, mut rx) = mpsc::channel::<i32>(4);
+    io.ns("/", move |socket: SocketRef, state: State<i32>| {
+        println!("Socket connected on / namespace with id: {}", socket.id);
+        tx.try_send(*state).unwrap();
+
+        let tx1 = tx.clone();
+        let tx2 = tx.clone();
+        let tx3 = tx.clone();
+        socket.on("test", move |State(state): State<i32>| {
+            println!("test event received");
+            tx.try_send(*state).unwrap();
+        });
+        socket.on("async_test", move |State(state): State<i32>| async move {
+            println!("async_test event received");
+            tx2.try_send(*state).unwrap();
+        });
+        // This handler should not be called
+        socket.on("ko_test", move |State(_): State<String>| {
+            println!("ko_test event received");
+            tx3.try_send(1213231).unwrap();
+        });
+        socket.on_disconnect(move |State(state): State<i32>| {
+            println!("close event received");
+            tx1.try_send(*state).unwrap();
+        });
+    });
+
+    let mut stream = create_ws_connection(2000).await;
+    stream
+        .send(Message::Text("42[\"test\", 1]".to_string()))
+        .await
+        .unwrap();
+    stream
+        .send(Message::Text("42[\"async_test\", 2]".to_string()))
+        .await
+        .unwrap();
+    stream
+        .send(Message::Text("42[\"ko_test\", 2]".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(rx.recv().await.unwrap(), state);
+    assert_eq!(rx.recv().await.unwrap(), state);
+    assert_eq!(rx.recv().await.unwrap(), state);
+    stream.close(None).await.unwrap();
+    assert_eq!(rx.recv().await.unwrap(), state);
+}
+
+#[tokio::test]
+pub async fn data_extractor() {
+    let io = create_server(2001);
+    let (tx, mut rx) = mpsc::channel::<i32>(4);
+    io.ns("/", move |socket: SocketRef| {
+        println!("Socket connected on / namespace with id: {}", socket.id);
+        let tx1 = tx.clone();
+        let tx2 = tx.clone();
+        socket.on("test", move |Data(data): Data<i32>| {
+            println!("test event received");
+            tx1.try_send(data).unwrap();
+        });
+        socket.on("async_test", move |Data(data): Data<i32>| async move {
+            println!("async_test event received");
+            tx2.try_send(data).unwrap();
+        });
+        // This handler should not be called
+        socket.on("ko_test", move |Data(_): Data<String>| {
+            println!("ko_test event received");
+            tx.try_send(1213231).unwrap();
+        });
+    });
+
+    let mut stream = create_ws_connection(2001).await;
+    stream
+        .send(Message::Text("42[\"test\", 1]".to_string()))
+        .await
+        .unwrap();
+    stream
+        .send(Message::Text("42[\"async_test\", 2]".to_string()))
+        .await
+        .unwrap();
+    stream
+        .send(Message::Text("42[\"ko_test\", 2]".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(rx.recv().await.unwrap(), 1);
+    assert_eq!(rx.recv().await.unwrap(), 2);
+    stream.close(None).await.unwrap();
+}

--- a/socketioxide/tests/fixture.rs
+++ b/socketioxide/tests/fixture.rs
@@ -84,6 +84,22 @@ pub async fn create_ws_connection(port: u16) -> WebSocketStream<MaybeTlsStream<T
     ws
 }
 
+pub fn create_server_with_state<T: Send + Sync + 'static>(port: u16, state: T) -> SocketIo {
+    let (svc, io) = SocketIo::builder()
+        .ping_interval(Duration::from_millis(300))
+        .ping_timeout(Duration::from_millis(200))
+        .with_state(state)
+        .build_svc();
+
+    let addr = &SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+
+    let server = Server::bind(addr).serve(svc.into_make_service());
+
+    tokio::spawn(server);
+
+    io
+}
+
 pub fn create_server(port: u16) -> SocketIo {
     let (svc, io) = SocketIo::builder()
         .ping_interval(Duration::from_millis(300))


### PR DESCRIPTION
## This PR adds global state management as well as a `State` extractor to get the state in any handlers.

Note : Before merging this PR, it is necessary to use dynamics handler for the `on_disconnect` function. Otherwise it wont be possible to use the state in these handlers.

Currently it is not possible to use the references in extractors because of the following problem :
In the `ConnectHandler` implementation below for any function with arguments that implements `FromConnectParts` and are specified by values. To add a lifetime to extractors we could add a lifetime on the trait `FromConnectParts`. The problem is that the provided lifetime should be the one declared with the `for<'a>` corresponding to the function and its scope is rather limited.
```rust
impl<A, F, $($ty,)*> ConnectHandler<A, (private::Sync, $($ty,)*)> for F
        where
            F: for<'a> FnOnce($($ty,)*) + Send + Sync + Clone + 'static,  // The lifetime 'a should be propagated to the `FromConnectParts` 
            A: Adapter,                                                   // ---------------------------------------
            $( $ty: FromConnectParts<'a, A> + Send, )*                    // <----- here
        {
            fn call(
                &self,
                s: Arc<Socket<A>>,
                auth: Option<String>,
                state: &Arc<dyn std::any::Any + Send + Sync>)
            {
                $(
                    let $ty = match $ty::from_connect_parts(&s, &auth,  state) {
                        Ok(v) => v,
                        Err(_e) => {
                            #[cfg(feature = "tracing")]
                            tracing::error!("Error while extracting data: {}", _e);
                            return;
                        },
                    };
                )*

                (self.clone())($($ty,)*);
            }
        }
```

Because of this issue the state will be `static` so that `State` extractors only contains &'static references and don't need lifetime propagation.

* Fixes #178 
