### PR TITLE
wip: integrate binary data into payloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default-members = ["engineioxide", "socketioxide"]
 resolver = "2"
 
 [workspace.dependencies]
+bytes = { version = "1.4.0", features = ["serde"] }
 futures = "0.3.27"
 tokio = "1.35.0"
 tokio-tungstenite = "0.21.0"

--- a/README.md
+++ b/README.md
@@ -123,31 +123,31 @@ io.ns("/", |s: SocketRef| {
 
 ```rust
 use axum::routing::get;
-use serde_json::Value;
 use socketioxide::{
-    extract::{AckSender, Bin, Data, SocketRef},
+    extract::{AckSender, Data, SocketRef},
+    PayloadValue,
     SocketIo,
 };
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
     socket.emit("auth", data).ok();
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<Value>(data), Bin(bin)| {
+        |socket: SocketRef, Data::<PayloadValue>(data)| {
             info!("Received event: {:?} {:?}", data, bin);
-            socket.bin(bin).emit("message-back", data).ok();
+            socket.emit("message-back", data).ok();
         },
     );
 
     socket.on(
         "message-with-ack",
-        |Data::<Value>(data), ack: AckSender, Bin(bin)| {
+        |ack: AckSender, Data::<PayloadValue>(data)| {
             info!("Received event: {:?} {:?}", data, bin);
-            ack.bin(bin).send(data).ok();
+            ack.send(data).ok();
         },
     );
 }

--- a/e2e/socketioxide/socketioxide.rs
+++ b/e2e/socketioxide/socketioxide.rs
@@ -27,7 +27,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     // keep this handler async to test async message handlers
     socket.on(
         "message-with-ack",
-        |Data::<PayloadValue>(data), ack: AckSender| async move {
+        |ack: AckSender, Data::<PayloadValue>(data)| async move {
             info!("Received event: {:?}", data);
             ack.send(data).ok();
         },

--- a/e2e/socketioxide/socketioxide.rs
+++ b/e2e/socketioxide/socketioxide.rs
@@ -4,46 +4,44 @@ use std::time::Duration;
 
 use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
-use serde_json::Value;
 use socketioxide::{
-    extract::{AckSender, Bin, Data, SocketRef},
-    SocketIo,
+    extract::{AckSender, Data, SocketRef},
+    PayloadValue, SocketIo,
 };
 use tokio::net::TcpListener;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
     socket.emit("auth", data).ok();
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<Value>(data), Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            socket.bin(bin).emit("message-back", data).ok();
+        |socket: SocketRef, Data::<PayloadValue>(data)| {
+            info!("Received event: {:?}", data);
+            socket.emit("message-back", data).ok();
         },
     );
 
     // keep this handler async to test async message handlers
     socket.on(
         "message-with-ack",
-        |Data::<Value>(data), ack: AckSender, Bin(bin)| async move {
-            info!("Received event: {:?} {:?}", data, bin);
-            ack.bin(bin).send(data).ok();
+        |Data::<PayloadValue>(data), ack: AckSender| async move {
+            info!("Received event: {:?}", data);
+            ack.send(data).ok();
         },
     );
 
     socket.on(
         "emit-with-ack",
-        |s: SocketRef, Data::<Value>(data), Bin(bin)| async move {
+        |s: SocketRef, Data::<PayloadValue>(data)| async move {
             let ack = s
-                .bin(bin)
-                .emit_with_ack::<_, Value>("emit-with-ack", data)
+                .emit_with_ack::<_, PayloadValue>("emit-with-ack", data)
                 .unwrap()
                 .await
                 .unwrap();
-            s.bin(ack.binary).emit("emit-with-ack", ack.data).unwrap();
+            s.emit("emit-with-ack", ack.data).unwrap();
         },
     );
 }

--- a/engineioxide/Cargo.toml
+++ b/engineioxide/Cargo.toml
@@ -19,6 +19,7 @@ features = ["v3"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+bytes.workspace = true
 futures.workspace = true
 http.workspace = true
 http-body.workspace = true
@@ -34,7 +35,6 @@ pin-project-lite.workspace = true
 hyper-util = { workspace = true, features = ["tokio"] }
 
 base64 = "0.22.0"
-bytes = "1.4.0"
 rand = "0.8.5"
 
 # Tracing

--- a/examples/angular-todomvc/src/main.rs
+++ b/examples/angular-todomvc/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         s.on(
             "update-store",
-            |s: SocketRef, Data::<Vec<Todo>>(new_todos), State(Todos(todos))| {
+            |s: SocketRef, State(Todos(todos)), Data::<Vec<Todo>>(new_todos)| {
                 info!("Received update-store event: {:?}", new_todos);
 
                 let mut todos = todos.lock().unwrap();

--- a/examples/axum-echo-tls/axum_echo-tls.rs
+++ b/examples/axum-echo-tls/axum_echo-tls.rs
@@ -23,7 +23,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
 
     socket.on(
         "message-with-ack",
-        |Data::<PayloadValue>(data), ack: AckSender| {
+        |ack: AckSender, Data::<PayloadValue>(data)| {
             info!("Received event: {:?}", data);
             ack.send(data).ok();
         },

--- a/examples/axum-echo-tls/axum_echo-tls.rs
+++ b/examples/axum-echo-tls/axum_echo-tls.rs
@@ -2,31 +2,30 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use axum::routing::get;
 use axum_server::tls_rustls::RustlsConfig;
-use serde_json::Value;
 use socketioxide::{
-    extract::{AckSender, Bin, Data, SocketRef},
-    SocketIo,
+    extract::{AckSender, Data, SocketRef},
+    PayloadValue, SocketIo,
 };
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
     socket.emit("auth", data).ok();
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<Value>(data), Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            socket.bin(bin).emit("message-back", data).ok();
+        |socket: SocketRef, Data::<PayloadValue>(data)| {
+            info!("Received event: {:?}", data);
+            socket.emit("message-back", data).ok();
         },
     );
 
     socket.on(
         "message-with-ack",
-        |Data::<Value>(data), ack: AckSender, Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            ack.bin(bin).send(data).ok();
+        |Data::<PayloadValue>(data), ack: AckSender| {
+            info!("Received event: {:?}", data);
+            ack.send(data).ok();
         },
     );
 }

--- a/examples/axum-echo/axum_echo.rs
+++ b/examples/axum-echo/axum_echo.rs
@@ -20,7 +20,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
 
     socket.on(
         "message-with-ack",
-        |Data::<PayloadValue>(data), ack: AckSender| {
+        |ack: AckSender, Data::<PayloadValue>(data)| {
             info!("Received event: {:?}", data);
             ack.send(data).ok();
         },

--- a/examples/axum-echo/axum_echo.rs
+++ b/examples/axum-echo/axum_echo.rs
@@ -1,29 +1,28 @@
 use axum::routing::get;
-use serde_json::Value;
 use socketioxide::{
-    extract::{AckSender, Bin, Data, SocketRef},
-    SocketIo,
+    extract::{AckSender, Data, SocketRef},
+    PayloadValue, SocketIo,
 };
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
     socket.emit("auth", data).ok();
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<Value>(data), Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            socket.bin(bin).emit("message-back", data).ok();
+        |socket: SocketRef, Data::<PayloadValue>(data)| {
+            info!("Received event: {:?}", data);
+            socket.emit("message-back", data).ok();
         },
     );
 
     socket.on(
         "message-with-ack",
-        |Data::<Value>(data), ack: AckSender, Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            ack.bin(bin).send(data).ok();
+        |Data::<PayloadValue>(data), ack: AckSender| {
+            info!("Received event: {:?}", data);
+            ack.send(data).ok();
         },
     );
 }

--- a/examples/background-task/src/main.rs
+++ b/examples/background-task/src/main.rs
@@ -1,7 +1,6 @@
-use serde_json::Value;
 use socketioxide::{
     extract::{Data, SocketRef},
-    SocketIo,
+    PayloadValue, SocketIo,
 };
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
@@ -31,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (layer, io) = SocketIo::new_layer();
 
-    io.ns("/", |s: SocketRef, Data::<Value>(data)| {
+    io.ns("/", |s: SocketRef, Data::<PayloadValue>(data)| {
         info!("Received: {:?}", data);
         s.emit("welcome", data).ok();
     });

--- a/examples/basic-crud-application/src/handlers/todo.rs
+++ b/examples/basic-crud-application/src/handlers/todo.rs
@@ -41,7 +41,7 @@ impl Todos {
     }
 }
 
-pub fn create(s: SocketRef, Data(data): Data<PartialTodo>, ack: AckSender, todos: State<Todos>) {
+pub fn create(s: SocketRef, ack: AckSender, todos: State<Todos>, Data(data): Data<PartialTodo>) {
     let id = Uuid::new_v4();
     let todo = Todo { id, inner: data };
 
@@ -53,12 +53,12 @@ pub fn create(s: SocketRef, Data(data): Data<PartialTodo>, ack: AckSender, todos
     s.broadcast().emit("todo:created", todo).ok();
 }
 
-pub async fn read(Data(id): Data<Uuid>, ack: AckSender, todos: State<Todos>) {
+pub async fn read(ack: AckSender, todos: State<Todos>, Data(id): Data<Uuid>) {
     let todo = todos.get(&id).ok_or(Error::NotFound);
     ack.send(todo).ok();
 }
 
-pub async fn update(s: SocketRef, Data(data): Data<Todo>, ack: AckSender, todos: State<Todos>) {
+pub async fn update(s: SocketRef, ack: AckSender, todos: State<Todos>, Data(data): Data<Todo>) {
     let res = todos
         .get_mut(&data.id)
         .ok_or(Error::NotFound)
@@ -70,7 +70,7 @@ pub async fn update(s: SocketRef, Data(data): Data<Todo>, ack: AckSender, todos:
     ack.send(res).ok();
 }
 
-pub async fn delete(s: SocketRef, Data(id): Data<Uuid>, ack: AckSender, todos: State<Todos>) {
+pub async fn delete(s: SocketRef, ack: AckSender, todos: State<Todos>, Data(id): Data<Uuid>) {
     let res = todos.remove(&id).ok_or(Error::NotFound).map(|_| {
         s.broadcast().emit("todo:deleted", id).ok();
     });

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         s.on(
             "add user",
-            |s: SocketRef, Data::<String>(username), user_cnt: State<UserCnt>| {
+            |s: SocketRef, user_cnt: State<UserCnt>, Data::<String>(username)| {
                 if s.extensions.get::<Username>().is_some() {
                     return;
                 }

--- a/examples/hyper-echo/hyper_echo.rs
+++ b/examples/hyper-echo/hyper_echo.rs
@@ -24,7 +24,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
 
     socket.on(
         "message-with-ack",
-        |Data::<PayloadValue>(data), ack: AckSender| {
+        |ack: AckSender, Data::<PayloadValue>(data)| {
             info!("Received event: {:?}", data);
             ack.send(data).ok();
         },

--- a/examples/hyper-echo/hyper_echo.rs
+++ b/examples/hyper-echo/hyper_echo.rs
@@ -2,32 +2,31 @@ use std::net::SocketAddr;
 
 use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
-use serde_json::Value;
 use socketioxide::{
-    extract::{AckSender, Bin, Data, SocketRef},
-    SocketIo,
+    extract::{AckSender, Data, SocketRef},
+    PayloadValue, SocketIo,
 };
 use tokio::net::TcpListener;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
     socket.emit("auth", data).ok();
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<Value>(data), Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            socket.bin(bin).emit("message-back", data).ok();
+        |socket: SocketRef, Data::<PayloadValue>(data)| {
+            info!("Received event: {:?}", data);
+            socket.emit("message-back", data).ok();
         },
     );
 
     socket.on(
         "message-with-ack",
-        |Data::<Value>(data), ack: AckSender, Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            ack.bin(bin).send(data).ok();
+        |Data::<PayloadValue>(data), ack: AckSender| {
+            info!("Received event: {:?}", data);
+            ack.send(data).ok();
         },
     );
 }

--- a/examples/loco-rooms-chat/src/channels/application.rs
+++ b/examples/loco-rooms-chat/src/channels/application.rs
@@ -18,7 +18,7 @@ pub async fn on_connect(socket: SocketRef) {
 
     socket.on(
         "join",
-        |socket: SocketRef, Data::<String>(room), store: State<state::MessageStore>| async move {
+        |socket: SocketRef, store: State<state::MessageStore>, Data::<String>(room)| async move {
             tracing::info!("Received join: {:?}", room);
             let _ = socket.leave_all();
             let _ = socket.join(room.clone());
@@ -29,7 +29,7 @@ pub async fn on_connect(socket: SocketRef) {
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<MessageIn>(data), store: State<state::MessageStore>| async move {
+        |socket: SocketRef, store: State<state::MessageStore>, Data::<MessageIn>(data)| async move {
             tracing::info!("Received message: {:?}", data);
 
             let response = state::Message {

--- a/examples/private-messaging/src/handlers.rs
+++ b/examples/private-messaging/src/handlers.rs
@@ -53,7 +53,7 @@ pub fn on_connection(
 
     s.on(
         "private message",
-        |s: SocketRef, Data(PrivateMessageReq { to, content }), State(Messages(msg))| {
+        |s: SocketRef, State(Messages(msg)), Data(PrivateMessageReq { to, content })| {
             let user_id = s.extensions.get::<Session>().unwrap().user_id;
             let message = Message {
                 from: user_id,

--- a/examples/react-rooms-chat/src/main.rs
+++ b/examples/react-rooms-chat/src/main.rs
@@ -27,7 +27,7 @@ async fn on_connect(socket: SocketRef) {
 
     socket.on(
         "join",
-        |socket: SocketRef, Data::<String>(room), store: State<state::MessageStore>| async move {
+        |socket: SocketRef, store: State<state::MessageStore>, Data::<String>(room)| async move {
             info!("Received join: {:?}", room);
             let _ = socket.leave_all();
             let _ = socket.join(room.clone());
@@ -38,7 +38,7 @@ async fn on_connect(socket: SocketRef) {
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<MessageIn>(data), store: State<state::MessageStore>| async move {
+        |socket: SocketRef, store: State<state::MessageStore>, Data::<MessageIn>(data)| async move {
             info!("Received message: {:?}", data);
 
             let response = state::Message {

--- a/examples/salvo-echo/salvo_echo.rs
+++ b/examples/salvo-echo/salvo_echo.rs
@@ -23,7 +23,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
 
     socket.on(
         "message-with-ack",
-        |Data::<PayloadValue>(data), ack: AckSender| {
+        |ack: AckSender, Data::<PayloadValue>(data)| {
             info!("Received event: {:?}", data);
             ack.send(data).ok();
         },

--- a/examples/salvo-echo/salvo_echo.rs
+++ b/examples/salvo-echo/salvo_echo.rs
@@ -1,8 +1,7 @@
 use salvo::prelude::*;
-use serde_json::Value;
 use socketioxide::{
-    extract::{AckSender, Bin, Data, SocketRef},
-    SocketIo,
+    extract::{AckSender, Data, SocketRef},
+    PayloadValue, SocketIo,
 };
 
 use tower::ServiceBuilder;
@@ -10,23 +9,23 @@ use tower_http::cors::CorsLayer;
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
     socket.emit("auth", data).ok();
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<Value>(data), Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            socket.bin(bin).emit("message-back", data).ok();
+        |socket: SocketRef, Data::<PayloadValue>(data)| {
+            info!("Received event: {:?}", data);
+            socket.emit("message-back", data).ok();
         },
     );
 
     socket.on(
         "message-with-ack",
-        |Data::<Value>(data), ack: AckSender, Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            ack.bin(bin).send(data).ok();
+        |Data::<PayloadValue>(data), ack: AckSender| {
+            info!("Received event: {:?}", data);
+            ack.send(data).ok();
         },
     );
 }

--- a/examples/viz-echo/viz_echo.rs
+++ b/examples/viz-echo/viz_echo.rs
@@ -20,7 +20,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
 
     socket.on(
         "message-with-ack",
-        |Data::<PayloadValue>(data), ack: AckSender| {
+        |ack: AckSender, Data::<PayloadValue>(data)| {
             info!("Received event: {:?}", data);
             ack.send(data).ok();
         },

--- a/examples/viz-echo/viz_echo.rs
+++ b/examples/viz-echo/viz_echo.rs
@@ -1,29 +1,28 @@
-use serde_json::Value;
 use socketioxide::{
-    extract::{AckSender, Bin, Data, SocketRef},
-    SocketIo,
+    extract::{AckSender, Data, SocketRef},
+    PayloadValue, SocketIo,
 };
 use tracing::{error, info};
 use tracing_subscriber::FmtSubscriber;
 use viz::{handler::ServiceHandler, serve, Result, Router};
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+fn on_connect(socket: SocketRef, Data(data): Data<PayloadValue>) {
     info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
     socket.emit("auth", data).ok();
 
     socket.on(
         "message",
-        |socket: SocketRef, Data::<Value>(data), Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            socket.bin(bin).emit("message-back", data).ok();
+        |socket: SocketRef, Data::<PayloadValue>(data)| {
+            info!("Received event: {:?}", data);
+            socket.emit("message-back", data).ok();
         },
     );
 
     socket.on(
         "message-with-ack",
-        |Data::<Value>(data), ack: AckSender, Bin(bin)| {
-            info!("Received event: {:?} {:?}", data, bin);
-            ack.bin(bin).send(data).ok();
+        |Data::<PayloadValue>(data), ack: AckSender| {
+            info!("Received event: {:?}", data);
+            ack.send(data).ok();
         },
     );
 }

--- a/examples/whiteboard/src/main.rs
+++ b/examples/whiteboard/src/main.rs
@@ -1,7 +1,6 @@
-use serde_json::Value;
 use socketioxide::{
     extract::{Data, SocketRef},
-    SocketIo,
+    PayloadValue, SocketIo,
 };
 use tower::ServiceBuilder;
 use tower_http::{cors::CorsLayer, services::ServeDir};
@@ -19,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (layer, io) = SocketIo::new_layer();
 
     io.ns("/", |s: SocketRef| {
-        s.on("drawing", |s: SocketRef, Data::<Value>(data)| {
+        s.on("drawing", |s: SocketRef, Data::<PayloadValue>(data)| {
             s.broadcast().emit("drawing", data).unwrap();
         });
     });

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -14,6 +14,7 @@ readme = "../README.md"
 
 
 [dependencies]
+bytes.workspace = true
 engineioxide = { path = "../engineioxide", version = "0.11.0" }
 futures.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }

--- a/socketioxide/benches/packet_decode.rs
+++ b/socketioxide/benches/packet_decode.rs
@@ -1,8 +1,9 @@
+use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use engineioxide::sid::Sid;
 use socketioxide::{
     packet::{Packet, PacketData},
-    ProtocolVersion,
+    PayloadValue, ProtocolVersion,
 };
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Decode packet connect on /", |b| {
@@ -26,7 +27,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     const DATA: &str = r#"{"_placeholder":true,"num":0}"#;
     const BINARY: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     c.bench_function("Decode packet event on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet: String =
             Packet::event(black_box("/"), black_box("event"), black_box(data.clone()))
                 .try_into()
@@ -35,7 +36,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet event on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet: String = Packet::event(
             black_box("custom_nsp"),
             black_box("event"),
@@ -47,7 +48,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet event with ack on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet: Packet =
             Packet::event(black_box("/"), black_box("event"), black_box(data.clone()));
         match packet.inner {
@@ -59,7 +60,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet event with ack on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet = Packet::event(
             black_box("/custom_nsp"),
             black_box("event"),
@@ -75,7 +76,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet ack on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet: String = Packet::ack(black_box("/"), black_box(data.clone()), black_box(0))
             .try_into()
             .unwrap();
@@ -83,7 +84,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet ack on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet: String = Packet::ack(
             black_box("/custom_nsp"),
             black_box(data.clone()),
@@ -95,12 +96,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet binary event (b64) on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet: String = Packet::bin_event(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet: String = Packet::bin_event_with_payloads(
             black_box("/"),
             black_box("event"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         )
         .try_into()
         .unwrap();
@@ -108,12 +109,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet binary event (b64) on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet: String = Packet::bin_event(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet: String = Packet::bin_event_with_payloads(
             black_box("/custom_nsp"),
             black_box("event"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         )
         .try_into()
         .unwrap();
@@ -121,12 +122,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet binary ack (b64) on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet: String = Packet::bin_ack(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet: String = Packet::bin_ack_with_payloads(
             black_box("/"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
             black_box(0),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         )
         .try_into()
         .unwrap();
@@ -134,12 +135,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Decode packet binary ack (b64) on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet: String = Packet::bin_ack(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet: String = Packet::bin_ack_with_payloads(
             black_box("/custom_nsp"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
             black_box(0),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         )
         .try_into()
         .unwrap();

--- a/socketioxide/benches/packet_encode.rs
+++ b/socketioxide/benches/packet_encode.rs
@@ -1,8 +1,9 @@
+use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use engineioxide::sid::Sid;
 use socketioxide::{
     packet::{Packet, PacketData},
-    ProtocolVersion,
+    PayloadValue, ProtocolVersion,
 };
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Encode packet connect on /", |b| {
@@ -25,7 +26,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     const DATA: &str = r#"{"_placeholder":true,"num":0}"#;
     const BINARY: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     c.bench_function("Encode packet event on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet = Packet::event(black_box("/"), black_box("event"), black_box(data.clone()));
         b.iter(|| {
             let _: String = packet.clone().try_into().unwrap();
@@ -33,7 +34,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet event on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet = Packet::event(
             black_box("custom_nsp"),
             black_box("event"),
@@ -45,7 +46,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet event with ack on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet = Packet::event(black_box("/"), black_box("event"), black_box(data.clone()));
         match packet.inner {
             PacketData::Event(_, _, mut ack) => ack.insert(black_box(0)),
@@ -57,7 +58,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet event with ack on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet = Packet::event(
             black_box("/custom_nsp"),
             black_box("event"),
@@ -73,7 +74,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet ack on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet = Packet::ack(black_box("/"), black_box(data.clone()), black_box(0));
         b.iter(|| {
             let _: String = packet.clone().try_into().unwrap();
@@ -81,7 +82,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet ack on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
+        let data = PayloadValue::from_data(DATA).unwrap();
         let packet = Packet::ack(
             black_box("/custom_nsp"),
             black_box(data.clone()),
@@ -93,12 +94,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet binary event (b64) on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet = Packet::bin_event(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet = Packet::bin_event_with_payloads(
             black_box("/"),
             black_box("event"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         );
         b.iter(|| {
             let _: String = packet.clone().try_into().unwrap();
@@ -106,12 +107,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet binary event (b64) on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet = Packet::bin_event(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet = Packet::bin_event_with_payloads(
             black_box("/custom_nsp"),
             black_box("event"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         );
         b.iter(|| {
             let _: String = packet.clone().try_into().unwrap();
@@ -119,12 +120,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet binary ack (b64) on /", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet = Packet::bin_ack(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet = Packet::bin_ack_with_payloads(
             black_box("/"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
             black_box(0),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         );
         b.iter(|| {
             let _: String = packet.clone().try_into().unwrap();
@@ -132,12 +133,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("Encode packet binary ack (b64) on /custom_nsp", |b| {
-        let data = serde_json::to_value(DATA).unwrap();
-        let packet = Packet::bin_ack(
+        let data = PayloadValue::from_data(DATA).unwrap();
+        let packet = Packet::bin_ack_with_payloads(
             black_box("/custom_nsp"),
             black_box(data.clone()),
-            black_box(vec![BINARY.to_vec().clone()]),
             black_box(0),
+            black_box(vec![Bytes::from_static(&BINARY)]),
         );
         b.iter(|| {
             let _: String = packet.clone().try_into().unwrap();

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
+use bytes::Bytes;
 use engineioxide::handler::EngineIoHandler;
 use engineioxide::socket::{DisconnectReason as EIoDisconnectReason, Socket as EIoSocket};
 use futures::TryFutureExt;
@@ -242,7 +243,7 @@ impl<A: Adapter> EngineIoHandler for Client<A> {
     ///
     /// If the packet is complete, it is propagated to the namespace
     fn on_binary(&self, data: Vec<u8>, socket: Arc<EIoSocket<SocketData>>) {
-        if apply_payload_on_packet(data, &socket) {
+        if apply_payload_on_packet(data.into(), &socket) {
             if let Some(packet) = socket.data.partial_bin_packet.lock().unwrap().take() {
                 if let Err(ref err) = self.sock_propagate_packet(packet, socket.id) {
                     #[cfg(feature = "tracing")]
@@ -264,7 +265,7 @@ impl<A: Adapter> EngineIoHandler for Client<A> {
 /// waiting to be filled with all the payloads
 ///
 /// Returns true if the packet is complete and should be processed
-fn apply_payload_on_packet(data: Vec<u8>, socket: &EIoSocket<SocketData>) -> bool {
+fn apply_payload_on_packet(data: Bytes, socket: &EIoSocket<SocketData>) -> bool {
     #[cfg(feature = "tracing")]
     tracing::debug!("[sid={}] applying payload on packet", socket.id);
     if let Some(ref mut packet) = *socket.data.partial_bin_packet.lock().unwrap() {

--- a/socketioxide/src/errors.rs
+++ b/socketioxide/src/errors.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("invalid packet type")]
     InvalidPacketType,
 
+    #[error("invalid binary payload count")]
+    InvalidPayloadCount,
+
     #[error("invalid event name")]
     InvalidEventName,
 
@@ -165,9 +168,10 @@ impl From<&Error> for Option<EIoDisconnectReason> {
         use EIoDisconnectReason::*;
         match value {
             Error::SocketGone(_) => Some(TransportClose),
-            Error::Serialize(_) | Error::InvalidPacketType | Error::InvalidEventName => {
-                Some(PacketParsingError)
-            }
+            Error::Serialize(_)
+            | Error::InvalidPacketType
+            | Error::InvalidEventName
+            | Error::InvalidPayloadCount => Some(PacketParsingError),
             Error::Adapter(_) | Error::InvalidNamespace => None,
         }
     }

--- a/socketioxide/src/handler/message.rs
+++ b/socketioxide/src/handler/message.rs
@@ -29,9 +29,8 @@
 //!       ack.send("ack data").ok();
 //!     });
 //!
-//!     // `Bin` extractor must be the last argument because it consumes the rest of the packet
-//!     s.on("binary_event", |s: SocketRef, TryData::<String>(data), Bin(bin)| {
-//!       println!("Socket received event with data: {:?} and binary data: {:?}", data, bin);
+//!     s.on("binary_event", |s: SocketRef, TryData::<bytes::Bytes>(data)| {
+//!       println!("Socket received event with binary data: {:?}", data);
 //!     })
 //! });
 //! ```
@@ -47,9 +46,8 @@
 //!        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 //!        println!("Socket received event with data: {}", data);
 //!     });
-//!     // `Bin` extractor must be the last argument because it consumes the rest of the packet
-//!     s.on("/binary_event", move |s: SocketRef, TryData::<String>(data), Bin(bin)| async move {
-//!       println!("Socket received event with data: {:?} and binary data: {:?}", data, bin);
+//!     s.on("/binary_event", move |s: SocketRef, TryData::<bytes::Bytes>(data)| async move {
+//!       println!("Socket received event with binary data: {:?}", data);
 //!     })
 //! });
 //! ```
@@ -60,7 +58,7 @@
 //! # use serde_json::Error;
 //! # use socketioxide::extract::*;
 //! // async named event handler
-//! async fn on_event(s: SocketRef, Data(data): Data<PayloadValue>, ack: AckSender) {
+//! async fn on_event(s: SocketRef, ack: AckSender, Data(data): Data<PayloadValue>) {
 //!     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 //!     ack.send("Here is my acknowledgment!").ok();   
 //! }

--- a/socketioxide/src/handler/message.rs
+++ b/socketioxide/src/handler/message.rs
@@ -56,11 +56,11 @@
 //!
 //! ## Example with async non anonymous handler
 //! ```rust
-//! # use socketioxide::SocketIo;
+//! # use socketioxide::{PayloadValue, SocketIo};
 //! # use serde_json::Error;
 //! # use socketioxide::extract::*;
 //! // async named event handler
-//! async fn on_event(s: SocketRef, Data(data): Data<serde_json::PayloadValue>, ack: AckSender) {
+//! async fn on_event(s: SocketRef, Data(data): Data<PayloadValue>, ack: AckSender) {
 //!     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 //!     ack.send("Here is my acknowledgment!").ok();   
 //! }

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -283,7 +283,6 @@ impl<A: Adapter> SocketIo<A> {
     /// #### Example with a closure and an acknowledgement + binary data:
     /// ```
     /// # use socketioxide::{SocketIo, extract::*};
-    /// # use serde_json::Value;
     /// # use serde::{Serialize, Deserialize};
     /// #[derive(Debug, Serialize, Deserialize)]
     /// struct MyData {
@@ -296,10 +295,10 @@ impl<A: Adapter> SocketIo<A> {
     ///     // Register an async handler for the "test" event and extract the data as a `MyData` struct
     ///     // Extract the binary payload as a `Vec<Vec<u8>>` with the Bin extractor.
     ///     // It should be the last extractor because it consumes the request
-    ///     socket.on("test", |socket: SocketRef, Data::<MyData>(data), ack: AckSender, Bin(bin)| async move {
+    ///     socket.on("test", |socket: SocketRef, Data::<MyData>(data), ack: AckSender| async move {
     ///         println!("Received a test message {:?}", data);
     ///         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    ///         ack.bin(bin).send(data).ok(); // The data received is sent back to the client through the ack
+    ///         ack.send(data).ok(); // The data received is sent back to the client through the ack
     ///         socket.emit("test-test", MyData { name: "Test".to_string(), age: 8 }).ok(); // Emit a message to the client
     ///     });
     /// });
@@ -601,18 +600,16 @@ impl<A: Adapter> SocketIo<A> {
     ///
     /// # Example
     /// ```
-    /// # use socketioxide::{SocketIo, extract::*};
-    /// # use serde_json::Value;
+    /// # use socketioxide::{PayloadValue, SocketIo, extract::*};
     /// # use futures::stream::StreamExt;
     /// let (_, io) = SocketIo::new_svc();
     /// io.ns("/", |socket: SocketRef| {
-    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data), Bin(bin)| async move {
+    ///     socket.on("test", |socket: SocketRef, Data::<PayloadValue>(data)| async move {
     ///         // Emit a test message in the room1 and room3 rooms,
     ///         // except for the room2 room with the binary payload received
     ///         let ack_stream = socket.to("room1")
     ///             .to("room3")
     ///             .except("room2")
-    ///             .bin(bin)
     ///             .emit_with_ack::<String>("message-back", data)
     ///             .unwrap();
     ///

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -293,9 +293,8 @@ impl<A: Adapter> SocketIo<A> {
     /// let (_, io) = SocketIo::new_svc();
     /// io.ns("/", |socket: SocketRef| {
     ///     // Register an async handler for the "test" event and extract the data as a `MyData` struct
-    ///     // Extract the binary payload as a `Vec<Vec<u8>>` with the Bin extractor.
-    ///     // It should be the last extractor because it consumes the request
-    ///     socket.on("test", |socket: SocketRef, Data::<MyData>(data), ack: AckSender| async move {
+    ///     // `Data` should be the last extractor because it consumes the request
+    ///     socket.on("test", |socket: SocketRef, ack: AckSender, Data::<MyData>(data)| async move {
     ///         println!("Received a test message {:?}", data);
     ///         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     ///         ack.send(data).ok(); // The data received is sent back to the client through the ack

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -535,34 +535,6 @@ impl<A: Adapter> SocketIo<A> {
         self.get_default_op().timeout(timeout)
     }
 
-    /// Adds a binary payload to the message.
-    ///
-    /// Alias for `io.of("/").unwrap().bin(binary_payload)`
-    ///
-    /// ## Panics
-    /// If the **default namespace "/" is not found** this fn will panic!
-    ///
-    /// ## Example
-    /// ```
-    /// # use socketioxide::{SocketIo, extract::SocketRef};
-    /// # use serde_json::Value;
-    /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |socket: SocketRef| {
-    ///     println!("Socket connected on / namespace with id: {}", socket.id);
-    /// });
-    ///
-    /// // Later in your code you can emit a test message on the root namespace in the room1 and room3 rooms,
-    /// // except for the room2 with a binary payload
-    /// io.to("room1")
-    ///   .to("room3")
-    ///   .except("room2")
-    ///   .bin(vec![vec![1, 2, 3, 4]])
-    ///   .emit("test", ());
-    #[inline]
-    pub fn bin(&self, binary: Vec<Vec<u8>>) -> BroadcastOperators<A> {
-        self.get_default_op().bin(binary)
-    }
-
     /// Emits a message to all sockets selected with the previous operators.
     ///
     /// Alias for `io.of("/").unwrap().emit(event, data)`

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -275,11 +275,13 @@ pub use engineioxide::TransportType;
 pub use errors::{AckError, AdapterError, BroadcastError, DisconnectError, SendError, SocketError};
 pub use handler::extract;
 pub use io::{SocketIo, SocketIoBuilder, SocketIoConfig};
+pub use payload_value::PayloadValue;
 
 mod client;
 mod errors;
 mod io;
 mod ns;
+mod payload_value;
 
 /// Socket.IO protocol version.
 /// It is accessible with the [`Socket::protocol`](socket::Socket) method or as an extractor

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -199,7 +199,6 @@
 //! * rooms: emit, join, leave to specific rooms
 //! * namespace: emit to a specific namespace (only from the [`SocketIo`] handle)
 //! * timeout: set a custom timeout when waiting for an ack
-//! * binary: emit a binary payload with the message
 //! * local: broadcast only to the current node (in case of a cluster)
 //!
 //! Check the [`operators`] module doc for more details on operators.
@@ -271,6 +270,7 @@ pub mod packet;
 pub mod service;
 pub mod socket;
 
+pub use bytes::Bytes;
 pub use engineioxide::TransportType;
 pub use errors::{AckError, AdapterError, BroadcastError, DisconnectError, SendError, SocketError};
 pub use handler::extract;

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -152,7 +152,6 @@
 //!     - for [`ConnectHandler`](handler::ConnectHandler): extracts and deserialize to json the auth data
 //!     - for [`MessageHandler`](handler::MessageHandler): extracts and deserialize to json the message data
 //! * [`SocketRef`](extract::SocketRef): extracts a reference to the [`Socket`](socket::Socket)
-//! * [`Bin`](extract::Bin): extract a binary payload for a given message. Because it consumes the event it should be the last argument
 //! * [`AckSender`](extract::AckSender): Can be used to send an ack response to the current message event
 //! * [`ProtocolVersion`]: extracts the protocol version of the socket
 //! * [`TransportType`]: extracts the transport type of the socket
@@ -161,7 +160,7 @@
 //! ### Extractor order
 //! Extractors are run in the order of their declaration in the handler signature. If an extractor returns an error, the handler won't be called and a `tracing::error!` call will be emitted if the `tracing` feature is enabled.
 //!
-//! For the [`MessageHandler`](handler::MessageHandler), some extractors require to _consume_ the event and therefore only implement the [`FromMessage`](handler::FromMessage) trait, like the [`Bin`](extract::Bin) extractor, therefore they should be the last argument.
+//! For the [`MessageHandler`](handler::MessageHandler), some extractors require to _consume_ the event and therefore only implement the [`FromMessage`](handler::FromMessage) trait, like the [`Data`](extract::Data) extractor, therefore they should be the last argument.
 //!
 //! Note that any extractors that implement the [`FromMessageParts`](handler::FromMessageParts) also implement by default the [`FromMessage`](handler::FromMessage) trait.
 //!

--- a/socketioxide/src/operators.rs
+++ b/socketioxide/src/operators.rs
@@ -304,16 +304,16 @@ impl<A: Adapter> ConfOperators<'_, A> {
     /// # use socketioxide::{PayloadValue, SocketIo, extract::*};
     /// let (_, io) = SocketIo::new_svc();
     /// io.ns("/", |socket: SocketRef| {
-    ///     socket.on("test", |socket: SocketRef, Data::<PayloadValue>(data), Bin(bin)| async move {
-    ///          // Emit a test message to the client
-    ///         socket.emit("test", data).ok();
-    ///
-    ///         let bins: Vec<_> = bin
-    ///             .clone()
+    ///     socket.on("test", |socket: SocketRef, Data::<PayloadValue>(data)| async move {
+    ///         // Get all the binary payloads in the data
+    ///         let bins: Vec<_> = data.get_binary_payloads()
     ///             .into_iter()
     ///             .enumerate()
     ///             .map(|(i, bin)| PayloadValue::Binary(i, bin))
     ///             .collect();
+    ///
+    ///         // Emit a test message to the client
+    ///         socket.emit("test", data).ok();
     ///
     ///         // Emit a test message with multiple arguments to the client
     ///         let mut message: Vec<PayloadValue> = vec!["world".into(), "hello".into(), 1.into()];

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -102,6 +102,23 @@ impl<'a> Packet<'a> {
         }
     }
 
+    /// Create a binary event packet for the given namespace, with binary payloads
+    pub fn bin_event_with_payloads(
+        ns: impl Into<Cow<'a, str>>,
+        e: impl Into<Cow<'a, str>>,
+        data: PayloadValue,
+        bins: Vec<Bytes>,
+    ) -> Self {
+        let mut packet = BinaryPacket::outgoing(data);
+        for bin in bins {
+            packet.add_payload(bin);
+        }
+        Self {
+            inner: PacketData::BinaryEvent(e.into(), packet, None),
+            ns: ns.into(),
+        }
+    }
+
     /// Create an ack packet for the given namespace
     pub fn ack(ns: &'a str, data: PayloadValue, ack: i64) -> Self {
         Self {
@@ -113,6 +130,23 @@ impl<'a> Packet<'a> {
     /// Create a binary ack packet for the given namespace
     pub fn bin_ack(ns: &'a str, data: PayloadValue, ack: i64) -> Self {
         let packet = BinaryPacket::outgoing(data);
+        Self {
+            inner: PacketData::BinaryAck(packet, ack),
+            ns: Cow::Borrowed(ns),
+        }
+    }
+
+    /// Create a binary ack packet for the given namespace, with binary payloads
+    pub fn bin_ack_with_payloads(
+        ns: &'a str,
+        data: PayloadValue,
+        ack: i64,
+        bins: Vec<Bytes>,
+    ) -> Self {
+        let mut packet = BinaryPacket::outgoing(data);
+        for bin in bins {
+            packet.add_payload(bin);
+        }
         Self {
             inner: PacketData::BinaryAck(packet, ack),
             ns: Cow::Borrowed(ns),

--- a/socketioxide/src/payload_value/de.rs
+++ b/socketioxide/src/payload_value/de.rs
@@ -1,0 +1,936 @@
+use std::{borrow::Cow, collections::HashMap, marker::PhantomData, vec};
+
+use bytes::Bytes;
+use serde::{
+    de::{
+        self, DeserializeSeed, EnumAccess, Error, IntoDeserializer, MapAccess, SeqAccess,
+        Unexpected, VariantAccess,
+    },
+    forward_to_deserialize_any,
+};
+use serde_json::Number;
+
+use super::PayloadValue;
+
+// For Deserializer impl for PayloadValue
+macro_rules! impl_deser_number {
+    ($method:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: de::Visitor<'de>,
+        {
+            match self {
+                PayloadValue::Number(n) => n.$method(visitor),
+                _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+            }
+        }
+    };
+}
+
+// For Deserializer impl for MapKeyDeserializer
+macro_rules! impl_deser_numeric_key {
+    ($method:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: de::Visitor<'de>,
+        {
+            // This is less efficient than it could be, but `Deserializer::from_str()` (used
+            // internally by `serde_json`) wants to hold a reference to `self.key` longer than is
+            // permitted.  The methods on `Deserializer` for deserializing into a `Number` without
+            // that constraint are not exposed publicly.
+            let reader = VecRead::from(self.key);
+            let mut deser = serde_json::Deserializer::from_reader(reader);
+            let number = deser.$method(visitor)?;
+            let _ = deser
+                .end()
+                .map_err(|_| serde_json::Error::custom("expected numeric map key"))?;
+            Ok(number)
+        }
+    };
+}
+
+macro_rules! impl_visit_integer {
+    ($ty:ty, $fn:ident) => {
+        fn $fn<E>(self, v: $ty) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Ok(PayloadValue::Number(v.into()))
+        }
+    };
+}
+
+macro_rules! impl_visit_float {
+    ($ty:ty, $fn:ident) => {
+        fn $fn<E>(self, v: $ty) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Number::from_f64(v as f64)
+                .map(PayloadValue::Number)
+                .ok_or_else(|| {
+                    E::custom(format!(
+                        "float value '{}' could not be converted into a number",
+                        v
+                    ))
+                })
+        }
+    };
+}
+
+/// Helper struct that implements `std::io::Read`, which allows us to use
+/// `serde_json::Deserializer` to deserialize a string into a `serde_json::Number`.
+struct VecRead {
+    vec: Vec<u8>,
+    pos: usize,
+}
+
+impl<'any> From<Cow<'any, str>> for VecRead {
+    fn from(value: Cow<'any, str>) -> Self {
+        Self {
+            vec: value.to_string().into_bytes(),
+            pos: 0,
+        }
+    }
+}
+
+impl std::io::Read for VecRead {
+    fn read(&mut self, mut buf: &mut [u8]) -> std::io::Result<usize> {
+        use std::io::Write;
+
+        let to_write = std::cmp::min(buf.len(), self.vec.len() - self.pos);
+        if to_write > 0 {
+            let written = buf.write(&self.vec[self.pos..to_write])?;
+            self.pos += to_write;
+            Ok(written)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+impl PayloadValue {
+    fn unexpected(&self) -> Unexpected<'_> {
+        match self {
+            PayloadValue::Null => Unexpected::Unit,
+            PayloadValue::Bool(b) => Unexpected::Bool(*b),
+            PayloadValue::Number(n) => {
+                if let Some(n) = n.as_u64() {
+                    Unexpected::Unsigned(n)
+                } else if let Some(n) = n.as_i64() {
+                    Unexpected::Signed(n)
+                } else if let Some(n) = n.as_f64() {
+                    Unexpected::Float(n)
+                } else {
+                    Unexpected::Other("non-unsigned, non-signed, non-float number")
+                }
+            }
+            PayloadValue::String(s) => Unexpected::Str(s),
+            PayloadValue::Binary(_, data) => Unexpected::Bytes(data),
+            PayloadValue::Array(_) => Unexpected::Seq,
+            PayloadValue::Object(_) => Unexpected::Map,
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for PayloadValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let mut next_binary_payload_num: usize = 0;
+        let state = PayloadValueState(&mut next_binary_payload_num);
+        state.deserialize(deserializer)
+    }
+}
+
+struct PayloadValueState<'a>(&'a mut usize);
+
+impl<'de, 'a> serde::de::DeserializeSeed<'de> for PayloadValueState<'a> {
+    type Value = PayloadValue;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct PayloadValueVisitor<'a>(&'a mut usize);
+
+        impl<'de, 'a> de::Visitor<'de> for PayloadValueVisitor<'a> {
+            type Value = PayloadValue;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a json value")
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::Null)
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::Null)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(self)
+            }
+
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::Bool(v))
+            }
+
+            impl_visit_integer!(u8, visit_u8);
+            impl_visit_integer!(i8, visit_i8);
+            impl_visit_integer!(u16, visit_u16);
+            impl_visit_integer!(i16, visit_i16);
+            impl_visit_integer!(u32, visit_u32);
+            impl_visit_integer!(i32, visit_i32);
+            impl_visit_integer!(u64, visit_u64);
+            impl_visit_integer!(i64, visit_i64);
+            impl_visit_float!(f32, visit_f32);
+            impl_visit_float!(f64, visit_f64);
+
+            fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::String(v.into()))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::String(v.to_string()))
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::String(v.to_string()))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::String(v))
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::Binary(0, Bytes::copy_from_slice(v)))
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(PayloadValue::Binary(0, Bytes::copy_from_slice(v)))
+            }
+
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let num = *self.0;
+                *self.0 += 1;
+                Ok(PayloadValue::Binary(num, v.into()))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec = Vec::<PayloadValue>::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(element) = seq.next_element_seed(PayloadValueState(self.0))? {
+                    vec.push(element);
+                }
+                Ok(PayloadValue::Array(vec))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut hmap =
+                    HashMap::<String, PayloadValue>::with_capacity(map.size_hint().unwrap_or(0));
+                while let Some((key, value)) =
+                    map.next_entry_seed(PhantomData, PayloadValueState(self.0))?
+                {
+                    hmap.insert(key, value);
+                }
+
+                if hmap.len() == 2
+                    && hmap
+                        .get("_placeholder")
+                        .and_then(|pv| pv.as_bool())
+                        .unwrap_or(false)
+                {
+                    if let Some(num) = hmap.get("num").and_then(|pv| pv.as_u64()) {
+                        return Ok(PayloadValue::Binary(num as usize, Bytes::new()));
+                    }
+                }
+
+                Ok(PayloadValue::Object(hmap))
+            }
+        }
+
+        deserializer.deserialize_any(PayloadValueVisitor(self.0))
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for PayloadValue {
+    type Error = serde_json::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Null => visitor.visit_unit(),
+            PayloadValue::Bool(b) => visitor.visit_bool(b),
+            PayloadValue::Number(n) => n.deserialize_any(visitor),
+            PayloadValue::String(s) => visitor.visit_string(s),
+            PayloadValue::Binary(_, data) => visitor.visit_bytes(&data),
+            PayloadValue::Array(a) => visit_array(a, visitor),
+            PayloadValue::Object(o) => visit_object(o, visitor),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Null => visitor.visit_unit(),
+            _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Bool(b) => visitor.visit_bool(b),
+            _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+        }
+    }
+
+    impl_deser_number!(deserialize_i8);
+    impl_deser_number!(deserialize_i16);
+    impl_deser_number!(deserialize_i32);
+    impl_deser_number!(deserialize_i64);
+    impl_deser_number!(deserialize_i128);
+    impl_deser_number!(deserialize_u8);
+    impl_deser_number!(deserialize_u16);
+    impl_deser_number!(deserialize_u32);
+    impl_deser_number!(deserialize_u64);
+    impl_deser_number!(deserialize_u128);
+    impl_deser_number!(deserialize_f32);
+    impl_deser_number!(deserialize_f64);
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::String(s) => visitor.visit_string(s),
+            _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::String(s) => visitor.visit_string(s),
+            PayloadValue::Binary(_, data) => visitor.visit_bytes(&data),
+            PayloadValue::Array(a) => visit_array(a, visitor),
+            _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+        }
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_byte_buf(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Null => visitor.visit_none(),
+            other => visitor.visit_some(other),
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Array(a) => visit_array(a, visitor),
+            _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Object(o) => visit_object(o, visitor),
+            _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Object(o) => visit_object(o, visitor),
+            PayloadValue::Array(a) => visit_array(a, visitor),
+            _ => Err(serde_json::Error::invalid_type(self.unexpected(), &visitor)),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            PayloadValue::Object(o) => {
+                // From serde_json: enums are encoded as a map with _only_ a single key-value pair
+                if o.len() == 1 {
+                    let (variant, value) = o.into_iter().next().unwrap();
+                    visitor.visit_enum(EnumDeserializer::from((variant, Some(value))))
+                } else {
+                    Err(serde_json::Error::invalid_value(
+                        Unexpected::Map,
+                        &"a map with a single key-value pair",
+                    ))
+                }
+            }
+            PayloadValue::String(s) => visitor.visit_enum(EnumDeserializer::from((s, None))),
+            _ => Err(serde_json::Error::invalid_type(
+                self.unexpected(),
+                &"map or string",
+            )),
+        }
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        drop(self);
+        visitor.visit_unit()
+    }
+}
+
+fn visit_array<'de, V>(a: Vec<PayloadValue>, visitor: V) -> Result<V::Value, serde_json::Error>
+where
+    V: de::Visitor<'de>,
+{
+    let len = a.len();
+    let mut deser = SeqDeserializer::from(a);
+    let seq = visitor.visit_seq(&mut deser)?;
+    if deser.iter.len() == 0 {
+        Ok(seq)
+    } else {
+        Err(serde_json::Error::invalid_length(
+            len,
+            &"array with fewer elements",
+        ))
+    }
+}
+
+fn visit_object<'de, V>(
+    o: HashMap<String, PayloadValue>,
+    visitor: V,
+) -> Result<V::Value, serde_json::Error>
+where
+    V: de::Visitor<'de>,
+{
+    let len = o.len();
+    let mut deser = MapDeserializer::from(o);
+    let map = visitor.visit_map(&mut deser)?;
+    if deser.iter.len() == 0 {
+        Ok(map)
+    } else {
+        Err(serde_json::Error::invalid_length(
+            len,
+            &"map with fewer elements",
+        ))
+    }
+}
+
+struct SeqDeserializer {
+    iter: vec::IntoIter<PayloadValue>,
+}
+
+impl From<Vec<PayloadValue>> for SeqDeserializer {
+    fn from(value: Vec<PayloadValue>) -> Self {
+        Self {
+            iter: value.into_iter(),
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for SeqDeserializer {
+    type Error = serde_json::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (_, Some(upper)) => Some(upper),
+            (lower, _) if lower > 0 => Some(lower),
+            _ => None,
+        }
+    }
+}
+
+struct MapDeserializer {
+    iter: <HashMap<String, PayloadValue> as IntoIterator>::IntoIter,
+    next_value: Option<PayloadValue>,
+}
+
+impl From<HashMap<String, PayloadValue>> for MapDeserializer {
+    fn from(value: HashMap<String, PayloadValue>) -> Self {
+        Self {
+            iter: value.into_iter(),
+            next_value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for MapDeserializer {
+    type Error = serde_json::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.next_value = Some(value);
+                let deser = MapKeyDeserializer::from(key);
+                seed.deserialize(deser).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        match self.next_value.take() {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde_json::Error::custom(
+                "next_value() called before next_key()",
+            )),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (_, Some(upper)) => Some(upper),
+            (lower, _) if lower > 0 => Some(lower),
+            _ => None,
+        }
+    }
+}
+
+struct MapKeyDeserializer<'de> {
+    key: Cow<'de, str>,
+}
+
+impl<'de> From<String> for MapKeyDeserializer<'de> {
+    fn from(value: String) -> Self {
+        MapKeyDeserializer {
+            key: Cow::Owned(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
+    type Error = serde_json::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        MapKeyStrDeserializer::from(self.key).deserialize_any(visitor)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.key.as_ref() {
+            "true" => visitor.visit_bool(true),
+            "false" => visitor.visit_bool(false),
+            _ => Err(serde_json::Error::invalid_type(
+                Unexpected::Str(&self.key),
+                &visitor,
+            )),
+        }
+    }
+
+    impl_deser_numeric_key!(deserialize_i8);
+    impl_deser_numeric_key!(deserialize_i16);
+    impl_deser_numeric_key!(deserialize_i32);
+    impl_deser_numeric_key!(deserialize_i64);
+    impl_deser_numeric_key!(deserialize_u8);
+    impl_deser_numeric_key!(deserialize_u16);
+    impl_deser_numeric_key!(deserialize_u32);
+    impl_deser_numeric_key!(deserialize_u64);
+    impl_deser_numeric_key!(deserialize_f64);
+    impl_deser_numeric_key!(deserialize_f32);
+    impl_deser_numeric_key!(deserialize_i128);
+    impl_deser_numeric_key!(deserialize_u128);
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.key
+            .into_deserializer()
+            .deserialize_enum(name, variants, visitor)
+    }
+
+    forward_to_deserialize_any! {
+        char str string bytes byte_buf unit unit_struct seq tuple tuple_struct
+        map struct identifier ignored_any
+    }
+}
+
+struct MapKeyStrDeserializer<'de> {
+    key: Cow<'de, str>,
+}
+
+impl<'de> From<Cow<'de, str>> for MapKeyStrDeserializer<'de> {
+    fn from(value: Cow<'de, str>) -> Self {
+        Self { key: value }
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for MapKeyStrDeserializer<'de> {
+    type Error = serde_json::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.key {
+            Cow::Owned(s) => visitor.visit_string(s),
+            Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_enum(self)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct identifier ignored_any
+    }
+}
+
+impl<'de> EnumAccess<'de> for MapKeyStrDeserializer<'de> {
+    type Variant = UnitEnum;
+    type Error = serde_json::Error;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        Ok((seed.deserialize(self)?, UnitEnum))
+    }
+}
+
+struct UnitEnum;
+
+impl<'de> VariantAccess<'de> for UnitEnum {
+    type Error = serde_json::Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(serde_json::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"tuple variant",
+        ))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(serde_json::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"struct variant",
+        ))
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        Err(serde_json::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"newtype variant",
+        ))
+    }
+}
+
+struct EnumDeserializer {
+    variant: String,
+    value: Option<PayloadValue>,
+}
+
+impl From<(String, Option<PayloadValue>)> for EnumDeserializer {
+    fn from(value: (String, Option<PayloadValue>)) -> Self {
+        Self {
+            variant: value.0,
+            value: value.1,
+        }
+    }
+}
+
+impl<'de> EnumAccess<'de> for EnumDeserializer {
+    type Variant = VariantDeserializer;
+    type Error = serde_json::Error;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let variant = self.variant.into_deserializer();
+        let visitor = VariantDeserializer::from(self.value);
+        seed.deserialize(variant).map(|v| (v, visitor))
+    }
+}
+
+struct VariantDeserializer {
+    value: Option<PayloadValue>,
+}
+
+impl From<Option<PayloadValue>> for VariantDeserializer {
+    fn from(value: Option<PayloadValue>) -> Self {
+        Self { value }
+    }
+}
+
+impl<'de> VariantAccess<'de> for VariantDeserializer {
+    type Error = serde_json::Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        match self.value {
+            Some(value) => serde::Deserialize::deserialize(value),
+            None => Ok(()),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(PayloadValue::Array(a)) => {
+                if a.is_empty() {
+                    visitor.visit_unit()
+                } else {
+                    visit_array(a, visitor)
+                }
+            }
+            Some(other) => Err(serde_json::Error::invalid_type(
+                other.unexpected(),
+                &"tuple variant",
+            )),
+            None => Err(serde_json::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(PayloadValue::Object(o)) => visit_object(o, visitor),
+            Some(other) => Err(serde_json::Error::invalid_type(
+                other.unexpected(),
+                &"struct variant",
+            )),
+            None => Err(serde_json::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde_json::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+}

--- a/socketioxide/src/payload_value/from.rs
+++ b/socketioxide/src/payload_value/from.rs
@@ -1,0 +1,158 @@
+use std::{borrow::Cow, collections::HashMap};
+
+use bytes::Bytes;
+use serde_json::{Number, Value};
+
+use super::PayloadValue;
+
+macro_rules! impl_from_integer {
+    ($ty:ty) => {
+        impl From<$ty> for PayloadValue {
+            fn from(value: $ty) -> Self {
+                PayloadValue::Number(value.into())
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_binary {
+    ($intty:ty) => {
+        impl From<($intty, Bytes)> for PayloadValue {
+            fn from(value: ($intty, Bytes)) -> Self {
+                PayloadValue::Binary(value.0 as usize, value.1)
+            }
+        }
+    };
+}
+
+impl From<()> for PayloadValue {
+    fn from(_value: ()) -> Self {
+        PayloadValue::Null
+    }
+}
+
+impl From<bool> for PayloadValue {
+    fn from(value: bool) -> Self {
+        PayloadValue::Bool(value)
+    }
+}
+
+impl_from_integer!(u8);
+impl_from_integer!(i8);
+impl_from_integer!(u16);
+impl_from_integer!(i16);
+impl_from_integer!(u32);
+impl_from_integer!(i32);
+impl_from_integer!(u64);
+impl_from_integer!(i64);
+impl_from_integer!(usize);
+impl_from_integer!(isize);
+
+impl From<Number> for PayloadValue {
+    fn from(value: Number) -> Self {
+        PayloadValue::Number(value)
+    }
+}
+
+impl From<String> for PayloadValue {
+    fn from(value: String) -> Self {
+        PayloadValue::String(value)
+    }
+}
+
+impl From<&str> for PayloadValue {
+    fn from(value: &str) -> Self {
+        PayloadValue::String(value.to_string())
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for PayloadValue {
+    fn from(value: Cow<'a, str>) -> Self {
+        match value {
+            Cow::Owned(s) => PayloadValue::String(s),
+            Cow::Borrowed(s) => PayloadValue::String(s.to_string()),
+        }
+    }
+}
+
+impl_from_binary!(u8);
+impl_from_binary!(u16);
+impl_from_binary!(u32);
+impl_from_binary!(u64);
+impl_from_binary!(usize);
+
+impl<V: Into<PayloadValue>> From<HashMap<String, V>> for PayloadValue {
+    fn from(value: HashMap<String, V>) -> Self {
+        PayloadValue::Object(value.into_iter().map(|(k, v)| (k, v.into())).collect())
+    }
+}
+
+impl<T: Into<PayloadValue>> From<Vec<T>> for PayloadValue {
+    fn from(value: Vec<T>) -> Self {
+        PayloadValue::Array(value.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<T: Into<PayloadValue>, const N: usize> From<[T; N]> for PayloadValue {
+    fn from(value: [T; N]) -> Self {
+        PayloadValue::Array(value.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<Value> for PayloadValue {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Null => PayloadValue::Null,
+            Value::Bool(b) => PayloadValue::Bool(b),
+            Value::Number(n) => PayloadValue::Number(n),
+            Value::String(s) => PayloadValue::String(s),
+            Value::Array(a) => PayloadValue::Array(a.into_iter().map(Into::into).collect()),
+            Value::Object(o) => match (o.get("_placeholder"), o.get("num")) {
+                (Some(Value::Bool(true)), Some(Value::Number(num)))
+                    if num
+                        .as_u64()
+                        .map(|n| n <= usize::MAX as u64)
+                        .unwrap_or(false) =>
+                {
+                    PayloadValue::Binary(num.as_u64().unwrap() as usize, Bytes::new())
+                }
+                _ => PayloadValue::Object(o.into_iter().map(|(k, v)| (k, v.into())).collect()),
+            },
+        }
+    }
+}
+
+impl From<PayloadValue> for Value {
+    fn from(value: PayloadValue) -> Self {
+        match value {
+            PayloadValue::Null => Value::Null,
+            PayloadValue::Bool(b) => Value::Bool(b),
+            PayloadValue::Number(n) => Value::Number(n),
+            PayloadValue::String(s) => Value::String(s),
+            PayloadValue::Binary(num, _) => Value::Object(
+                [
+                    ("_placeholder".to_string(), Value::Bool(true)),
+                    ("num".to_string(), Value::Number(Number::from(num))),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            PayloadValue::Array(a) => Value::Array(a.into_iter().map(Into::into).collect()),
+            PayloadValue::Object(o) => {
+                Value::Object(o.into_iter().map(|(k, v)| (k, v.into())).collect())
+            }
+        }
+    }
+}
+
+impl<V: Into<PayloadValue>> FromIterator<(String, V)> for PayloadValue {
+    fn from_iter<T: IntoIterator<Item = (String, V)>>(iter: T) -> Self {
+        PayloadValue::Object(iter.into_iter().map(|(k, v)| (k, v.into())).collect())
+    }
+}
+
+impl<T: Into<PayloadValue>> FromIterator<T> for PayloadValue {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        PayloadValue::Array(iter.into_iter().map(Into::into).collect())
+    }
+}

--- a/socketioxide/src/payload_value/mod.rs
+++ b/socketioxide/src/payload_value/mod.rs
@@ -1,0 +1,441 @@
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Number;
+
+mod de;
+mod from;
+mod ser;
+
+/// Wrapper that implements [`serde::Serialize`]; the output it produces has
+/// [`PayloadValue::Binary()`] variants converted into binary placholder JSON objects.
+pub(crate) struct AsJson<'a>(pub(crate) &'a PayloadValue);
+
+/// Payload value representation, similar to [`serde_json::Value`], that can hold binary payloads.
+///
+/// Note that, if your data contains binary payloads, the [`serde::Serialize`] implementation for
+/// this data type will *not* produce the type of JSON string you want, suitable for sending in a
+/// socket.io binary event.  The default [`serde::Serialize`] implementation is set up so that the
+/// data represented can be transformed into other types losslessly, which is at odds with the
+/// correct JSON string representation needed for socket.io.
+///
+/// Instead, use [`to_json_string()`] to serialize properly for a socket.io event payload.
+#[derive(Debug, Clone, Eq)]
+pub enum PayloadValue {
+    /// Represents a JSON `null` value.
+    Null,
+    /// Represents a JSON boolean value.
+    Bool(bool),
+    /// Represents a JSON number value.
+    ///
+    /// Both integers and floats are represented by the [`serde_json::Number`] type.
+    Number(Number),
+    /// Represents a JSON string value.
+    String(String),
+    /// Represents a binary payload.
+    ///
+    /// In socket.io, binary data is extracted from the JSON payload data, is replaced by a
+    /// placeholder, and is sent over the wire in a more efficient way than is possible with JSON.
+    /// When received, the original payload data is reconstructed with the binary data placed in
+    /// the correct place.
+    Binary(usize, Bytes),
+    /// Represents a JSON array value.
+    Array(Vec<PayloadValue>),
+    /// Represents a JSON object value.
+    Object(HashMap<String, PayloadValue>),
+}
+
+impl PayloadValue {
+    /// Convert a `T` into a [`PayloadValue`].
+    pub fn from_data<T: Serialize>(data: T) -> Result<PayloadValue, serde_json::Error> {
+        ser::to_payload_value(data)
+    }
+
+    /// Interpret a [`PayloadValue`] as a `T`.
+    pub fn into_data<T: DeserializeOwned>(self) -> Result<T, serde_json::Error> {
+        T::deserialize(self)
+    }
+
+    /// Wraps `self` such that it can be serialized properly into a JSON string suitable for use in
+    /// a socket.io event payload.
+    pub(crate) fn as_json(&self) -> AsJson<'_> {
+        AsJson(self)
+    }
+
+    /// Converts `self` to a [`serde_json::Value`]. Binary payloads are serialized as placeholder
+    /// JSON objects.
+    pub fn to_value(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self.as_json())
+    }
+
+    /// Converts `self` to a JSON string. Binary payloads are serialized as placeholder JSON
+    /// objects.
+    pub fn to_json_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(&self.as_json())
+    }
+
+    /// Converts `self` to a JSON string that is pretty-printed for readability. Binary payloads
+    /// are serialized as placeholder JSON objects.
+    pub fn to_json_string_pretty(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(&self.as_json())
+    }
+
+    /// Create a [`PayloadValue]` from a float.
+    ///
+    /// This may fail, if [`serde_json::Number`] cannot properly represent the number.
+    pub fn from_f64(value: f64) -> Option<PayloadValue> {
+        Number::from_f64(value).map(PayloadValue::Number)
+    }
+
+    /// Interprets `self` as a `bool`, if it contains boolean data.
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            PayloadValue::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    /// Interprets `self` as a `u64`, if it contains unsigned integer data.
+    pub fn as_u64(&self) -> Option<u64> {
+        match self {
+            PayloadValue::Number(n) => n.as_u64(),
+            _ => None,
+        }
+    }
+
+    /// Interprets `self` as a [`&str`], if it contains string ata.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            PayloadValue::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Determines if `self` contains any binary payloads.
+    pub fn has_binary(&self) -> bool {
+        match self {
+            PayloadValue::Binary(_, _) => true,
+            PayloadValue::Array(a) => a.iter().any(PayloadValue::has_binary),
+            PayloadValue::Object(o) => o.iter().any(|(_, v)| v.has_binary()),
+            _ => false,
+        }
+    }
+
+    /// Counts the number of binary payloads (or placeholders) contained in `self`.
+    pub fn count_payloads(&self) -> usize {
+        match self {
+            PayloadValue::Binary(_, _) => 1,
+            PayloadValue::Array(a) => a.iter().map(PayloadValue::count_payloads).sum(),
+            PayloadValue::Object(o) => o.iter().map(|(_, v)| v.count_payloads()).sum(),
+            _ => 0,
+        }
+    }
+
+    /// Returns a list of all binary payloads in `self`, ordered as they will be sent over the wire
+    /// as part of a socket.io binary event.
+    pub fn get_binary_payloads(&self) -> Vec<Bytes> {
+        fn rec(data: &PayloadValue) -> Vec<(usize, Bytes)> {
+            let mut bins = Vec::<(usize, Bytes)>::new();
+
+            match data {
+                PayloadValue::Binary(num, bin) => {
+                    bins.push((*num, bin.clone()));
+                }
+                PayloadValue::Array(a) => {
+                    for value in a.iter() {
+                        bins.extend(rec(value));
+                    }
+                }
+                PayloadValue::Object(o) => {
+                    for value in o.values() {
+                        bins.extend(rec(value));
+                    }
+                }
+                _ => (),
+            }
+
+            bins
+        }
+
+        let mut bins = rec(self);
+        bins.sort_by(|(a, _), (b, _)| a.cmp(b));
+        bins.into_iter().map(|(_, bin)| bin).collect()
+    }
+}
+
+// PartialEq is implemented manually rather than being derived because the binary payload num
+// should not be included in the comparison.  It's enough that the binary bytes in the node are
+// equivalent.
+impl PartialEq for PayloadValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (PayloadValue::Null, PayloadValue::Null) => true,
+            (PayloadValue::Bool(a), PayloadValue::Bool(b)) => a.eq(b),
+            (PayloadValue::Number(a), PayloadValue::Number(b)) => a.eq(b),
+            (PayloadValue::String(a), PayloadValue::String(b)) => a.eq(b),
+            (PayloadValue::Array(a), PayloadValue::Array(b)) => a.eq(b),
+            (PayloadValue::Object(a), PayloadValue::Object(b)) => a.eq(b),
+            (PayloadValue::Binary(_, a), PayloadValue::Binary(_, b)) => a.eq(b),
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Number, Value};
+
+    use super::PayloadValue;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestSubPayload {
+        more_binary: Bytes,
+        opt_int: Option<i32>,
+        opt_float: Option<f32>,
+        opt_string: Option<String>,
+        opt_boolean: Option<bool>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestPayload {
+        uint: u32,
+        float: f64,
+        binary: Bytes,
+        string: String,
+        boolean: bool,
+        array: Vec<String>,
+        sub_payload: TestSubPayload,
+    }
+
+    const BINARY_PAYLOAD: &[u8] = &[1, 2, 3, 4, 5, 6, 7];
+    const MORE_BINARY_PAYLOAD: &[u8] = &[10, 9, 8, 7, 6, 5];
+
+    fn build_test_payload(fill_options: bool) -> TestPayload {
+        let fill_options = fill_options.then_some(true);
+        TestPayload {
+            uint: 42,
+            float: 1.75,
+            binary: Bytes::from_static(BINARY_PAYLOAD),
+            string: "test string".to_string(),
+            boolean: true,
+            array: ["one", "two", "three"]
+                .into_iter()
+                .map(ToString::to_string)
+                .collect(),
+            sub_payload: TestSubPayload {
+                more_binary: Bytes::from_static(MORE_BINARY_PAYLOAD),
+                opt_int: fill_options.map(|_| 99),
+                opt_float: fill_options.map(|_| 2.5),
+                opt_string: fill_options.map(|_| "another test string".to_string()),
+                opt_boolean: fill_options,
+            },
+        }
+    }
+
+    fn build_test_payload_value(fill_options: bool, fill_binary_data: bool) -> PayloadValue {
+        let fill_options = fill_options.then_some(true);
+        let fill_binary_data = fill_binary_data.then_some(true);
+        PayloadValue::Object(
+            [
+                ("uint", PayloadValue::Number(42.into())),
+                (
+                    "float",
+                    PayloadValue::Number(Number::from_f64(1.75).unwrap()),
+                ),
+                (
+                    "binary",
+                    PayloadValue::Binary(
+                        0,
+                        fill_binary_data
+                            .map(|_| Bytes::from_static(BINARY_PAYLOAD))
+                            .unwrap_or(Bytes::new()),
+                    ),
+                ),
+                ("string", PayloadValue::String("test string".to_string())),
+                ("boolean", PayloadValue::Bool(true)),
+                (
+                    "array",
+                    PayloadValue::Array(
+                        ["one", "two", "three"]
+                            .into_iter()
+                            .map(|s| PayloadValue::String(s.to_string()))
+                            .collect(),
+                    ),
+                ),
+                (
+                    "sub_payload",
+                    PayloadValue::Object(
+                        [
+                            (
+                                "more_binary",
+                                PayloadValue::Binary(
+                                    1,
+                                    fill_binary_data
+                                        .map(|_| Bytes::from_static(MORE_BINARY_PAYLOAD))
+                                        .unwrap_or(Bytes::new()),
+                                ),
+                            ),
+                            (
+                                "opt_int",
+                                fill_options
+                                    .map(|_| PayloadValue::Number(99.into()))
+                                    .unwrap_or(PayloadValue::Null),
+                            ),
+                            (
+                                "opt_float",
+                                fill_options
+                                    .map(|_| {
+                                        PayloadValue::Number(
+                                            Number::from_f64(2.5f32 as f64).unwrap(),
+                                        )
+                                    })
+                                    .unwrap_or(PayloadValue::Null),
+                            ),
+                            (
+                                "opt_string",
+                                fill_options
+                                    .map(|_| {
+                                        PayloadValue::String("another test string".to_string())
+                                    })
+                                    .unwrap_or(PayloadValue::Null),
+                            ),
+                            (
+                                "opt_boolean",
+                                fill_options
+                                    .map(PayloadValue::Bool)
+                                    .unwrap_or(PayloadValue::Null),
+                            ),
+                        ]
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v))
+                        .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+        )
+    }
+
+    fn build_test_payload_json_value(fill_options: bool) -> Value {
+        let sub_payload = if fill_options {
+            json!({
+                "more_binary": {
+                    "_placeholder": true,
+                    "num": 1
+                },
+                "opt_int": 99,
+                "opt_float": 2.5,
+                "opt_string": "another test string",
+                "opt_boolean": true
+            })
+        } else {
+            json!({
+                "more_binary": {
+                    "_placeholder": true,
+                    "num": 1
+                },
+                "opt_int": null,
+                "opt_float": null,
+                "opt_string": null,
+                "opt_boolean": null
+            })
+        };
+
+        let mut main_payload = json!({
+            "uint": 42,
+            "float": 1.75,
+            "binary": {
+                "_placeholder": true,
+                "num": 0
+            },
+            "string": "test string",
+            "boolean": true,
+            "array": [
+                "one",
+                "two",
+                "three"
+            ]
+        });
+
+        if let Value::Object(ref mut o) = &mut main_payload {
+            o.insert("sub_payload".to_string(), sub_payload);
+        } else {
+            panic!("test bug: not an object");
+        }
+
+        main_payload
+    }
+
+    #[test]
+    pub fn test_payload_value_from_data() {
+        let test_payload = build_test_payload(true);
+        let payload_value = PayloadValue::from_data(test_payload).unwrap();
+        assert_eq!(payload_value, build_test_payload_value(true, true));
+
+        let test_payload = build_test_payload(false);
+        let payload_value = PayloadValue::from_data(test_payload).unwrap();
+        assert_eq!(payload_value, build_test_payload_value(false, true));
+    }
+
+    #[test]
+    pub fn test_payload_value_into_data() {
+        let payload_value = build_test_payload_value(true, true);
+        let test_payload: TestPayload = payload_value.into_data().unwrap();
+        assert_eq!(test_payload, build_test_payload(true));
+
+        let payload_value = build_test_payload_value(false, true);
+        let test_payload: TestPayload = payload_value.into_data().unwrap();
+        assert_eq!(test_payload, build_test_payload(false));
+    }
+
+    #[test]
+    pub fn test_payload_value_to_json_value() {
+        let payload_value = build_test_payload_value(true, false);
+        let json = payload_value.to_value().unwrap();
+        assert_eq!(json, build_test_payload_json_value(true));
+
+        let payload_value = build_test_payload_value(false, false);
+        let json = payload_value.to_value().unwrap();
+        assert_eq!(json, build_test_payload_json_value(false));
+    }
+
+    #[test]
+    pub fn test_payload_value_from_json_value() {
+        let json = build_test_payload_json_value(true);
+        let payload_value: PayloadValue = serde_json::from_value(json).unwrap();
+        assert_eq!(payload_value, build_test_payload_value(true, false));
+
+        let json = build_test_payload_json_value(false);
+        let payload_value: PayloadValue = serde_json::from_value(json).unwrap();
+        assert_eq!(payload_value, build_test_payload_value(false, false));
+    }
+
+    #[test]
+    pub fn test_count_payloads() {
+        let payload_value = build_test_payload_value(true, false);
+        assert_eq!(payload_value.count_payloads(), 2);
+    }
+
+    #[test]
+    pub fn test_extract_binary_payloads() {
+        let test_payload = build_test_payload(true);
+        let payload_value = build_test_payload_value(true, true);
+        let bins = payload_value.get_binary_payloads();
+
+        assert_eq!(bins.len(), 2);
+        assert_eq!(bins[0], *test_payload.binary);
+        assert_eq!(bins[1], *test_payload.sub_payload.more_binary);
+    }
+
+    #[test]
+    pub fn test_payload_value_redeser() {
+        let payload_value_again: PayloadValue =
+            build_test_payload_value(true, true).into_data().unwrap();
+        assert_eq!(build_test_payload_value(true, true), payload_value_again);
+    }
+}

--- a/socketioxide/src/payload_value/ser.rs
+++ b/socketioxide/src/payload_value/ser.rs
@@ -1,0 +1,673 @@
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use serde::ser::{Error, Impossible, SerializeSeq};
+use serde_json::Number;
+
+use super::{AsJson, PayloadValue};
+
+const KEY_STRING_ERROR: &str = "key must be a string";
+
+#[derive(Default)]
+struct Serializer {
+    next_binary_payload_num: usize,
+}
+
+pub fn to_payload_value<T: serde::Serialize>(data: T) -> Result<PayloadValue, serde_json::Error> {
+    let mut ser = Serializer::default();
+    data.serialize(&mut ser)
+}
+
+impl serde::Serialize for PayloadValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            PayloadValue::Null => serializer.serialize_unit(),
+            PayloadValue::Bool(b) => serializer.serialize_bool(*b),
+            PayloadValue::Number(n) => {
+                if let Some(u) = n.as_u64() {
+                    serializer.serialize_u64(u)
+                } else if let Some(i) = n.as_i64() {
+                    serializer.serialize_i64(i)
+                } else if let Some(f) = n.as_f64() {
+                    serializer.serialize_f64(f)
+                } else {
+                    Err(S::Error::custom("number is not representable"))
+                }
+            }
+            PayloadValue::String(s) => serializer.serialize_str(s.as_str()),
+            PayloadValue::Binary(_, bin) => serializer.serialize_bytes(bin),
+            PayloadValue::Array(a) => {
+                let mut seq = serializer.serialize_seq(Some(a.len()))?;
+                for elem in a.iter() {
+                    seq.serialize_element(elem)?;
+                }
+                seq.end()
+            }
+            PayloadValue::Object(o) => {
+                use serde::ser::SerializeMap;
+
+                let mut map = serializer.serialize_map(Some(o.len()))?;
+                for (key, value) in o.iter() {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'a> serde::Serialize for AsJson<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            PayloadValue::Null => serializer.serialize_unit(),
+            PayloadValue::Bool(b) => serializer.serialize_bool(*b),
+            PayloadValue::Number(n) => {
+                if let Some(u) = n.as_u64() {
+                    serializer.serialize_u64(u)
+                } else if let Some(i) = n.as_i64() {
+                    serializer.serialize_i64(i)
+                } else if let Some(f) = n.as_f64() {
+                    serializer.serialize_f64(f)
+                } else {
+                    Err(S::Error::custom("number is not representable"))
+                }
+            }
+            PayloadValue::String(s) => serializer.serialize_str(s.as_str()),
+            PayloadValue::Binary(num, _) => {
+                use serde::ser::SerializeMap;
+
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry(&"_placeholder", &true)?;
+                map.serialize_entry(&"num", num)?;
+                map.end()
+            }
+            PayloadValue::Array(a) => {
+                let mut seq = serializer.serialize_seq(Some(a.len()))?;
+                for elem in a.iter() {
+                    seq.serialize_element(&AsJson(elem))?;
+                }
+                seq.end()
+            }
+            PayloadValue::Object(o) => {
+                use serde::ser::SerializeMap;
+
+                let mut map = serializer.serialize_map(Some(o.len()))?;
+                for (key, value) in o.iter() {
+                    map.serialize_entry(key, &AsJson(value))?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'a> serde::Serializer for &'a mut Serializer {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    type SerializeSeq = SerializeVec<'a>;
+    type SerializeTuple = SerializeVec<'a>;
+    type SerializeTupleVariant = SerializeTupleVariant<'a>;
+    type SerializeMap = SerializeMap<'a>;
+    type SerializeStruct = SerializeMap<'a>;
+    type SerializeStructVariant = SerializeStructVariant<'a>;
+    type SerializeTupleStruct = SerializeVec<'a>;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::Bool(v))
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        self.serialize_i64(v as i64)
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        self.serialize_i64(v as i64)
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        self.serialize_i64(v as i64)
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::Number(v.into()))
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        if let Ok(v) = u64::try_from(v) {
+            Ok(PayloadValue::Number(v.into()))
+        } else if let Ok(v) = i64::try_from(v) {
+            Ok(PayloadValue::Number(v.into()))
+        } else {
+            Err(serde_json::Error::custom("number out of range"))
+        }
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        self.serialize_u64(v as u64)
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        self.serialize_u64(v as u64)
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        self.serialize_u64(v as u64)
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::Number(v.into()))
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        if let Ok(v) = u64::try_from(v) {
+            Ok(PayloadValue::Number(v.into()))
+        } else {
+            Err(serde_json::Error::custom("number out of range"))
+        }
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        if v.is_finite() {
+            Ok(Number::from_f64(v as f64).map_or(PayloadValue::Null, PayloadValue::Number))
+        } else {
+            Ok(PayloadValue::Null)
+        }
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(Number::from_f64(v).map_or(PayloadValue::Null, PayloadValue::Number))
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::String(String::from(v)))
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::String(v.to_string()))
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        let num = self.next_binary_payload_num;
+        self.next_binary_payload_num += 1;
+        Ok(PayloadValue::Binary(num, Bytes::copy_from_slice(v)))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::Null)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_some<T: ?Sized + serde::Serialize>(
+        self,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(SerializeVec {
+            root_ser: self,
+            elements: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(SerializeTupleVariant {
+            root_ser: self,
+            name: String::from(variant),
+            elements: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(SerializeMap {
+            root_ser: self,
+            map: HashMap::with_capacity(len.unwrap_or(0)),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(SerializeStructVariant {
+            root_ser: self,
+            name: String::from(variant),
+            map: HashMap::new(),
+        })
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        let mut obj = HashMap::new();
+        obj.insert(name.to_string(), value.serialize(self)?);
+        Ok(PayloadValue::Object(obj))
+    }
+
+    fn collect_str<T: ?Sized + std::fmt::Display>(
+        self,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::String(value.to_string()))
+    }
+}
+
+struct SerializeVec<'a> {
+    root_ser: &'a mut Serializer,
+    elements: Vec<PayloadValue>,
+}
+
+impl<'a> SerializeSeq for SerializeVec<'a> {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    fn serialize_element<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        let element = value.serialize(&mut *self.root_ser)?;
+        self.elements.push(element);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(PayloadValue::Array(self.elements))
+    }
+}
+
+impl<'a> serde::ser::SerializeTuple for SerializeVec<'a> {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    fn serialize_element<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+impl<'a> serde::ser::SerializeTupleStruct for SerializeVec<'a> {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+struct SerializeTupleVariant<'a> {
+    root_ser: &'a mut Serializer,
+    name: String,
+    elements: Vec<PayloadValue>,
+}
+
+impl<'a> serde::ser::SerializeTupleVariant for SerializeTupleVariant<'a> {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        let element = value.serialize(&mut *self.root_ser)?;
+        self.elements.push(element);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut obj = HashMap::new();
+        obj.insert(self.name, PayloadValue::Array(self.elements));
+        Ok(PayloadValue::Object(obj))
+    }
+}
+
+struct SerializeMap<'a> {
+    root_ser: &'a mut Serializer,
+    map: HashMap<String, PayloadValue>,
+    next_key: Option<String>,
+}
+
+impl<'a> serde::ser::SerializeMap for SerializeMap<'a> {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    fn serialize_key<T: ?Sized + serde::Serialize>(&mut self, key: &T) -> Result<(), Self::Error> {
+        self.next_key = Some(key.serialize(MapKeySerializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        if let Some(key) = self.next_key.take() {
+            self.map.insert(key, value.serialize(&mut *self.root_ser)?);
+            Ok(())
+        } else {
+            panic!("serialize_value() called before serialize_key()");
+        }
+    }
+
+    fn serialize_entry<K: ?Sized + serde::Serialize, V: ?Sized + serde::Serialize>(
+        &mut self,
+        key: &K,
+        value: &V,
+    ) -> Result<(), Self::Error> {
+        self.map.insert(
+            key.serialize(MapKeySerializer)?,
+            value.serialize(&mut *self.root_ser)?,
+        );
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        if self.map.len() == 2
+            && self
+                .map
+                .get("_placeholder")
+                .and_then(|p| p.as_bool())
+                .unwrap_or(false)
+        {
+            if let Some(num) = self.map.get("num").and_then(|n| n.as_u64()) {
+                return Ok(PayloadValue::Binary(num as usize, Bytes::new()));
+            }
+        }
+
+        Ok(PayloadValue::Object(self.map))
+    }
+}
+
+impl<'a> serde::ser::SerializeStruct for SerializeMap<'a> {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        serde::ser::SerializeMap::serialize_entry(self, key, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeMap::end(self)
+    }
+}
+
+struct SerializeStructVariant<'a> {
+    root_ser: &'a mut Serializer,
+    name: String,
+    map: HashMap<String, PayloadValue>,
+}
+
+impl<'a> serde::ser::SerializeStructVariant for SerializeStructVariant<'a> {
+    type Ok = PayloadValue;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        self.map
+            .insert(key.to_string(), value.serialize(&mut *self.root_ser)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut obj = HashMap::new();
+        obj.insert(self.name, PayloadValue::Object(self.map));
+        Ok(PayloadValue::Object(obj))
+    }
+}
+
+struct MapKeySerializer;
+
+impl serde::Serializer for MapKeySerializer {
+    type Ok = String;
+    type Error = serde_json::Error;
+
+    type SerializeSeq = Impossible<String, Self::Error>;
+    type SerializeMap = Impossible<String, Self::Error>;
+    type SerializeTuple = Impossible<String, Self::Error>;
+    type SerializeStruct = Impossible<String, Self::Error>;
+    type SerializeTupleStruct = Impossible<String, Self::Error>;
+    type SerializeTupleVariant = Impossible<String, Self::Error>;
+    type SerializeStructVariant = Impossible<String, Self::Error>;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_some<T: ?Sized + serde::Serialize>(
+        self,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+}

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -206,7 +206,6 @@ impl<A: Adapter> Socket<A> {
     /// #### Example with a closure and an acknowledgement + binary data:
     /// ```
     /// # use socketioxide::{SocketIo, extract::*};
-    /// # use serde_json::Value;
     /// # use serde::{Serialize, Deserialize};
     /// #[derive(Debug, Serialize, Deserialize)]
     /// struct MyData {
@@ -219,10 +218,10 @@ impl<A: Adapter> Socket<A> {
     ///     // Register an async handler for the "test" event and extract the data as a `MyData` struct
     ///     // Extract the binary payload as a `Vec<Vec<u8>>` with the Bin extractor.
     ///     // It should be the last extractor because it consumes the request
-    ///     socket.on("test", |socket: SocketRef, Data::<MyData>(data), ack: AckSender, Bin(bin)| async move {
+    ///     socket.on("test", |socket: SocketRef, Data::<MyData>(data), ack: AckSender| async move {
     ///         println!("Received a test message {:?}", data);
     ///         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    ///         ack.bin(bin).send(data).ok(); // The data received is sent back to the client through the ack
+    ///         ack.send(data).ok(); // The data received is sent back to the client through the ack
     ///         socket.emit("test-test", MyData { name: "Test".to_string(), age: 8 }).ok(); // Emit a message to the client
     ///     });
     /// });
@@ -555,21 +554,19 @@ impl<A: Adapter> Socket<A> {
     ///
     /// # Example
     /// ```
-    /// # use socketioxide::{SocketIo, extract::*};
-    /// # use serde_json::Value;
+    /// # use socketioxide::{PayloadValue, SocketIo, extract::*};
     /// # use futures::stream::StreamExt;
     /// # use std::time::Duration;
     /// # use std::sync::Arc;
     /// let (_, io) = SocketIo::new_svc();
     /// io.ns("/", |socket: SocketRef| {
-    ///    socket.on("test", |socket: SocketRef, Data::<Value>(data), Bin(bin)| async move {
+    ///    socket.on("test", |socket: SocketRef, Data::<PayloadValue>(data)| async move {
     ///       // Emit a test message in the room1 and room3 rooms, except for the room2 room with the binary payload received, wait for 5 seconds for an acknowledgement
     ///       socket.to("room1")
     ///             .to("room3")
     ///             .except("room2")
-    ///             .bin(bin)
     ///             .timeout(Duration::from_secs(5))
-    ///             .emit_with_ack::<Value>("message-back", data)
+    ///             .emit_with_ack::<PayloadValue>("message-back", data)
     ///             .unwrap()
     ///             .for_each(|(sid, ack)| async move {
     ///                match ack {
@@ -587,12 +584,11 @@ impl<A: Adapter> Socket<A> {
     /// Broadcasts to all clients without any filtering (except the current socket).
     /// # Example
     /// ```
-    /// # use socketioxide::{SocketIo, extract::*};
-    /// # use serde_json::Value;
+    /// # use socketioxide::{PayloadValue, SocketIo, extract::*};
     /// # use std::sync::Arc;
     /// let (_, io) = SocketIo::new_svc();
     /// io.ns("/", |socket: SocketRef| {
-    ///     socket.on("test", |socket: SocketRef, Data::<Value>(data)| async move {
+    ///     socket.on("test", |socket: SocketRef, Data::<PayloadValue>(data)| async move {
     ///         // This message will be broadcast to all clients in this namespace
     ///         socket.broadcast().emit("test", data);
     ///     });

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -216,9 +216,8 @@ impl<A: Adapter> Socket<A> {
     /// let (_, io) = SocketIo::new_svc();
     /// io.ns("/", |socket: SocketRef| {
     ///     // Register an async handler for the "test" event and extract the data as a `MyData` struct
-    ///     // Extract the binary payload as a `Vec<Vec<u8>>` with the Bin extractor.
-    ///     // It should be the last extractor because it consumes the request
-    ///     socket.on("test", |socket: SocketRef, Data::<MyData>(data), ack: AckSender| async move {
+    ///     // `Data` should be the last extractor because it consumes the request
+    ///     socket.on("test", |socket: SocketRef, ack: AckSender, Data::<MyData>(data)| async move {
     ///         println!("Received a test message {:?}", data);
     ///         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     ///         ack.send(data).ok(); // The data received is sent back to the client through the ack


### PR DESCRIPTION
Previously, the non-binary part of a message and the binary payloads in a message were represented separately: the non-binary portion was represented by a serde_json::Value, and could be converted to an arbitrary data structure.  That data structure would not include the binary data or any indication that there is any binary data at all.  The binary data would be provided in a Vec<Vec<u8>>.

There were a few problems with this:

1. The original code only supported cases where the payload was a flat array with some binary payloads in the root of the array, or a flat object where the root of the object was a binary payload.  Objects with more complicated structure and binary data embedded in various places in the structure were not supported.
2. Adding support for the above turned out to not be possible in a useful way, because the ordering of the Vec<Vec<u8>> matters, and it could never be clear where exactly in the possibly-complex structure each binary payload belonged.
3. One of the useful features of the socket.io protocol is that it lets users efficiently transmit binary data in addition to textual/numeric data, and have that handled transparently by the protocol, with either end of the connection believing that they just sent or received a single mixed textual/numeric/binary payload.  Separating the non-binary from the binary negates that benefit.

This introduces a new type, PayloadValue, that behaves similarly to serde_json::Value.  The main difference is that it has a Binary variant, which holds a numeric index and a Vec<u8>.  This allows us to include the binary data where the sender of that data intended it to be.

There is currently one wrinkle: serde_json does not appear to consistently handle binary data; when serializing a struct with Vec<u8>, I believe it will serialize it as an array of numbers, rather than recognize that it's binary data.  For now, I've included a Binary struct that wraps a Vec<u8>, which can be included as the type of a binary member, instead of using a Vec<u8> directly.  Hopefully I'll be able to figure out a better way to do this.

Unfinished tasks:

* Testing: I have no idea if this even works yet.  All I've done is get it to compile.
* Benchmarking: I've tried to ensure that I don't copy data any more than the existing library does, but it's possible I've introduced some performance regressions, so I'll have to look into that.
* Documentation: the documentation still references the old way of doing things and needs to be updated.

Closes #276.