### PR TITLE
Clone http request for ws transport

### DIFF
--- a/engineioxide/src/transport/ws.rs
+++ b/engineioxide/src/transport/ws.rs
@@ -58,16 +58,9 @@ pub fn new_req<R: Send + 'static, B, H: EngineIoHandler>(
     sid: Option<Sid>,
     req: Request<R>,
 ) -> Result<Response<ResponseBody<B>>, Error> {
-    let mut parts = Request::builder()
-        .method(req.method().clone())
-        .uri(req.uri().clone())
-        .version(req.version())
-        .body(())
-        .unwrap()
-        .into_parts()
-        .0;
+    let (parts, body) = req.into_parts();
+    let req = Request::from_parts(parts.clone(), body);
 
-    parts.headers.extend(req.headers().clone());
     let ws_key = parts
         .headers
         .get("Sec-WebSocket-Key")

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -633,10 +633,7 @@ impl<A: Adapter> Socket<A> {
 
     /// Gets the request info made by the client to connect
     ///
-    /// Note that the `extensions` field will be empty and will not
-    /// contain extensions set in the previous http layers for requests initialized with ws transport.
-    ///
-    /// It is because [`http::Extensions`] is not cloneable and is needed for ws upgrade.
+    /// It might be used to retrieve the [`http::request::Extensions`]
     pub fn req_parts(&self) -> &http::request::Parts {
         &self.esocket.req_parts
     }


### PR DESCRIPTION
## Motivation

Before http `1.0` the `Parts` struct was not `clonable` because extensions were not. Because it is now possible, we can now clone the whole `Parts` sruct rather than rebuilding it for the ws transport. 
Therefore it is now possible to retrieve `Extensions` related to the initialized request.

## Solution

Use `parts.clone()` rather than rebuilding an entire `Request` struct and ommitting the `extensions` field.