### PR TITLE
feat(socketio/operators): get all rooms from `io`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.10.2
+## socketioxide
+* New [`rooms`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIo.html#method.rooms) fn to get all the rooms of a namespace.
+
+# 0.10.1
+## socketioxide
+* New [`as_str`](https://docs.rs/socketioxide/latest/socketioxide/socket/struct.Sid.html#method.as_str) fn for `Sid`.
+* Http request is now cloned for the websocket transport (it was not possible before http v1). Therefore it is possible to get headers/extensions of the initial request.
+
 # 0.10.0
 ## socketioxide
 * Rework for `emit_with_ack` fns. It now returns an `AckStream` that can be used either as a future when expecting one ack or as a stream when expecting multiple acks. When expecting multiple acks the `AckStream` will yield `AckResult`s as well as their corresponding socket `id`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 rust-version = "1.67.0"
 authors = ["Théodore Prévot <"]

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.10.1" }
+engineioxide = { path = "../engineioxide", version = "0.10.2" }
 futures.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 serde.workspace = true

--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -116,6 +116,9 @@ pub trait Adapter: std::fmt::Debug + Send + Sync + 'static {
     /// Disconnects the sockets that match the [`BroadcastOptions`].
     fn disconnect_socket(&self, opts: BroadcastOptions) -> Result<(), Vec<DisconnectError>>;
 
+    /// Returns all the rooms for this adapter.
+    fn rooms(&self) -> Result<Vec<Room>, Self::Error>;
+
     //TODO: implement
     // fn server_side_emit(&self, packet: Packet, opts: BroadcastOptions) -> Result<u64, Error>;
     // fn persist_session(&self, sid: i64);
@@ -277,6 +280,10 @@ impl Adapter for LocalAdapter {
         } else {
             Err(errors)
         }
+    }
+
+    fn rooms(&self) -> Result<Vec<Room>, Self::Error> {
+        Ok(self.rooms.read().unwrap().keys().cloned().collect())
     }
 }
 

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -9,7 +9,7 @@ use engineioxide::{
 
 use crate::{
     ack::AckStream,
-    adapter::{Adapter, LocalAdapter},
+    adapter::{Adapter, LocalAdapter, Room},
     client::Client,
     extract::SocketRef,
     handler::ConnectHandler,
@@ -732,6 +732,27 @@ impl<A: Adapter> SocketIo<A> {
     #[inline]
     pub fn join(self, rooms: impl RoomParam) -> Result<(), A::Error> {
         self.get_default_op().join(rooms)
+    }
+
+    /// Gets all room names on the current namespace.
+    ///
+    /// Alias for `io.of("/").unwrap().rooms()`
+    ///
+    /// ## Panics
+    /// If the **default namespace "/" is not found** this fn will panic!
+    ///
+    /// ### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::SocketRef};
+    /// let (_, io) = SocketIo::new_svc();
+    /// let io2 = io.clone();
+    /// io.ns("/", move |socket: SocketRef| async move {
+    ///     println!("Socket connected on /test namespace with id: {}", socket.id);
+    ///     let rooms = io2.rooms().unwrap();
+    ///     println!("All rooms on / namespace: {:?}", rooms);
+    /// });
+    pub fn rooms(&self) -> Result<Vec<Room>, A::Error> {
+        self.get_default_op().rooms()
     }
 
     /// Makes all sockets selected with the previous operators leave the given room(s).

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -467,6 +467,11 @@ impl<A: Adapter> Operators<A> {
         self.ns.adapter.del_sockets(self.opts, rooms)
     }
 
+    /// Gets all room names for a given namespace
+    pub fn rooms(self) -> Result<Vec<Room>, A::Error> {
+        self.ns.adapter.rooms()
+    }
+
     /// Creates a packet with the given event and data.
     fn get_packet(
         &mut self,


### PR DESCRIPTION
## Add a `rooms` fn to get a `Vec<Room>` with all the rooms in the namespace.

Fixes:
* #247 