### PR TITLE
chore(deps): bump to v0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.11.0
+## socketioxide
+* fix: a panic was raised sometimes under heavy traffic with socketio v5 when the connect timeout handler is destroyed but that the chan sender is still alive.
+* **(Breaking)**: Emit errors now contains the provided data if there is an issue with the internal channel (for example if it is full) or if the socket closed.
+* **(Breaking)**: Operators are now splitted between `Operators` and `BroadcastOperators` in order to split logic and fn signatures between broadcast and non-broadcast operators.
+
+## engineioxide
+* fix #277: with engine.io v3, the message byte prefix `0x4` was not added to the binary payload with `ws` transport.
+* bump dependency `base64` to 0.22.0.
+
 # 0.10.2
 ## socketioxide
 * New [`rooms`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIo.html#method.rooms) fn to get all the rooms of a namespace.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.67.0"
 authors = ["Théodore Prévot <"]
@@ -7,9 +7,9 @@ repository = "https://github.com/totodore/socketioxide"
 homepage = "https://github.com/totodore/socketioxide"
 keywords = ["socketio", "tower", "axum", "hyper", "websocket"]
 categories = [
-    "asynchronous",
-    "network-programming",
-    "web-programming::websocket",
+	"asynchronous",
+	"network-programming",
+	"web-programming::websocket",
 ]
 license = "MIT"
 

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.10.2" }
+engineioxide = { path = "../engineioxide", version = "0.11.0" }
 futures.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 serde.workspace = true
@@ -45,18 +45,18 @@ state = ["dep:state"]
 
 [dev-dependencies]
 engineioxide = { path = "../engineioxide", features = [
-    "v3",
-    "tracing",
-    "test-utils",
+	"v3",
+	"tracing",
+	"test-utils",
 ] }
 tokio-tungstenite.workspace = true
 rust_socketio.workspace = true
 axum.workspace = true
 salvo.workspace = true
 tokio = { workspace = true, features = [
-    "macros",
-    "parking_lot",
-    "rt-multi-thread",
+	"macros",
+	"parking_lot",
+	"rt-multi-thread",
 ] }
 tracing-subscriber.workspace = true
 criterion.workspace = true


### PR DESCRIPTION
# Changelog
## socketioxide
* fix: a panic was raised sometimes under heavy traffic with socketio v5 when the connect timeout handler is destroyed but that the chan sender is still alive.
* **(Breaking)**: Emit errors now contains the provided data if there is an issue with the internal channel (for example if it is full) or if the socket closed.
* **(Breaking)**: Operators are now splitted between `Operators` and `BroadcastOperators` in order to split logic and fn signatures between broadcast and non-broadcast operators.

## engineioxide
* fix #277: with engine.io v3, the message byte prefix `0x4` was not added to the binary payload with `ws` transport.
* bump dependency `base64` to 0.22.0.