### PR TITLE
Return emitted data in case of emission error.

### DIFF
--- a/e2e/socketioxide/socketioxide.rs
+++ b/e2e/socketioxide/socketioxide.rs
@@ -39,7 +39,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
         |s: SocketRef, Data::<Value>(data), Bin(bin)| async move {
             let ack = s
                 .bin(bin)
-                .emit_with_ack::<Value>("emit-with-ack", data)
+                .emit_with_ack::<_, Value>("emit-with-ack", data)
                 .unwrap()
                 .await
                 .unwrap();

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -122,10 +122,12 @@ pub struct Permit<'a> {
 }
 impl Permit<'_> {
     /// Consume the permit and emit a message to the client.
+    #[inline]
     pub fn emit(self, msg: String) {
         self.inner.send(Packet::Message(msg));
     }
     /// Consume the permit and emit a binary message to the client.
+    #[inline]
     pub fn emit_binary(self, data: Vec<u8>) {
         self.inner.send(Packet::Binary(data));
     }
@@ -140,12 +142,14 @@ pub struct PermitIterator<'a> {
 impl<'a> Iterator for PermitIterator<'a> {
     type Item = Permit<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let inner = self.inner.next()?;
         Some(Permit { inner })
     }
 }
 impl ExactSizeIterator for PermitIterator<'_> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -390,6 +394,7 @@ where
     ///
     /// If the internal chan is full, the function will return a [`TrySendError::Full`] error.
     /// If the socket is closed, the function will return a [`TrySendError::Closed`] error.
+    #[inline]
     pub fn reserve(&self, n: usize) -> Result<PermitIterator<'_>, TrySendError<()>> {
         let inner = self.internal_tx.try_reserve_many(n)?;
         Ok(PermitIterator { inner })

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -115,6 +115,43 @@ impl From<&Error> for Option<DisconnectReason> {
     }
 }
 
+/// A permit to emit a message to the client.
+/// A permit holds a place in the internal channel to send one packet to the client.
+pub struct Permit<'a> {
+    inner: mpsc::Permit<'a, Packet>,
+}
+impl Permit<'_> {
+    /// Consume the permit and emit a message to the client.
+    pub fn emit(self, msg: String) {
+        self.inner.send(Packet::Message(msg));
+    }
+    /// Consume the permit and emit a binary message to the client.
+    pub fn emit_binary(self, data: Vec<u8>) {
+        self.inner.send(Packet::Binary(data));
+    }
+}
+
+/// An [`Iterator`] over the permits returned by the [`reserve`](Socket::reserve) function
+#[derive(Debug)]
+pub struct PermitIterator<'a> {
+    inner: mpsc::PermitIterator<'a, Packet>,
+}
+
+impl<'a> Iterator for PermitIterator<'a> {
+    type Item = Permit<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let inner = self.inner.next()?;
+        Some(Permit { inner })
+    }
+}
+impl ExactSizeIterator for PermitIterator<'_> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+impl std::iter::FusedIterator for PermitIterator<'_> {}
+
 /// A [`Socket`] represents a client connection to the server.
 /// It is agnostic to the [`TransportType`].
 ///
@@ -346,6 +383,16 @@ where
     /// Returns the current [`TransportType`] of the [`Socket`]
     pub fn transport_type(&self) -> TransportType {
         TransportType::from(self.transport.load(Ordering::Relaxed))
+    }
+
+    /// Reserve `n` permits to emit multiple messages and ensure that there is enough
+    /// space in the internal chan.
+    ///
+    /// If the internal chan is full, the function will return a [`TrySendError::Full`] error.
+    /// If the socket is closed, the function will return a [`TrySendError::Closed`] error.
+    pub fn reserve(&self, n: usize) -> Result<PermitIterator<'_>, TrySendError<()>> {
+        let inner = self.internal_tx.try_reserve_many(n)?;
+        Ok(PermitIterator { inner })
     }
 
     /// Emits a message to the client.

--- a/examples/private-messaging/Cargo.toml
+++ b/examples/private-messaging/Cargo.toml
@@ -18,3 +18,4 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+anyhow = "1.0"

--- a/socketioxide/src/ack.rs
+++ b/socketioxide/src/ack.rs
@@ -102,7 +102,7 @@ pin_project_lite::pin_project! {
     /// let (svc, io) = SocketIo::new_svc();
     /// io.ns("/test", move |socket: SocketRef| async move {
     ///     // We wait for the acknowledgement of the first emit (only one in this case)
-    ///     let ack = socket.emit_with_ack::<String>("test", "test").unwrap().await;
+    ///     let ack = socket.emit_with_ack::<_, String>("test", "test").unwrap().await;
     ///     println!("Ack: {:?}", ack);
     ///
     ///     // We apply the `for_each` StreamExt fn to the AckStream

--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -89,7 +89,11 @@ pub trait Adapter: std::fmt::Debug + Send + Sync + 'static {
     fn del_all(&self, sid: Sid) -> Result<(), Self::Error>;
 
     /// Broadcasts the packet to the sockets that match the [`BroadcastOptions`].
-    fn broadcast(&self, packet: Packet<'_>, opts: BroadcastOptions) -> Result<(), BroadcastError>;
+    fn broadcast(
+        &self,
+        packet: Packet<'_>,
+        opts: BroadcastOptions,
+    ) -> Result<(), BroadcastError<()>>;
 
     /// Broadcasts the packet to the sockets that match the [`BroadcastOptions`] and return a stream of ack responses.
     fn broadcast_with_ack(&self, packet: Packet<'static>, opts: BroadcastOptions)
@@ -191,7 +195,11 @@ impl Adapter for LocalAdapter {
         Ok(())
     }
 
-    fn broadcast(&self, packet: Packet<'_>, opts: BroadcastOptions) -> Result<(), BroadcastError> {
+    fn broadcast(
+        &self,
+        packet: Packet<'_>,
+        opts: BroadcastOptions,
+    ) -> Result<(), BroadcastError<()>> {
         let sockets = self.apply_opts(opts);
 
         #[cfg(feature = "tracing")]

--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -53,7 +53,7 @@ pub struct BroadcastOptions {
 /// The default adapter is the [`LocalAdapter`], which stores the state in memory.
 pub trait Adapter: std::fmt::Debug + Send + Sync + 'static {
     /// An error that can occur when using the adapter. The default [`LocalAdapter`] has an [`Infallible`] error.
-    type Error: std::error::Error + Into<AdapterError> + Send + 'static;
+    type Error: std::error::Error + Into<AdapterError> + Send + Sync + 'static;
 
     /// Create a new adapter and give the namespace ref to retrieve sockets.
     fn new(ns: Weak<Namespace<Self>>) -> Self

--- a/socketioxide/src/adapter.rs
+++ b/socketioxide/src/adapter.rs
@@ -31,14 +31,12 @@ pub type Room = Cow<'static, str>;
 pub enum BroadcastFlags {
     /// Broadcast only to the current server
     Local,
-    /// Broadcast to all servers
+    /// Broadcast to all clients except the sender
     Broadcast,
-    /// Add a custom timeout to the ack callback
-    Timeout(Duration),
 }
 
 /// Options that can be used to modify the behavior of the broadcast methods.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BroadcastOptions {
     /// The flags to apply to the broadcast.
     pub flags: HashSet<BroadcastFlags>,
@@ -49,17 +47,6 @@ pub struct BroadcastOptions {
     /// The socket id of the sender.
     pub sid: Option<Sid>,
 }
-impl BroadcastOptions {
-    pub(crate) fn new(sid: Option<Sid>) -> Self {
-        Self {
-            flags: HashSet::new(),
-            rooms: HashSet::new(),
-            except: HashSet::new(),
-            sid,
-        }
-    }
-}
-
 //TODO: Make an AsyncAdapter trait
 /// An adapter is responsible for managing the state of the server.
 /// This adapter can be implemented to share the state between multiple servers.
@@ -89,15 +76,15 @@ pub trait Adapter: std::fmt::Debug + Send + Sync + 'static {
     fn del_all(&self, sid: Sid) -> Result<(), Self::Error>;
 
     /// Broadcasts the packet to the sockets that match the [`BroadcastOptions`].
-    fn broadcast(
-        &self,
-        packet: Packet<'_>,
-        opts: BroadcastOptions,
-    ) -> Result<(), BroadcastError<()>>;
+    fn broadcast(&self, packet: Packet<'_>, opts: BroadcastOptions) -> Result<(), BroadcastError>;
 
     /// Broadcasts the packet to the sockets that match the [`BroadcastOptions`] and return a stream of ack responses.
-    fn broadcast_with_ack(&self, packet: Packet<'static>, opts: BroadcastOptions)
-        -> AckInnerStream;
+    fn broadcast_with_ack(
+        &self,
+        packet: Packet<'static>,
+        opts: BroadcastOptions,
+        timeout: Option<Duration>,
+    ) -> AckInnerStream;
 
     /// Returns the sockets ids that match the [`BroadcastOptions`].
     fn sockets(&self, rooms: impl RoomParam) -> Result<Vec<Sid>, Self::Error>;
@@ -195,11 +182,7 @@ impl Adapter for LocalAdapter {
         Ok(())
     }
 
-    fn broadcast(
-        &self,
-        packet: Packet<'_>,
-        opts: BroadcastOptions,
-    ) -> Result<(), BroadcastError<()>> {
+    fn broadcast(&self, packet: Packet<'_>, opts: BroadcastOptions) -> Result<(), BroadcastError> {
         let sockets = self.apply_opts(opts);
 
         #[cfg(feature = "tracing")]
@@ -219,11 +202,8 @@ impl Adapter for LocalAdapter {
         &self,
         packet: Packet<'static>,
         opts: BroadcastOptions,
+        timeout: Option<Duration>,
     ) -> AckInnerStream {
-        let duration = opts.flags.iter().find_map(|flag| match flag {
-            BroadcastFlags::Timeout(duration) => Some(*duration),
-            _ => None,
-        });
         let sockets = self.apply_opts(opts);
         #[cfg(feature = "tracing")]
         tracing::debug!(
@@ -231,11 +211,11 @@ impl Adapter for LocalAdapter {
             sockets.len(),
             sockets.iter().map(|s| s.id).collect::<Vec<_>>()
         );
-        AckInnerStream::broadcast(packet, sockets, duration)
+        AckInnerStream::broadcast(packet, sockets, timeout)
     }
 
     fn sockets(&self, rooms: impl RoomParam) -> Result<Vec<Sid>, Infallible> {
-        let mut opts = BroadcastOptions::new(None);
+        let mut opts = BroadcastOptions::default();
         opts.rooms.extend(rooms.into_room_iter());
         Ok(self
             .apply_opts(opts)
@@ -429,7 +409,10 @@ mod test {
         let adapter = LocalAdapter::new(Arc::downgrade(&ns));
         adapter.add_all(socket, ["room1"]).unwrap();
 
-        let mut opts = BroadcastOptions::new(Some(socket));
+        let mut opts = BroadcastOptions {
+            sid: Some(socket),
+            ..Default::default()
+        };
         opts.rooms = hash_set!["room1".into()];
         adapter.add_sockets(opts, "room2").unwrap();
         let rooms_map = adapter.rooms.read().unwrap();
@@ -446,7 +429,10 @@ mod test {
         let adapter = LocalAdapter::new(Arc::downgrade(&ns));
         adapter.add_all(socket, ["room1"]).unwrap();
 
-        let mut opts = BroadcastOptions::new(Some(socket));
+        let mut opts = BroadcastOptions {
+            sid: Some(socket),
+            ..Default::default()
+        };
         opts.rooms = hash_set!["room1".into()];
         adapter.add_sockets(opts, "room2").unwrap();
 
@@ -458,7 +444,10 @@ mod test {
             assert!(rooms_map.get("room2").unwrap().contains(&socket));
         }
 
-        let mut opts = BroadcastOptions::new(Some(socket));
+        let mut opts = BroadcastOptions {
+            sid: Some(socket),
+            ..Default::default()
+        };
         opts.rooms = hash_set!["room1".into()];
         adapter.del_sockets(opts, "room2").unwrap();
 
@@ -515,7 +504,10 @@ mod test {
             .add_all(socket2, ["room2", "room3", "room6"])
             .unwrap();
 
-        let mut opts = BroadcastOptions::new(Some(socket0));
+        let mut opts = BroadcastOptions {
+            sid: Some(socket0),
+            ..Default::default()
+        };
         opts.rooms = hash_set!["room5".into()];
         adapter.disconnect_socket(opts).unwrap();
 
@@ -541,14 +533,20 @@ mod test {
             .unwrap();
 
         // socket 2 is the sender
-        let mut opts = BroadcastOptions::new(Some(socket2));
+        let mut opts = BroadcastOptions {
+            sid: Some(socket2),
+            ..Default::default()
+        };
         opts.rooms = hash_set!["room1".into()];
         opts.except = hash_set!["room2".into()];
         let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 1);
         assert_eq!(sockets[0].id, socket1);
 
-        let mut opts = BroadcastOptions::new(Some(socket2));
+        let mut opts = BroadcastOptions {
+            sid: Some(socket2),
+            ..Default::default()
+        };
         opts.flags.insert(BroadcastFlags::Broadcast);
         let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 2);
@@ -556,18 +554,27 @@ mod test {
             assert!(s.id == socket0 || s.id == socket1);
         });
 
-        let mut opts = BroadcastOptions::new(Some(socket2));
+        let mut opts = BroadcastOptions {
+            sid: Some(socket2),
+            ..Default::default()
+        };
         opts.flags.insert(BroadcastFlags::Broadcast);
         opts.except = hash_set!["room2".into()];
         let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 1);
 
-        let opts = BroadcastOptions::new(Some(socket2));
+        let opts = BroadcastOptions {
+            sid: Some(socket2),
+            ..Default::default()
+        };
         let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 1);
         assert_eq!(sockets[0].id, socket2);
 
-        let opts = BroadcastOptions::new(Some(Sid::new()));
+        let opts = BroadcastOptions {
+            sid: Some(Sid::new()),
+            ..Default::default()
+        };
         let sockets = adapter.fetch_sockets(opts).unwrap();
         assert_eq!(sockets.len(), 0);
     }

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -111,7 +111,7 @@ pub enum DisconnectError {
 
 /// Error type for the [`Adapter`](crate::adapter::Adapter) trait.
 #[derive(Debug, thiserror::Error)]
-pub struct AdapterError(#[from] pub Box<dyn std::error::Error + Send>);
+pub struct AdapterError(#[from] pub Box<dyn std::error::Error + Send + Sync>);
 impl Display for AdapterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, f)

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -45,7 +45,7 @@ pub enum AckError<T> {
 }
 
 /// Error type for broadcast operations.
-#[derive(thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum BroadcastError<T> {
     /// An error occurred while sending packets.
     #[error("Error sending data through the engine.io socket: {0:?}")]
@@ -58,27 +58,6 @@ pub enum BroadcastError<T> {
     /// An error occured while broadcasting to other nodes.
     #[error("Adapter error: {0}")]
     Adapter(#[from] AdapterError),
-}
-impl Debug for BroadcastError<()> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Socket(errs) => {
-                f.write_str("BroadcastError::Socket(")?;
-                Debug::fmt(errs, f)?;
-                f.write_str(")")
-            }
-            Self::Serialize(err) => {
-                f.write_str("BroadcastError::Serialize(")?;
-                Debug::fmt(err, f)?;
-                f.write_str(")")
-            }
-            Self::Adapter(err) => {
-                f.write_str("BroadcastError::Adapter(")?;
-                Debug::fmt(err, f)?;
-                f.write_str(")")
-            }
-        }
-    }
 }
 
 /// Error type for sending operations.

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -132,6 +132,14 @@ impl Display for AdapterError {
     }
 }
 
+impl SocketError<()> {
+    pub(crate) fn with_value<T>(self, value: T) -> SocketError<T> {
+        match self {
+            Self::InternalChannelFull(_) => SocketError::InternalChannelFull(value),
+            Self::Closed(_) => SocketError::Closed(value),
+        }
+    }
+}
 impl<T> From<TrySendError<T>> for SocketError<()> {
     fn from(value: TrySendError<T>) -> Self {
         match value {

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -290,7 +290,7 @@ impl<A: Adapter> AckSender<A> {
     pub fn send<T: Serialize>(self, data: T) -> Result<(), SendError<T>> {
         use crate::socket::PermitIteratorExt;
         if let Some(ack_id) = self.ack_id {
-            let permits = match self.socket.reserve(self.binary.len() + 1) {
+            let permits = match self.socket.reserve(1 + self.binary.len()) {
                 Ok(permits) => permits,
                 Err(e) => {
                     #[cfg(feature = "tracing")]

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -288,6 +288,7 @@ impl<A: Adapter> AckSender<A> {
 
     /// Send the ack response to the client.
     pub fn send<T: Serialize>(self, data: T) -> Result<(), SendError<T>> {
+        use crate::socket::PermitIteratorExt;
         if let Some(ack_id) = self.ack_id {
             let permits = match self.socket.reserve(self.binary.len() + 1) {
                 Ok(permits) => permits,
@@ -304,7 +305,7 @@ impl<A: Adapter> AckSender<A> {
             } else {
                 Packet::bin_ack(ns, data, self.binary, ack_id)
             };
-            self.socket.permit_send(packet, permits);
+            permits.emit(packet);
             Ok(())
         } else {
             Ok(())

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -287,10 +287,10 @@ impl<A: Adapter> AckSender<A> {
     }
 
     /// Send the ack response to the client.
-    pub fn send(self, data: impl Serialize) -> Result<(), SendError> {
+    pub fn send<T: Serialize>(self, data: T) -> Result<(), SendError<()>> {
         if let Some(ack_id) = self.ack_id {
             let ns = self.socket.ns();
-            let data = serde_json::to_value(&data)?;
+            let data = serde_json::to_value(data)?;
             let packet = if self.binary.is_empty() {
                 Packet::ack(ns, data, ack_id)
             } else {

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -586,11 +586,11 @@ impl<A: Adapter> SocketIo<A> {
     ///   .except("room2")
     ///   .emit("Hello World!", ());
     #[inline]
-    pub fn emit(
+    pub fn emit<T: serde::Serialize>(
         &self,
         event: impl Into<Cow<'static, str>>,
-        data: impl serde::Serialize,
-    ) -> Result<(), BroadcastError> {
+        data: T,
+    ) -> Result<(), BroadcastError<()>> {
         self.get_default_op().emit(event, data)
     }
 

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -14,7 +14,7 @@ use crate::{
     extract::SocketRef,
     handler::ConnectHandler,
     layer::SocketIoLayer,
-    operators::{Operators, RoomParam},
+    operators::{BroadcastOperators, RoomParam},
     service::SocketIoService,
     BroadcastError, DisconnectError,
 };
@@ -374,7 +374,7 @@ impl<A: Adapter> SocketIo<A> {
     ///    println!("found socket on /custom_ns namespace with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn of<'a>(&self, path: impl Into<&'a str>) -> Option<Operators<A>> {
+    pub fn of<'a>(&self, path: impl Into<&'a str>) -> Option<BroadcastOperators<A>> {
         self.get_op(path.into())
     }
 
@@ -400,7 +400,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn to(&self, rooms: impl RoomParam) -> Operators<A> {
+    pub fn to(&self, rooms: impl RoomParam) -> BroadcastOperators<A> {
         self.get_default_op().to(rooms)
     }
 
@@ -428,7 +428,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn within(&self, rooms: impl RoomParam) -> Operators<A> {
+    pub fn within(&self, rooms: impl RoomParam) -> BroadcastOperators<A> {
         self.get_default_op().within(rooms)
     }
 
@@ -461,7 +461,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn except(&self, rooms: impl RoomParam) -> Operators<A> {
+    pub fn except(&self, rooms: impl RoomParam) -> BroadcastOperators<A> {
         self.get_default_op().except(rooms)
     }
 
@@ -488,7 +488,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn local(&self) -> Operators<A> {
+    pub fn local(&self) -> BroadcastOperators<A> {
         self.get_default_op().local()
     }
 
@@ -531,7 +531,7 @@ impl<A: Adapter> SocketIo<A> {
     ///      }
     ///   });
     #[inline]
-    pub fn timeout(&self, timeout: Duration) -> Operators<A> {
+    pub fn timeout(&self, timeout: Duration) -> BroadcastOperators<A> {
         self.get_default_op().timeout(timeout)
     }
 
@@ -559,7 +559,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   .bin(vec![vec![1, 2, 3, 4]])
     ///   .emit("test", ());
     #[inline]
-    pub fn bin(&self, binary: Vec<Vec<u8>>) -> Operators<A> {
+    pub fn bin(&self, binary: Vec<Vec<u8>>) -> BroadcastOperators<A> {
         self.get_default_op().bin(binary)
     }
 
@@ -590,7 +590,7 @@ impl<A: Adapter> SocketIo<A> {
         &self,
         event: impl Into<Cow<'static, str>>,
         data: T,
-    ) -> Result<(), BroadcastError<()>> {
+    ) -> Result<(), BroadcastError> {
         self.get_default_op().emit(event, data)
     }
 
@@ -785,10 +785,10 @@ impl<A: Adapter> SocketIo<A> {
 
     /// Returns a new operator on the given namespace
     #[inline(always)]
-    fn get_op(&self, path: &str) -> Option<Operators<A>> {
+    fn get_op(&self, path: &str) -> Option<BroadcastOperators<A>> {
         self.0
             .get_ns(path)
-            .map(|ns| Operators::new(ns, None).broadcast())
+            .map(|ns| BroadcastOperators::new(ns).broadcast())
     }
 
     /// Returns a new operator on the default namespace "/" (root namespace)
@@ -797,7 +797,7 @@ impl<A: Adapter> SocketIo<A> {
     ///
     /// If the **default namespace "/" is not found** this fn will panic!
     #[inline(always)]
-    fn get_default_op(&self) -> Operators<A> {
+    fn get_default_op(&self) -> BroadcastOperators<A> {
         self.get_op("/").expect("default namespace not found")
     }
 }
@@ -850,19 +850,5 @@ mod tests {
 
         assert!(io.get_socket(sid).is_some());
         assert!(io.get_socket(Sid::new()).is_none());
-    }
-
-    #[test]
-    fn every_op_should_be_broadcast() {
-        let (_, io) = SocketIo::builder().build_svc();
-        io.ns("/", || {});
-        assert!(io.get_default_op().is_broadcast());
-        assert!(io.to("room1").is_broadcast());
-        assert!(io.within("room1").is_broadcast());
-        assert!(io.except("room1").is_broadcast());
-        assert!(io.local().is_broadcast());
-        assert!(io.timeout(Duration::from_secs(5)).is_broadcast());
-        assert!(io.bin(vec![vec![1, 2, 3, 4]]).is_broadcast());
-        assert!(io.of("/").unwrap().is_broadcast());
     }
 }

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -189,18 +189,20 @@
 //!
 //! #### Emit errors
 //! If the data can't be serialized to json, an [`serde_json::Error`] will be returned.
-//! If the socket is disconnected or the internal channel is full, a tracing log will be emitted if the `tracing` feature is enabled and the message will be dropped.
-//! This solution is not ideal and will be improved in the future (see [socketioxide/172](https://github.com/Totodore/socketioxide/issues/172)).
+//!
+//! If the socket is disconnected or the internal channel is full,
+//! a [`SendError`] will be returned and the provided data will be given back.
+//! Moreover, a tracing log will be emitted if the `tracing` feature is enabled.
 //!
 //! #### Emitting with operators
-//! To configure the emit, you can chain [`Operators`](operators::Operators) methods to the emit call. With that you can easily configure the following options:
+//! To configure the emit, you can chain [`Operators`](operators) methods to the emit call. With that you can easily configure the following options:
 //! * rooms: emit, join, leave to specific rooms
 //! * namespace: emit to a specific namespace (only from the [`SocketIo`] handle)
 //! * timeout: set a custom timeout when waiting for an ack
 //! * binary: emit a binary payload with the message
 //! * local: broadcast only to the current node (in case of a cluster)
 //!
-//! Check the [`operators::Operators`] doc for more details on the operators.
+//! Check the [`operators`] module doc for more details on operators.
 //!
 //! ## Acknowledgements
 //! You can ensure that a message has been received by the client/server with acknowledgements.
@@ -213,11 +215,11 @@
 //! #### Client acknowledgements
 //! If you want to emit/broadcast a message and await for a/many client(s) acknowledgment(s) you can use:
 //! * [`SocketRef::emit_with_ack`] for a single client
-//! * [`Operators::emit_with_ack`] for broadcasting or [emit configuration](#emiting-data).
+//! * [`BroadcastOperators::emit_with_ack`] for broadcasting or [emit configuration](#emiting-data).
 //! * [`SocketIo::emit_with_ack`] for broadcasting.
 //!
 //! [`SocketRef::emit_with_ack`]: crate::extract::SocketRef#method.emit_with_ack
-//! [`Operators::emit_with_ack`]: crate::operators::Operators#method.emit_with_ack
+//! [`BroadcastOperators::emit_with_ack`]: crate::operators::BroadcastOperators#method.emit_with_ack
 //! [`SocketIo::emit_with_ack`]: SocketIo#method.emit_with_ack
 //! [`AckStream`]: crate::ack::AckStream
 //! [`AckResponse`]: crate::ack::AckResponse

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -5,10 +5,12 @@ use std::{sync::Arc, time::Duration};
 
 use engineioxide::sid::Sid;
 
-use crate::ack::AckStream;
+use crate::ack::{AckInnerStream, AckStream};
 use crate::adapter::LocalAdapter;
 use crate::errors::{BroadcastError, DisconnectError};
 use crate::extract::SocketRef;
+use crate::socket::Socket;
+use crate::SendError;
 use crate::{
     adapter::{Adapter, BroadcastFlags, BroadcastOptions, Room},
     ns::Namespace,
@@ -93,20 +95,413 @@ impl RoomParam for Sid {
     }
 }
 
-/// Operators are used to select sockets to send a packet to, or to configure the packet that will be emitted.
-#[derive(Debug)]
-pub struct Operators<A: Adapter = LocalAdapter> {
-    opts: BroadcastOptions,
-    ns: Arc<Namespace<A>>,
+/// Chainable operators to configure the message to be sent.
+pub struct ConfOperators<A: Adapter = LocalAdapter> {
     binary: Vec<Vec<u8>>,
+    timeout: Option<Duration>,
+    sender: Arc<Socket<A>>,
+}
+/// Chainable operators to select sockets to send a message to and to configure the message to be sent.
+pub struct BroadcastOperators<A: Adapter = LocalAdapter> {
+    binary: Vec<Vec<u8>>,
+    timeout: Option<Duration>,
+    ns: Arc<Namespace<A>>,
+    opts: BroadcastOptions,
 }
 
-impl<A: Adapter> Operators<A> {
-    pub(crate) fn new(ns: Arc<Namespace<A>>, sid: Option<Sid>) -> Self {
+impl<A: Adapter> From<ConfOperators<A>> for BroadcastOperators<A> {
+    fn from(conf: ConfOperators<A>) -> Self {
+        let mut opts = BroadcastOptions::default();
+        opts.sid = Some(conf.sender.id);
         Self {
-            opts: BroadcastOptions::new(sid),
-            ns,
+            binary: conf.binary,
+            timeout: conf.timeout,
+            ns: conf.sender.ns.clone(),
+            opts,
+        }
+    }
+}
+
+// ==== impl ConfOperators operations ====
+impl<A: Adapter> ConfOperators<A> {
+    pub(crate) fn new(sender: Arc<Socket<A>>) -> Self {
+        Self {
             binary: vec![],
+            timeout: None,
+            sender,
+        }
+    }
+
+    /// Selects all sockets in the given rooms except the current socket.
+    /// If it is called from the `Namespace` level there will be no difference with the `within()` operator
+    ///
+    /// If you want to include the current socket, use the `within()` operator.
+    /// #### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         let other_rooms = "room4".to_string();
+    ///         // In room1, room2, room3 and room4 except the current
+    ///         socket
+    ///             .to("room1")
+    ///             .to(["room2", "room3"])
+    ///             .to(vec![other_rooms])
+    ///             .emit("test", data);
+    ///     });
+    /// });
+    pub fn to(self, rooms: impl RoomParam) -> BroadcastOperators<A> {
+        BroadcastOperators::from(self).to(rooms)
+    }
+
+    /// Selects all sockets in the given rooms.
+    ///
+    /// It does include the current socket contrary to the `to()` operator.
+    /// If it is called from the `Namespace` level there will be no difference with the `to()` operator
+    /// #### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         let other_rooms = "room4".to_string();
+    ///         // In room1, room2, room3 and room4 including the current socket
+    ///         socket
+    ///             .within("room1")
+    ///             .within(["room2", "room3"])
+    ///             .within(vec![other_rooms])
+    ///             .emit("test", data);
+    ///     });
+    /// });
+    pub fn within(self, rooms: impl RoomParam) -> BroadcastOperators<A> {
+        BroadcastOperators::from(self).within(rooms)
+    }
+
+    /// Filters out all sockets selected with the previous operators which are in the given rooms.
+    /// #### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("register1", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         socket.join("room1");
+    ///     });
+    ///     socket.on("register2", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         socket.join("room2");
+    ///     });
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         // This message will be broadcast to all sockets in the Namespace
+    ///         // except for ones in room1 and the current socket
+    ///         socket.broadcast().except("room1").emit("test", data);
+    ///     });
+    /// });
+    pub fn except(self, rooms: impl RoomParam) -> BroadcastOperators<A> {
+        BroadcastOperators::from(self).except(rooms)
+    }
+
+    /// Broadcasts to all sockets only connected on this node (when using multiple nodes).
+    /// When using the default in-memory adapter, this operator is a no-op.
+    /// #### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         // This message will be broadcast to all sockets in this namespace and connected on this node
+    ///         socket.local().emit("test", data);
+    ///     });
+    /// });
+    pub fn local(self) -> BroadcastOperators<A> {
+        BroadcastOperators::from(self).local()
+    }
+
+    /// Broadcasts to all sockets without any filtering (except the current socket).
+    /// #### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         // This message will be broadcast to all sockets in this namespace
+    ///         socket.broadcast().emit("test", data);
+    ///     });
+    /// });
+    pub fn broadcast(self) -> BroadcastOperators<A> {
+        BroadcastOperators::from(self).broadcast()
+    }
+
+    /// Sets a custom timeout when sending a message with an acknowledgement.
+    ///
+    /// See [`SocketIoBuilder::ack_timeout`](crate::SocketIoBuilder) for the default timeout.
+    ///
+    /// See [`emit_with_ack()`] for more details on acknowledgements.
+    ///
+    /// [`emit_with_ack()`]: #method.emit_with_ack
+    ///
+    /// # Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// # use futures::stream::StreamExt;
+    /// # use std::time::Duration;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///    socket.on("test", |socket: SocketRef, Data::<Value>(data), Bin(bin)| async move {
+    ///       // Emit a test message in the room1 and room3 rooms, except for the room2
+    ///       // room with the binary payload received, wait for 5 seconds for an acknowledgement
+    ///       socket.to("room1")
+    ///             .to("room3")
+    ///             .except("room2")
+    ///             .bin(bin)
+    ///             .timeout(Duration::from_secs(5))
+    ///             .emit_with_ack::<Value>("message-back", data)
+    ///             .unwrap()
+    ///             .for_each(|(id, ack)| async move {
+    ///                match ack {
+    ///                    Ok(ack) => println!("Ack received, socket {} {:?}", id, ack),
+    ///                    Err(err) => println!("Ack error, socket {} {:?}", id, err),
+    ///                }
+    ///             }).await;
+    ///    });
+    /// });
+    ///
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Adds a binary payload to the message.
+    /// #### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data), Bin(bin)| async move {
+    ///         // This will send the binary payload received to all sockets in this namespace with the test message
+    ///         socket.bin(bin).emit("test", data);
+    ///     });
+    /// });
+    pub fn bin(mut self, binary: Vec<Vec<u8>>) -> Self {
+        self.binary = binary;
+        self
+    }
+}
+
+// ==== impl ConfOperators consume fns ====
+impl<A: Adapter> ConfOperators<A> {
+    /// Emits a message to all sockets selected with the previous operators.
+    ///
+    /// If you provide array-like data (tuple, vec, arrays), it will be considered as multiple arguments.
+    /// Therefore if you want to send an array as the _first_ argument of the payload,
+    /// you need to wrap it in an array or a tuple.
+    ///
+    /// ## Errors
+    /// * When encoding the data into JSON a [`BroadcastError::Serialize`] may be returned.
+    /// * If the underlying engine.io connection is closed for a given socket a [`BroadcastError::Socket(SocketError::Closed)`]
+    /// will be returned.
+    /// * If the packet buffer is full for a given socket, a [`BroadcastError::Socket(SocketError::InternalChannelFull)`]
+    /// will be retured.
+    /// See [`SocketIoBuilder::max_buffer_size`] option for more infos on internal buffer config
+    ///
+    /// [`SocketIoBuilder::max_buffer_size`]: crate::SocketIoBuilder#method.max_buffer_size
+    ///
+    /// #### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data), Bin(bin)| async move {
+    ///         // Emit a test message in the room1 and room3 rooms, except for the room2 room with the binary payload received
+    ///         socket.to("room1").to("room3").except("room2").bin(bin).emit("test", data);
+    ///
+    ///         // Emit a test message with multiple arguments to the client
+    ///         socket.to("room1").emit("test", ("world", "hello", 1)).ok();
+    ///
+    ///         // Emit a test message with an array as the first argument
+    ///         let arr = [1, 2, 3, 4];
+    ///         socket.to("room2").emit("test", [arr]).ok();
+    ///     });
+    /// });
+    pub fn emit<T: serde::Serialize>(
+        mut self,
+        event: impl Into<Cow<'static, str>>,
+        data: T,
+    ) -> Result<(), SendError<T>> {
+        use crate::socket::PermitIteratorExt;
+        let sock = self.sender.clone();
+        let permits = match sock.reserve(1 + self.binary.len()) {
+            Ok(permits) => permits,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                tracing::debug!("sending error during emit message: {e:?}");
+                return Err(e.with_value(data).into());
+            }
+        };
+        let packet = self.get_packet(event, data)?;
+        permits.emit(packet);
+
+        Ok(())
+    }
+
+    /// Emits a message to the client and wait for acknowledgement.
+    ///
+    /// The acknowledgement has a timeout specified in the config (5s by default)
+    /// (see [`SocketIoBuilder::ack_timeout`]) or with the [`timeout()`] operator.
+    ///
+    /// To get acknowledgements, an [`AckStream`] is returned.
+    /// It can be used in two ways:
+    /// * As a [`Stream`]: It will yield all the [`AckResponse`] with their corresponding socket id
+    /// received from the client. It can useful when broadcasting to multiple sockets and therefore expecting
+    /// more than one acknowledgement. If you want to get the socket from this id, use [`io::get_socket()`].
+    /// * As a [`Future`]: It will yield the first [`AckResponse`] received from the client.
+    /// Useful when expecting only one acknowledgement.
+    ///
+    /// If the packet encoding failed a [`serde_json::Error`] is **immediately** returned.
+    ///
+    /// If the socket is full or if it has been closed before receiving the acknowledgement,
+    /// an [`AckError::Socket`] will be yielded.
+    ///
+    /// If the client didn't respond before the timeout, the [`AckStream`] will yield
+    /// an [`AckError::Timeout`]. If the data sent by the client is not deserializable as `V`,
+    /// an [`AckError::Serde`] will be yielded.
+    ///
+    /// [`timeout()`]: crate::operators::Operators#method.timeout
+    /// [`SocketIoBuilder::ack_timeout`]: crate::SocketIoBuilder#method.ack_timeout
+    /// [`Stream`]: futures::stream::Stream
+    /// [`Future`]: futures::future::Future
+    /// [`AckError`]: crate::AckError
+    /// [`AckError::Serde`]: crate::AckError::Serde
+    /// [`AckError::Timeout`]: crate::AckError::Timeout
+    /// [`AckError::Socket`]: crate::AckError::Socket
+    /// [`AckError::Socket(SocketError::Closed)`]: crate::SocketError::Closed
+    /// [`io::get_socket()`]: crate::SocketIo#method.get_socket
+    ///
+    /// # Basic example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// # use serde_json::Value;
+    /// # use std::sync::Arc;
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///         // Emit a test message and wait for an acknowledgement with the timeout specified in the config
+    ///         match socket.emit_with_ack::<Value>("test", data).unwrap().await {
+    ///             Ok(ack) => println!("Ack received {:?}", ack),
+    ///             Err(err) => println!("Ack error {:?}", err),
+    ///         }
+    ///    });
+    /// });
+    /// ```
+    pub fn emit_with_ack<T: serde::Serialize, V>(
+        mut self,
+        event: impl Into<Cow<'static, str>>,
+        data: T,
+    ) -> Result<AckStream<V>, serde_json::Error> {
+        let timeout = self.timeout.unwrap_or(self.sender.config.ack_timeout);
+        let data = serde_json::to_value(data)?;
+        let packet = self.get_packet(event, data)?;
+        let rx = self.sender.send_with_ack(packet);
+        let stream = AckInnerStream::send(rx, timeout, self.sender.id);
+        Ok(AckStream::<V>::from(stream))
+    }
+
+    /// Disconnects the current socket.
+    ///
+    /// ### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///   socket.on("test", |socket: SocketRef| async move {
+    ///     // Disconnect all sockets in the room1 and room3 rooms, except for the room2
+    ///     socket.disconnect().unwrap();
+    ///   });
+    /// });
+    pub fn disconnect(self) -> Result<(), DisconnectError> {
+        self.sender.disconnect()
+    }
+
+    /// Makes all sockets selected with the previous operators join the given room(s).
+    ///
+    /// ### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    ///   socket.on("test", |socket: SocketRef| async move {
+    ///     // Add all sockets that are in the room1 and room3 to the room4 and room5
+    ///     socket.within("room1").within("room3").join(["room4", "room5"]).unwrap();
+    ///   });
+    /// });
+    pub fn join(self, rooms: impl RoomParam) -> Result<(), A::Error> {
+        self.sender.join(rooms)
+    }
+
+    /// Makes all sockets selected with the previous operators leave the given room(s).
+    ///
+    /// ### Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::*};
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/", |socket: SocketRef| {
+    /// socket.on("test", |socket: SocketRef| async move {
+    ///     // Remove all sockets that are in the room1 and room3 from the room4 and room5
+    ///     socket.within("room1").within("room3").leave(["room4", "room5"]).unwrap();
+    ///   });
+    /// });
+    pub fn leave(self, rooms: impl RoomParam) -> Result<(), A::Error> {
+        self.sender.leave(rooms)
+    }
+
+    /// Gets all room names for a given namespace
+    pub fn rooms(self) -> Result<Vec<Room>, A::Error> {
+        self.sender.rooms()
+    }
+
+    /// Creates a packet with the given event and data.
+    fn get_packet(
+        &mut self,
+        event: impl Into<Cow<'static, str>>,
+        data: impl serde::Serialize,
+    ) -> Result<Packet<'static>, serde_json::Error> {
+        let ns = self.sender.ns.path.clone();
+        let data = serde_json::to_value(data)?;
+        let packet = if self.binary.is_empty() {
+            Packet::event(ns, event.into(), data)
+        } else {
+            let binary = std::mem::take(&mut self.binary);
+            Packet::bin_event(ns, event.into(), data, binary)
+        };
+        Ok(packet)
+    }
+}
+
+impl<A: Adapter> BroadcastOperators<A> {
+    pub(crate) fn new(ns: Arc<Namespace<A>>) -> Self {
+        Self {
+            binary: vec![],
+            timeout: None,
+            ns,
+            opts: BroadcastOptions::default(),
+        }
+    }
+    pub(crate) fn from_sock(ns: Arc<Namespace<A>>, sid: Sid) -> Self {
+        Self {
+            binary: vec![],
+            timeout: None,
+            ns,
+            opts: BroadcastOptions {
+                sid: Some(sid),
+                ..Default::default()
+            },
         }
     }
 
@@ -132,8 +527,7 @@ impl<A: Adapter> Operators<A> {
     /// });
     pub fn to(mut self, rooms: impl RoomParam) -> Self {
         self.opts.rooms.extend(rooms.into_room_iter());
-        self.opts.flags.insert(BroadcastFlags::Broadcast);
-        self
+        self.broadcast()
     }
 
     /// Selects all sockets in the given rooms.
@@ -182,8 +576,7 @@ impl<A: Adapter> Operators<A> {
     /// });
     pub fn except(mut self, rooms: impl RoomParam) -> Self {
         self.opts.except.extend(rooms.into_room_iter());
-        self.opts.flags.insert(BroadcastFlags::Broadcast);
-        self
+        self.broadcast()
     }
 
     /// Broadcasts to all sockets only connected on this node (when using multiple nodes).
@@ -257,7 +650,7 @@ impl<A: Adapter> Operators<A> {
     /// });
     ///
     pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.opts.flags.insert(BroadcastFlags::Timeout(timeout));
+        self.timeout = Some(timeout);
         self
     }
 
@@ -277,7 +670,10 @@ impl<A: Adapter> Operators<A> {
         self.binary = binary;
         self
     }
+}
 
+// ==== impl BroadcastOperators consume fns ====
+impl<A: Adapter> BroadcastOperators<A> {
     /// Emits a message to all sockets selected with the previous operators.
     ///
     /// If you provide array-like data (tuple, vec, arrays), it will be considered as multiple arguments.
@@ -316,7 +712,7 @@ impl<A: Adapter> Operators<A> {
         mut self,
         event: impl Into<Cow<'static, str>>,
         data: T,
-    ) -> Result<(), BroadcastError<()>> {
+    ) -> Result<(), BroadcastError> {
         let packet = self.get_packet(event, data)?;
         if let Err(e) = self.ns.adapter.broadcast(packet, self.opts) {
             #[cfg(feature = "tracing")]
@@ -390,7 +786,12 @@ impl<A: Adapter> Operators<A> {
         data: impl serde::Serialize,
     ) -> Result<AckStream<V>, serde_json::Error> {
         let packet = self.get_packet(event, data)?;
-        Ok(self.ns.adapter.broadcast_with_ack(packet, self.opts).into())
+        let stream = self
+            .ns
+            .adapter
+            .broadcast_with_ack(packet, self.opts, self.timeout)
+            .into();
+        Ok(stream)
     }
 
     /// Gets all sockets selected with the previous operators.
@@ -430,11 +831,6 @@ impl<A: Adapter> Operators<A> {
         self.ns.adapter.disconnect_socket(self.opts)
     }
 
-    /// Gets a [`SocketRef`] by the specified [`Sid`].
-    pub fn get_socket(&self, sid: Sid) -> Option<SocketRef<A>> {
-        self.ns.get_socket(sid).map(SocketRef::from).ok()
-    }
-
     /// Makes all sockets selected with the previous operators join the given room(s).
     ///
     /// ### Example
@@ -472,6 +868,11 @@ impl<A: Adapter> Operators<A> {
         self.ns.adapter.rooms()
     }
 
+    /// Gets a [`SocketRef`] by the specified [`Sid`].
+    pub fn get_socket(&self, sid: Sid) -> Option<SocketRef<A>> {
+        self.ns.get_socket(sid).map(SocketRef::from).ok()
+    }
+
     /// Creates a packet with the given event and data.
     fn get_packet(
         &mut self,
@@ -487,13 +888,5 @@ impl<A: Adapter> Operators<A> {
             Packet::bin_event(ns, event.into(), data, binary)
         };
         Ok(packet)
-    }
-}
-
-#[cfg(feature = "test-utils")]
-impl<A: Adapter> Operators<A> {
-    #[allow(dead_code)]
-    pub(crate) fn is_broadcast(&self) -> bool {
-        self.opts.flags.contains(&BroadcastFlags::Broadcast)
     }
 }

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -312,11 +312,11 @@ impl<A: Adapter> Operators<A> {
     ///         socket.to("room2").emit("test", [arr]).ok();
     ///     });
     /// });
-    pub fn emit(
+    pub fn emit<T: serde::Serialize>(
         mut self,
         event: impl Into<Cow<'static, str>>,
-        data: impl serde::Serialize,
-    ) -> Result<(), BroadcastError> {
+        data: T,
+    ) -> Result<(), BroadcastError<()>> {
         let packet = self.get_packet(event, data)?;
         if let Err(e) = self.ns.adapter.broadcast(packet, self.opts) {
             #[cfg(feature = "tracing")]

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -111,8 +111,10 @@ pub struct BroadcastOperators<A: Adapter = LocalAdapter> {
 
 impl<A: Adapter> From<ConfOperators<'_, A>> for BroadcastOperators<A> {
     fn from(conf: ConfOperators<'_, A>) -> Self {
-        let mut opts = BroadcastOptions::default();
-        opts.sid = Some(conf.socket.id);
+        let opts = BroadcastOptions {
+			sid: Some(conf.socket.id),
+			..Default::default()
+		};
         Self {
             binary: conf.binary,
             timeout: conf.timeout,

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -330,10 +330,10 @@ impl<A: Adapter> ConfOperators<'_, A> {
     /// io.ns("/", |socket: SocketRef| {
     ///     socket.on("test", |socket: SocketRef, Data::<Value>(data), Bin(bin)| async move {
     ///          // Emit a test message to the client
-    ///         socket.bin(bin).emit("test", data).ok();
+    ///         socket.bin(bin.clone()).emit("test", data).ok();
     ///
     ///         // Emit a test message with multiple arguments to the client
-    ///         socket.bin(bin).emit("test", ("world", "hello", 1)).ok();
+    ///         socket.bin(bin.clone()).emit("test", ("world", "hello", 1)).ok();
     ///
     ///         // Emit a test message with an array as the first argument
     ///         let arr = [1, 2, 3, 4];

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -394,7 +394,7 @@ impl<A: Adapter> ConfOperators<'_, A> {
     /// io.ns("/", |socket: SocketRef| {
     ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
     ///         // Emit a test message and wait for an acknowledgement with the timeout specified in the config
-    ///         match socket.emit_with_ack::<Value>("test", data).unwrap().await {
+    ///         match socket.emit_with_ack::<_, Value>("test", data).unwrap().await {
     ///             Ok(ack) => println!("Ack received {:?}", ack),
     ///             Err(err) => println!("Ack error {:?}", err),
     ///         }

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -238,7 +238,7 @@ impl<'a> PacketData<'a> {
         )
     }
 
-	/// Get the number of binary payloads or 0 if it is not a binary packet
+    /// Get the number of binary payloads or 0 if it is not a binary packet
     pub(crate) fn payload_count(&self) -> usize {
         match self {
             PacketData::BinaryEvent(_, bin, _) | PacketData::BinaryAck(bin, _) => bin.payload_count,

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -237,6 +237,14 @@ impl<'a> PacketData<'a> {
             PacketData::BinaryEvent(_, _, _) | PacketData::BinaryAck(_, _)
         )
     }
+
+	/// Get the number of binary payloads or 0 if it is not a binary packet
+    pub(crate) fn payload_count(&self) -> usize {
+        match self {
+            PacketData::BinaryEvent(_, bin, _) | PacketData::BinaryAck(bin, _) => bin.payload_count,
+            _ => 0,
+        }
+    }
 }
 
 impl BinaryPacket {

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -367,7 +367,7 @@ impl<A: Adapter> Socket<A> {
     /// io.ns("/", |socket: SocketRef| {
     ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
     ///         // Emit a test message and wait for an acknowledgement with the timeout specified in the config
-    ///         match socket.emit_with_ack::<Value>("test", data).unwrap().await {
+    ///         match socket.emit_with_ack::<_, Value>("test", data).unwrap().await {
     ///             Ok(ack) => println!("Ack received {:?}", ack),
     ///             Err(err) => println!("Ack error {:?}", err),
     ///         }
@@ -805,7 +805,6 @@ impl<A: Adapter> Socket<A> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::AckError;
 
     #[tokio::test]
     async fn send_with_ack_error() {
@@ -819,13 +818,10 @@ mod test {
                 .unwrap();
         }
 
-        let ack = socket
-            .emit_with_ack::<_, Value>("test", Value::Null)
-            .unwrap()
-            .await;
+        let ack = socket.emit_with_ack::<_, Value>("test", Value::Null);
         assert!(matches!(
             ack,
-            Err(AckError::Socket(SocketError::InternalChannelFull(_)))
+            Err(SendError::Socket(SocketError::InternalChannelFull(_)))
         ));
     }
 }

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -624,7 +624,7 @@ impl<A: Adapter> Socket<A> {
         Ok(self.esocket.reserve(n)?)
     }
 
-    pub(crate) fn send(&self, mut packet: Packet<'_>) -> Result<(), SocketError<()>> {
+    pub(crate) fn send(&self, packet: Packet<'_>) -> Result<(), SocketError<()>> {
         let permits = self.reserve(1 + packet.inner.payload_count())?;
         permits.emit(packet);
         Ok(())

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -633,7 +633,6 @@ impl<A: Adapter> Socket<A> {
         &self.ns.path
     }
 
-    #[inline]
     pub(crate) fn reserve(&self, n: usize) -> Result<PermitIterator<'_>, SocketError<()>> {
         Ok(self.esocket.reserve(n)?)
     }

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -663,7 +663,7 @@ impl<A: Adapter> Socket<A> {
                 self.ack_message.lock().unwrap().insert(ack, tx);
             }
             Err(e) => {
-                tx.send(Err(AckError::Socket(e.into()))).ok();
+                tx.send(Err(AckError::Socket(e))).ok();
             }
         }
         rx

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -553,8 +553,8 @@ impl<A: Adapter> Socket<A> {
     ///    });
     /// });
     ///
-    pub fn timeout(self: Arc<Self>, timeout: Duration) -> ConfOperators<A> {
-        ConfOperators::new(self.clone()).timeout(timeout)
+    pub fn timeout(&self, timeout: Duration) -> ConfOperators<'_, A> {
+        ConfOperators::new(self).timeout(timeout)
     }
 
     /// Adds a binary payload to the message.
@@ -570,8 +570,8 @@ impl<A: Adapter> Socket<A> {
     ///         socket.bin(bin).emit("test", data);
     ///     });
     /// });
-    pub fn bin(self: Arc<Self>, binary: Vec<Vec<u8>>) -> ConfOperators<A> {
-        ConfOperators::new(self.clone()).bin(binary)
+    pub fn bin(&self, binary: Vec<Vec<u8>>) -> ConfOperators<'_, A> {
+        ConfOperators::new(self).bin(binary)
     }
 
     /// Broadcasts to all clients without any filtering (except the current socket).

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -279,12 +279,15 @@ impl<A: Adapter> Socket<A> {
     /// ## Errors
     /// * When encoding the data into JSON a [`SendError::Serialize`] may be returned.
     /// * If the underlying engine.io connection is closed a [`SendError::Socket(SocketError::Closed)`]
-    /// will be returned.
+    /// will be returned and the provided data to be send will be given back in the error.
     /// * If the packet buffer is full, a [`SendError::Socket(SocketError::InternalChannelFull)`]
-    /// will be returned.
+    /// will be returned and the provided data to be send will be given back in the error.
     /// See [`SocketIoBuilder::max_buffer_size`] option for more infos on internal buffer config
     ///
     /// [`SocketIoBuilder::max_buffer_size`]: crate::SocketIoBuilder#method.max_buffer_size
+    /// [`SendError::Serialize`]: crate::SendError::Serialize
+    /// [`SendError::Socket(SocketError::Closed)`]: crate::SocketError::Closed
+    /// [`SendError::Socket(SocketError::InternalChannelFull)`]: crate::SocketError::InternalChannelFull
     /// ## Example
     /// ```
     /// # use socketioxide::{SocketIo, extract::*};
@@ -338,10 +341,12 @@ impl<A: Adapter> Socket<A> {
     /// * As a [`Future`]: It will yield the first [`AckResponse`] received from the client.
     /// Useful when expecting only one acknowledgement.
     ///
+    /// # Errors
+    ///
     /// If the packet encoding failed a [`serde_json::Error`] is **immediately** returned.
     ///
     /// If the socket is full or if it has been closed before receiving the acknowledgement,
-    /// an [`AckError::Socket`] will be yielded.
+    /// an [`SendError::Socket`] will be **immediately returned** and the value to send will be given back.
     ///
     /// If the client didn't respond before the timeout, the [`AckStream`] will yield
     /// an [`AckError::Timeout`]. If the data sent by the client is not deserializable as `V`,
@@ -697,7 +702,7 @@ impl<A: Adapter> Socket<A> {
 
     /// Gets the request info made by the client to connect
     ///
-    /// It might be used to retrieve the [`http::request::Extensions`]
+    /// It might be used to retrieve the [`http::Extensions`]
     pub fn req_parts(&self) -> &http::request::Parts {
         &self.esocket.req_parts
     }

--- a/socketioxide/tests/acknowledgement.rs
+++ b/socketioxide/tests/acknowledgement.rs
@@ -20,7 +20,7 @@ pub async fn emit_with_ack() {
     let (tx, mut rx) = mpsc::channel::<[String; 1]>(4);
 
     io.ns("/", move |s: SocketRef| async move {
-        let res = assert_ok!(s.emit_with_ack::<[String; 1]>("test", "foo")).await;
+        let res = assert_ok!(s.emit_with_ack::<_, [String; 1]>("test", "foo")).await;
         let ack = assert_ok!(res);
         assert_ok!(tx.try_send(ack.data));
 

--- a/socketioxide/tests/acknowledgement.rs
+++ b/socketioxide/tests/acknowledgement.rs
@@ -26,7 +26,7 @@ pub async fn emit_with_ack() {
 
         let res = s
             .timeout(Duration::from_millis(500))
-            .emit_with_ack::<[String; 1]>("test", "foo");
+            .emit_with_ack::<_, [String; 1]>("test", "foo");
         let res = assert_ok!(res).await;
         let ack = assert_ok!(res);
         assert_ok!(tx.try_send(ack.data));


### PR DESCRIPTION
## Fix #172

> There are two remaining questions :
> * What should be done with binary packets. Because a message can contain N binary payloads it means that we would need N+1 Permits for each emit call.
> * What should be done when broadcasting. What is the performance cost of asking X Permits from N sockets at the same time ? Because packet is encoded only once and then cloned many times to be sent. Maybe it would be better to just clone the data before sending anything so it is possible to send it back to the user.
Also broadcasting is done through Operators, and Operators are not always used to broadcast, they can be used to simply add a timeout or a binary payload when emitting. So the emit signature needs to be the same from the Operator fn even if it is not broadcasting.

* The new `reserve_many` API on tokio `v1.36` resolves the first question.
* The second problem still needs to be resolved.