### PR TITLE
feat(engineio/sid): add `as_str` fn for `Sid`

### DIFF
--- a/engineioxide/src/sid.rs
+++ b/engineioxide/src/sid.rs
@@ -21,7 +21,8 @@ impl Sid {
         Self::default()
     }
 
-    fn as_str(&self) -> &str {
+    /// Get the session id as a base64 10 chars string
+    pub fn as_str(&self) -> &str {
         // SAFETY: SID is always a base64 chars string
         unsafe { std::str::from_utf8_unchecked(&self.0) }
     }


### PR DESCRIPTION
## Add `as_str` fn for `Sid` type to get the Sid as a base64 10 char `str`