### PR TITLE
doc(socketioxide) typo in extensions::len documentation

### DIFF
--- a/socketioxide/src/extensions.rs
+++ b/socketioxide/src/extensions.rs
@@ -253,7 +253,7 @@ impl Extensions {
         self.map.is_empty()
     }
 
-    /// Get the numer of extensions available.
+    /// Get the number of extensions available.
     ///
     /// # Example
     ///


### PR DESCRIPTION
numer -> number

## Motivation

A typo was found

## Solution

Added a 'b' to correct the typo
