### PR TITLE
chore(deps): switch to `pin-project-lite` for Pin Projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "memchr",
- "pin-project",
+ "pin-project-lite",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tracing = "0.1.37"
 itoa = "1.0.10"
 hyper-util.version = "0.1.1"
 hyper = { version = "1.0.1", features = ["http1", "http2", "server"] }
+pin-project-lite = "0.2.13"
 
 # Dev deps
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/engineioxide/Cargo.toml
+++ b/engineioxide/Cargo.toml
@@ -30,11 +30,11 @@ tower.workspace = true
 hyper.workspace = true
 tokio-tungstenite.workspace = true
 http-body-util.workspace = true
+pin-project-lite.workspace = true
 hyper-util = { workspace = true, features = ["tokio"] }
 
 base64 = "0.21.0"
 bytes = "1.4.0"
-pin-project = "1.0.12"
 rand = "0.8.5"
 
 # Tracing

--- a/engineioxide/src/body.rs
+++ b/engineioxide/src/body.rs
@@ -3,21 +3,23 @@
 use bytes::Bytes;
 use http_body::{Body, Frame, SizeHint};
 use http_body_util::Full;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-#[pin_project(project = BodyProj)]
-pub enum ResponseBody<B> {
-    EmptyResponse,
-    CustomBody {
-        #[pin]
-        body: Full<Bytes>,
-    },
-    Body {
-        #[pin]
-        body: B,
-    },
+pin_project! {
+    #[project = BodyProj]
+    pub enum ResponseBody<B> {
+        EmptyResponse,
+        CustomBody {
+            #[pin]
+            body: Full<Bytes>,
+        },
+        Body {
+            #[pin]
+            body: B,
+        },
+    }
 }
 impl<B> Default for ResponseBody<B> {
     fn default() -> Self {

--- a/engineioxide/src/service/futures.rs
+++ b/engineioxide/src/service/futures.rs
@@ -2,7 +2,7 @@ use crate::body::ResponseBody;
 use crate::errors::Error;
 use futures::ready;
 use http::Response;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -10,21 +10,23 @@ use std::task::{Context, Poll};
 pub(crate) type BoxFuture<B> =
     Pin<Box<dyn Future<Output = Result<Response<ResponseBody<B>>, Error>> + Send>>;
 
-#[pin_project(project = ResFutProj)]
-pub enum ResponseFuture<F, B> {
-    EmptyResponse {
-        code: u16,
-    },
-    ReadyResponse {
-        res: Option<Result<Response<ResponseBody<B>>, Error>>,
-    },
-    AsyncResponse {
-        future: BoxFuture<B>,
-    },
-    Future {
-        #[pin]
-        future: F,
-    },
+pin_project! {
+    #[project = ResFutProj]
+    pub enum ResponseFuture<F, B> {
+        EmptyResponse {
+            code: u16,
+        },
+        ReadyResponse {
+            res: Option<Result<Response<ResponseBody<B>>, Error>>,
+        },
+        AsyncResponse {
+            future: BoxFuture<B>,
+        },
+        Future {
+            #[pin]
+            future: F,
+        },
+    }
 }
 
 impl<F, B> ResponseFuture<F, B> {


### PR DESCRIPTION
### `pin-project-lite` is a subcrate of `pin-project` and is more than sufficient for the needs of socketioxide. 
It will allow to have lighter required deps.