### PR TITLE
Minor fix + Prepare v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.1
+## socketioxide
+* Add `SocketIo::get_socket` and `Operators::get_socket` methods to get a socket ref from its id.
+* Switch to `pin-project-lite` instead of `pin-project`.
+
 # 0.9.0
 * Bump `hyper` to 1.0.1. Therefore it is now possible to use frameworks based on hyper v1.*. Check the [compatibility table](./README.md#compatibility) for more details.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["engineioxide", "socketioxide", "e2e/*", "examples/*"]
+exclude = ["examples/viz-echo"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -24,10 +25,9 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 axum = "0.7.2"
 salvo = { version = "0.63.0", features = ["tower-compat"] }
-viz = "0.7.0"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.67.0"
 authors = ["Théodore Prévot <"]

--- a/examples/viz-echo/Cargo.toml
+++ b/examples/viz-echo/Cargo.toml
@@ -4,10 +4,8 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+viz = "0.7.0"
 socketioxide = { path = "../../socketioxide" }
-viz.workspace = true
-hyper.workspace = true
-http-body-util.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.9.0" }
+engineioxide = { path = "../engineioxide", version = "0.9.1" }
 futures.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 serde.workspace = true
@@ -51,7 +51,6 @@ engineioxide = { path = "../engineioxide", features = [
 tokio-tungstenite.workspace = true
 axum.workspace = true
 salvo.workspace = true
-viz.workspace = true
 tokio = { workspace = true, features = [
     "macros",
     "parking_lot",

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -12,7 +12,6 @@ use serde::de::DeserializeOwned;
 use crate::{
     adapter::{Adapter, LocalAdapter},
     client::Client,
-    errors::Error,
     extract::SocketRef,
     handler::ConnectHandler,
     layer::SocketIoLayer,
@@ -727,7 +726,7 @@ impl<A: Adapter> SocketIo<A> {
 
     /// Gets a [`SocketRef`] by the specified [`Sid`].
     #[inline]
-    pub fn get_socket(&self, sid: Sid) -> Result<SocketRef<A>, Error> {
+    pub fn get_socket(&self, sid: Sid) -> Option<SocketRef<A>> {
         self.get_default_op().get_socket(sid)
     }
 

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -783,9 +783,20 @@ mod tests {
 
     #[test]
     fn get_socket_by_sid() {
+        use engineioxide::Socket;
+        let sid = Sid::new();
         let (_, io) = SocketIo::builder().build_svc();
         io.ns("/", || {});
-        assert!(io.get_socket(Sid::new()).is_err());
+
+        let socket = Socket::new_dummy(sid, Box::new(|_, _| {})).into();
+        let config = SocketIoConfig::default().into();
+        io.0.get_ns("/")
+            .unwrap()
+            .connect(sid, socket, None, config)
+            .unwrap();
+
+        assert!(io.get_socket(sid).is_some());
+        assert!(io.get_socket(Sid::new()).is_none());
     }
 
     #[test]

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -13,7 +13,7 @@ use crate::extract::SocketRef;
 use crate::socket::AckResponse;
 use crate::{
     adapter::{Adapter, BroadcastFlags, BroadcastOptions, Room},
-    errors::{AckError, Error},
+    errors::AckError,
     ns::Namespace,
     packet::Packet,
 };
@@ -369,8 +369,8 @@ impl<A: Adapter> Operators<A> {
     }
 
     /// Gets a [`SocketRef`] by the specified [`Sid`].
-    pub fn get_socket(&self, sid: Sid) -> Result<SocketRef<A>, Error> {
-        self.ns.get_socket(sid).map(SocketRef::new)
+    pub fn get_socket(&self, sid: Sid) -> Option<SocketRef<A>> {
+        self.ns.get_socket(sid).map(SocketRef::new).ok()
     }
 
     /// Makes all sockets selected with the previous operators join the given room(s).

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use engineioxide::{sid::Sid, socket::DisconnectReason as EIoDisconnectReason};
+use engineioxide::socket::DisconnectReason as EIoDisconnectReason;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use tokio::sync::oneshot;
@@ -36,6 +36,8 @@ use crate::{
     client::SocketData,
     errors::{AdapterError, SendError},
 };
+
+pub use engineioxide::sid::Sid;
 
 /// All the possible reasons for a [`Socket`] to be disconnected from a namespace.
 ///


### PR DESCRIPTION
## PR to prepare for v0.9.1 
Also :
* Add better test for `get_socket` fn
* export `Sid` type
* make `get_socket` fn return an `Option<SocketRef>` rather than a private `Error`
* Remove viz from workspace deps because of https://github.com/viz-rs/viz/issues/122