### PR TITLE
test(socketio): improve testing by directly using the `rust_socketio` client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 axum = "0.7.2"
 salvo = { version = "0.63.0", features = ["tower-compat"] }
+rust_socketio = { version = "0.4.2", features = ["async"] }
 
 [workspace.package]
 version = "0.9.1"

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -49,6 +49,7 @@ engineioxide = { path = "../engineioxide", features = [
     "test-utils",
 ] }
 tokio-tungstenite.workspace = true
+rust_socketio.workspace = true
 axum.workspace = true
 salvo.workspace = true
 tokio = { workspace = true, features = [

--- a/socketioxide/tests/extractors.rs
+++ b/socketioxide/tests/extractors.rs
@@ -51,7 +51,7 @@ pub async fn data_extractor() {
     assert_eq!(tx1.capacity(), 4);
 
     let client = assert_ok!(socketio_client(PORT, "foo").await);
-    assert_eq!(assert_ok!(rx.try_recv()), "foo");
+    assert_eq!(rx.recv().await.unwrap(), "foo");
 
     assert_ok!(client.emit("test", json!("oof")).await);
     assert_eq!(rx.recv().await.unwrap(), "oof");

--- a/socketioxide/tests/utils.rs
+++ b/socketioxide/tests/utils.rs
@@ -1,0 +1,43 @@
+#![allow(dead_code)]
+
+#[macro_export]
+macro_rules! assert_ok {
+    ($e:expr) => {
+        assert_ok!($e,)
+    };
+    ($e:expr,) => {{
+        use std::result::Result::*;
+        match $e {
+            Ok(v) => v,
+            Err(e) => panic!("assertion failed: Err({:?})", e),
+        }
+    }};
+    ($e:expr, $($arg:tt)+) => {{
+        use std::result::Result::*;
+        match $e {
+            Ok(v) => v,
+            Err(e) => panic!("assertion failed: Err({:?}): {}", e, format_args!($($arg)+)),
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_err {
+    ($e:expr) => {
+        assert_err!($e,);
+    };
+    ($e:expr,) => {{
+        use std::result::Result::*;
+        match $e {
+            Ok(v) => panic!("assertion failed: Ok({:?})", v),
+            Err(e) => e,
+        }
+    }};
+    ($e:expr, $($arg:tt)+) => {{
+        use std::result::Result::*;
+        match $e {
+            Ok(v) => panic!("assertion failed: Ok({:?}): {}", v, format_args!($($arg)+)),
+            Err(e) => e,
+        }
+    }};
+}


### PR DESCRIPTION
## Motivation
Integration tests are quite complex without the use of a `socketio` client. 

## Solution
The  `rust_socketio` lib has been ended to the integration tests and the `extractors` tests have been refactored.
