### PR TITLE
Unify non-binary and binary data, take 2

### DIFF
--- a/e2e/socketioxide/socketioxide.rs
+++ b/e2e/socketioxide/socketioxide.rs
@@ -39,7 +39,7 @@ fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
         |s: SocketRef, Data::<Value>(data), Bin(bin)| async move {
             let ack = s
                 .bin(bin)
-                .emit_with_ack::<_, Value>("emit-with-ack", data)
+                .emit_with_ack::<Value>("emit-with-ack", data)
                 .unwrap()
                 .await
                 .unwrap();

--- a/socketioxide/src/handler/extract.rs
+++ b/socketioxide/src/handler/extract.rs
@@ -144,11 +144,11 @@ where
     fn from_message_parts(
         _: &Arc<Socket<A>>,
         v: &mut serde_json::Value,
-        _: &mut Vec<Bytes>,
+        b: &mut Vec<Bytes>,
         _: &Option<i64>,
     ) -> Result<Self, Self::Error> {
         upwrap_array(v);
-        serde_json::from_value(v.clone()).map(Data)
+        crate::from_value::<T>(v.clone(), b).map(Data)
     }
 }
 
@@ -178,11 +178,11 @@ where
     fn from_message_parts(
         _: &Arc<Socket<A>>,
         v: &mut serde_json::Value,
-        _: &mut Vec<Bytes>,
+        b: &mut Vec<Bytes>,
         _: &Option<i64>,
     ) -> Result<Self, Infallible> {
         upwrap_array(v);
-        Ok(TryData(serde_json::from_value(v.clone())))
+        Ok(TryData(crate::from_value::<T>(v.clone(), b)))
     }
 }
 /// An Extractor that returns a reference to a [`Socket`].

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -15,7 +15,10 @@ use crate::{
     extract::SocketRef,
     handler::ConnectHandler,
     layer::SocketIoLayer,
-    operators::{BroadcastOperators, RoomParam},
+    operators::{
+        holding::{WithBinary, WithoutBinary},
+        BroadcastOperators, RoomParam,
+    },
     service::SocketIoService,
     BroadcastError, DisconnectError,
 };
@@ -375,7 +378,7 @@ impl<A: Adapter> SocketIo<A> {
     ///    println!("found socket on /custom_ns namespace with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn of<'a>(&self, path: impl Into<&'a str>) -> Option<BroadcastOperators<A>> {
+    pub fn of<'a>(&self, path: impl Into<&'a str>) -> Option<BroadcastOperators<WithoutBinary, A>> {
         self.get_op(path.into())
     }
 
@@ -401,7 +404,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn to(&self, rooms: impl RoomParam) -> BroadcastOperators<A> {
+    pub fn to(&self, rooms: impl RoomParam) -> BroadcastOperators<WithoutBinary, A> {
         self.get_default_op().to(rooms)
     }
 
@@ -429,7 +432,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn within(&self, rooms: impl RoomParam) -> BroadcastOperators<A> {
+    pub fn within(&self, rooms: impl RoomParam) -> BroadcastOperators<WithoutBinary, A> {
         self.get_default_op().within(rooms)
     }
 
@@ -462,7 +465,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn except(&self, rooms: impl RoomParam) -> BroadcastOperators<A> {
+    pub fn except(&self, rooms: impl RoomParam) -> BroadcastOperators<WithoutBinary, A> {
         self.get_default_op().except(rooms)
     }
 
@@ -489,7 +492,7 @@ impl<A: Adapter> SocketIo<A> {
     ///   println!("found socket on / ns in room1 with id: {}", socket.id);
     /// }
     #[inline]
-    pub fn local(&self) -> BroadcastOperators<A> {
+    pub fn local(&self) -> BroadcastOperators<WithoutBinary, A> {
         self.get_default_op().local()
     }
 
@@ -532,7 +535,7 @@ impl<A: Adapter> SocketIo<A> {
     ///      }
     ///   });
     #[inline]
-    pub fn timeout(&self, timeout: Duration) -> BroadcastOperators<A> {
+    pub fn timeout(&self, timeout: Duration) -> BroadcastOperators<WithoutBinary, A> {
         self.get_default_op().timeout(timeout)
     }
 
@@ -559,9 +562,12 @@ impl<A: Adapter> SocketIo<A> {
     ///   .to("room3")
     ///   .except("room2")
     ///   .bin(vec![Bytes::from_static(&[1, 2, 3, 4])])
-    ///   .emit("test", ());
+    ///   .emit("test", ().into());
     #[inline]
-    pub fn bin(&self, binary: impl IntoIterator<Item = impl Into<Bytes>>) -> BroadcastOperators<A> {
+    pub fn bin(
+        &self,
+        binary: impl IntoIterator<Item = impl Into<Bytes>>,
+    ) -> BroadcastOperators<WithBinary, A> {
         self.get_default_op().bin(binary)
     }
 
@@ -787,7 +793,7 @@ impl<A: Adapter> SocketIo<A> {
 
     /// Returns a new operator on the given namespace
     #[inline(always)]
-    fn get_op(&self, path: &str) -> Option<BroadcastOperators<A>> {
+    fn get_op(&self, path: &str) -> Option<BroadcastOperators<WithoutBinary, A>> {
         self.0
             .get_ns(path)
             .map(|ns| BroadcastOperators::new(ns).broadcast())
@@ -799,7 +805,7 @@ impl<A: Adapter> SocketIo<A> {
     ///
     /// If the **default namespace "/" is not found** this fn will panic!
     #[inline(always)]
-    fn get_default_op(&self) -> BroadcastOperators<A> {
+    fn get_default_op(&self) -> BroadcastOperators<WithoutBinary, A> {
         self.get_op("/").expect("default namespace not found")
     }
 }

--- a/socketioxide/src/lib.rs
+++ b/socketioxide/src/lib.rs
@@ -292,11 +292,13 @@ pub use engineioxide::TransportType;
 pub use errors::{AckError, AdapterError, BroadcastError, DisconnectError, SendError, SocketError};
 pub use handler::extract;
 pub use io::{SocketIo, SocketIoBuilder, SocketIoConfig};
+pub use value::{de::from_value, ser::to_value};
 
 mod client;
 mod errors;
 mod io;
 mod ns;
+mod value;
 
 /// Socket.IO protocol version.
 /// It is accessible with the [`Socket::protocol`](socket::Socket) method or as an extractor

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -549,6 +549,43 @@ pub struct ConnectPacket {
     sid: Sid,
 }
 
+/// Creates a binary placeholder in the packet data
+///
+/// Packets that contain binary payloads need to have a "placeholder" object placed in the location
+/// of the payload where the binary blob logically resides.
+///
+/// # Arguments
+///
+/// * `num` - the index into the binary payloads `Vec`
+///
+/// # Example
+///
+/// ```
+/// # use bytes::Bytes;
+/// # use serde_json::Value;
+/// # use socketioxide::{SocketIo, extract::*, packet::create_binary_placeholder};
+///
+/// let (_, io) = SocketIo::new_svc();
+/// io.ns("/", |socket: SocketRef| {
+///     socket.on("test", |socket: SocketRef| async move {
+///         let data = Value::Array(vec![
+///             "my_data".into(),
+///             create_binary_placeholder(0),
+///         ]);
+///
+///         let binary_payloads = vec![Bytes::from_static(&[1, 2, 3])];
+///
+///         socket.bin(binary_payloads).emit("data", data).ok();
+///     });
+/// });
+/// ```
+pub fn create_binary_placeholder(num: usize) -> Value {
+    json!({
+        "_placeholder": true,
+        "num": num
+    })
+}
+
 #[cfg(test)]
 mod test {
     use serde_json::json;

--- a/socketioxide/src/value/de.rs
+++ b/socketioxide/src/value/de.rs
@@ -1,0 +1,841 @@
+use std::{borrow::Cow, marker::PhantomData};
+
+use bytes::Bytes;
+use serde::{
+    de::{
+        self, DeserializeSeed, EnumAccess, Error, IntoDeserializer, MapAccess, SeqAccess,
+        Unexpected, VariantAccess,
+    },
+    forward_to_deserialize_any,
+};
+use serde_json::{Map, Value};
+
+// For Deserializer impl for Value Deserializer wrapper
+macro_rules! forward_deser {
+    ($method:ident) => {
+        #[inline]
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: de::Visitor<'de>,
+        {
+            self.value.$method(visitor)
+        }
+    };
+}
+
+// For Deserializer impl for MapKeyDeserializer
+macro_rules! impl_deser_numeric_key {
+    ($method:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: de::Visitor<'de>,
+        {
+            // This is less efficient than it could be, but `Deserializer::from_str()` (used
+            // internally by `serde_json`) wants to hold a reference to `self.key` longer than is
+            // permitted.  The methods on `Deserializer` for deserializing into a `Number` without
+            // that constraint are not exposed publicly.
+            let reader = VecRead::from(self.key);
+            let mut deser = serde_json::Deserializer::from_reader(reader);
+            let number = deser.$method(visitor)?;
+            let _ = deser
+                .end()
+                .map_err(|_| serde_json::Error::custom("expected numeric map key"))?;
+            Ok(number)
+        }
+    };
+}
+
+struct Deserializer<'a, T> {
+    value: serde_json::Value,
+    binary_payloads: &'a [Bytes],
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, 'de, T: serde::Deserialize<'de>> serde::de::Deserializer<'de> for Deserializer<'a, T> {
+    type Error = serde_json::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Value::Array(a) => visit_value_array::<'a, 'de, V, T>(a, self.binary_payloads, visitor),
+            Value::Object(o) => {
+                visit_value_object::<'a, 'de, V, T>(o, self.binary_payloads, visitor)
+            }
+            other => other.deserialize_any(visitor),
+        }
+    }
+
+    forward_deser!(deserialize_unit);
+    forward_deser!(deserialize_bool);
+    forward_deser!(deserialize_u8);
+    forward_deser!(deserialize_i8);
+    forward_deser!(deserialize_u16);
+    forward_deser!(deserialize_i16);
+    forward_deser!(deserialize_u32);
+    forward_deser!(deserialize_i32);
+    forward_deser!(deserialize_u64);
+    forward_deser!(deserialize_i64);
+    forward_deser!(deserialize_u128);
+    forward_deser!(deserialize_i128);
+    forward_deser!(deserialize_f32);
+    forward_deser!(deserialize_f64);
+    forward_deser!(deserialize_char);
+    forward_deser!(deserialize_str);
+    forward_deser!(deserialize_string);
+    forward_deser!(deserialize_identifier);
+
+    #[inline]
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.value.deserialize_unit_struct(name, visitor)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Value::String(s) => visitor.visit_bytes(s.as_bytes()),
+            Value::Object(o) => visit_value_object_for_bytes(o, self.binary_payloads, visitor),
+            Value::Array(a) => visit_value_array_for_bytes(a, visitor),
+            _ => Err(serde_json::Error::invalid_type(
+                unexpected_value(&self.value),
+                &"byte array or binary payload",
+            )),
+        }
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    #[inline]
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    #[inline]
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Value::Null => visitor.visit_none(),
+            Value::Array(a) => visit_value_array::<'a, 'de, V, T>(a, self.binary_payloads, visitor),
+            Value::Object(o) => {
+                visit_value_object::<'a, 'de, V, T>(o, self.binary_payloads, visitor)
+            }
+            other => other.deserialize_option(visitor),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Value::Array(a) => visit_value_array::<'a, 'de, V, T>(a, self.binary_payloads, visitor),
+            Value::Object(o) => {
+                visit_value_object::<'a, 'de, V, T>(o, self.binary_payloads, visitor)
+            }
+            _ => Err(serde_json::Error::invalid_type(
+                unexpected_value(&self.value),
+                &visitor,
+            )),
+        }
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Value::Object(o) => {
+                visit_value_object::<'a, 'de, V, T>(o, self.binary_payloads, visitor)
+            }
+            _ => Err(serde_json::Error::invalid_type(
+                unexpected_value(&self.value),
+                &visitor,
+            )),
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Value::Array(a) => visit_value_array::<'a, 'de, V, T>(a, self.binary_payloads, visitor),
+            _ => Err(serde_json::Error::invalid_type(
+                unexpected_value(&self.value),
+                &visitor,
+            )),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Value::Object(o) => {
+                // From serde_json: enums are encoded as a map with _only_ a single key-value pair
+                if o.len() == 1 {
+                    let (variant, value) = o.into_iter().next().unwrap();
+                    visitor.visit_enum(EnumDeserializer {
+                        variant,
+                        value: Some(value),
+                        binary_payloads: self.binary_payloads,
+                        _phantom: PhantomData::<T>,
+                    })
+                } else {
+                    Err(serde_json::Error::invalid_value(
+                        Unexpected::Map,
+                        &"a map with a single key-value pair",
+                    ))
+                }
+            }
+            Value::String(s) => visitor.visit_enum(EnumDeserializer {
+                variant: s,
+                value: None,
+                binary_payloads: self.binary_payloads,
+                _phantom: PhantomData::<T>,
+            }),
+            _ => Err(serde_json::Error::invalid_type(
+                unexpected_value(&self.value),
+                &"map or string",
+            )),
+        }
+    }
+
+    #[inline]
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        drop(self);
+        visitor.visit_unit()
+    }
+}
+
+fn visit_value_object_for_bytes<'a: 'a, 'de, V>(
+    o: Map<String, Value>,
+    binary_payloads: &'a [Bytes],
+    visitor: V,
+) -> Result<V::Value, serde_json::Error>
+where
+    V: de::Visitor<'de>,
+{
+    if !o.len() == 2
+        || !o
+            .get("_placeholder")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    {
+        Err(serde_json::Error::invalid_type(
+            Unexpected::Map,
+            &"binary payload placeholder object",
+        ))
+    } else if let Some(num) = o.get("num").and_then(|v| v.as_u64()) {
+        if let Some(payload) = binary_payloads.get(num as usize) {
+            visitor.visit_bytes(payload)
+        } else {
+            Err(serde_json::Error::invalid_value(
+                Unexpected::Unsigned(num),
+                &"a payload number in range",
+            ))
+        }
+    } else {
+        Err(serde_json::Error::invalid_value(
+            Unexpected::Map,
+            &"binary payload placeholder without valid num",
+        ))
+    }
+}
+
+fn visit_value_array_for_bytes<'de, V>(
+    a: Vec<Value>,
+    visitor: V,
+) -> Result<V::Value, serde_json::Error>
+where
+    V: de::Visitor<'de>,
+{
+    let bytes = a
+        .into_iter()
+        .map(|v| match v {
+            Value::Number(n) => n
+                .as_u64()
+                .and_then(|n| u8::try_from(n).ok())
+                .ok_or_else(|| {
+                    serde_json::Error::invalid_value(
+                        Unexpected::Other("non-u8 number"),
+                        &"number that fits in a u8",
+                    )
+                }),
+            _ => Err(serde_json::Error::invalid_value(
+                unexpected_value(&v),
+                &"number that fits in a u8",
+            )),
+        })
+        .collect::<Result<Vec<u8>, _>>()?;
+    visitor.visit_bytes(&bytes)
+}
+
+fn visit_value_object<'a: 'a, 'de, V, T>(
+    o: Map<String, Value>,
+    binary_payloads: &'a [Bytes],
+    visitor: V,
+) -> Result<V::Value, serde_json::Error>
+where
+    V: de::Visitor<'de>,
+    T: serde::Deserialize<'de>,
+{
+    let len = o.len();
+
+    let mut deser = MapDeserializer {
+        iter: o.into_iter(),
+        binary_payloads,
+        value: None,
+        _phantom: PhantomData::<T>,
+    };
+    let map = visitor.visit_map(&mut deser)?;
+    if deser.iter.len() == 0 {
+        Ok(map)
+    } else {
+        Err(serde_json::Error::invalid_length(
+            len,
+            &"fewer elements in map",
+        ))
+    }
+}
+
+fn visit_value_array<'a: 'a, 'de, V, T>(
+    a: Vec<Value>,
+    binary_payloads: &'a [Bytes],
+    visitor: V,
+) -> Result<V::Value, serde_json::Error>
+where
+    V: de::Visitor<'de>,
+    T: serde::Deserialize<'de>,
+{
+    let len = a.len();
+    let mut deser = SeqDeserializer {
+        iter: a.into_iter(),
+        binary_payloads,
+        _phantom: PhantomData::<T>,
+    };
+    let seq = visitor.visit_seq(&mut deser)?;
+    if deser.iter.len() == 0 {
+        Ok(seq)
+    } else {
+        Err(serde_json::Error::invalid_length(
+            len,
+            &"fewer elements in seq",
+        ))
+    }
+}
+
+struct MapDeserializer<'a, T> {
+    iter: <Map<String, Value> as IntoIterator>::IntoIter,
+    binary_payloads: &'a [Bytes],
+    value: Option<Value>,
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, 'de, T: serde::Deserialize<'de>> MapAccess<'de> for MapDeserializer<'a, T> {
+    type Error = serde_json::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                let key_deser = MapKeyDeserializer::from(key);
+                seed.deserialize(key_deser).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => {
+                let payload = Deserializer {
+                    value,
+                    binary_payloads: self.binary_payloads,
+                    _phantom: PhantomData::<T>,
+                };
+                seed.deserialize(payload)
+            }
+            None => Err(serde_json::Error::custom("value is missing")),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct SeqDeserializer<'a, T> {
+    iter: <Vec<Value> as IntoIterator>::IntoIter,
+    binary_payloads: &'a [Bytes],
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, 'de, T: serde::Deserialize<'de>> SeqAccess<'de> for SeqDeserializer<'a, T> {
+    type Error = serde_json::Error;
+
+    fn next_element_seed<S>(&mut self, seed: S) -> Result<Option<S::Value>, Self::Error>
+    where
+        S: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => {
+                let payload = Deserializer {
+                    value,
+                    binary_payloads: self.binary_payloads,
+                    _phantom: PhantomData::<T>,
+                };
+                seed.deserialize(payload).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct EnumDeserializer<'a, T> {
+    variant: String,
+    value: Option<Value>,
+    binary_payloads: &'a [Bytes],
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, 'de, T: serde::Deserialize<'de>> EnumAccess<'de> for EnumDeserializer<'a, T> {
+    type Variant = VariantDeserializer<'a, T>;
+    type Error = serde_json::Error;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = self.variant.into_deserializer();
+        let visitor = VariantDeserializer {
+            value: self.value,
+            binary_payloads: self.binary_payloads,
+            _phantom: PhantomData::<T>,
+        };
+        seed.deserialize(variant).map(|v| (v, visitor))
+    }
+}
+
+struct VariantDeserializer<'a, T> {
+    value: Option<Value>,
+    binary_payloads: &'a [Bytes],
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, 'de, T: serde::Deserialize<'de>> VariantAccess<'de> for VariantDeserializer<'a, T> {
+    type Error = serde_json::Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        match self.value {
+            Some(value) => {
+                let deser = Deserializer {
+                    value,
+                    binary_payloads: self.binary_payloads,
+                    _phantom: PhantomData::<T>,
+                };
+                serde::Deserialize::deserialize(deser)
+            }
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<S>(self, seed: S) -> Result<S::Value, Self::Error>
+    where
+        S: DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => {
+                let deser = Deserializer {
+                    value,
+                    binary_payloads: self.binary_payloads,
+                    _phantom: PhantomData::<T>,
+                };
+                seed.deserialize(deser)
+            }
+            None => Err(serde_json::Error::invalid_type(
+                Unexpected::Unit,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(Value::Array(a)) => {
+                if a.is_empty() {
+                    visitor.visit_unit()
+                } else {
+                    visit_value_array::<'a, 'de, V, T>(a, self.binary_payloads, visitor)
+                }
+            }
+            Some(other) => Err(serde_json::Error::invalid_type(
+                unexpected_value(&other),
+                &"tuple variant",
+            )),
+            None => Err(serde_json::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(Value::Object(o)) => {
+                visit_value_object::<'a, 'de, V, T>(o, self.binary_payloads, visitor)
+            }
+            Some(other) => Err(serde_json::Error::invalid_type(
+                unexpected_value(&other),
+                &"struct variant",
+            )),
+            None => Err(serde_json::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}
+
+/// Helper struct that implements `std::io::Read`, which allows us to use
+/// `serde_json::Deserializer` to deserialize a string into a `serde_json::Number`.
+struct VecRead {
+    vec: Vec<u8>,
+    pos: usize,
+}
+
+impl<'any> From<Cow<'any, str>> for VecRead {
+    fn from(value: Cow<'any, str>) -> Self {
+        Self {
+            vec: value.to_string().into_bytes(),
+            pos: 0,
+        }
+    }
+}
+
+impl std::io::Read for VecRead {
+    fn read(&mut self, mut buf: &mut [u8]) -> std::io::Result<usize> {
+        use std::io::Write;
+
+        let to_write = std::cmp::min(buf.len(), self.vec.len() - self.pos);
+        if to_write > 0 {
+            let written = buf.write(&self.vec[self.pos..to_write])?;
+            self.pos += to_write;
+            Ok(written)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+struct MapKeyDeserializer<'de> {
+    key: Cow<'de, str>,
+}
+
+impl<'de> From<String> for MapKeyDeserializer<'de> {
+    fn from(value: String) -> Self {
+        MapKeyDeserializer {
+            key: Cow::Owned(value),
+        }
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
+    type Error = serde_json::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        MapKeyStrDeserializer::from(self.key).deserialize_any(visitor)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.key.as_ref() {
+            "true" => visitor.visit_bool(true),
+            "false" => visitor.visit_bool(false),
+            _ => Err(serde_json::Error::invalid_type(
+                Unexpected::Str(&self.key),
+                &visitor,
+            )),
+        }
+    }
+
+    impl_deser_numeric_key!(deserialize_i8);
+    impl_deser_numeric_key!(deserialize_i16);
+    impl_deser_numeric_key!(deserialize_i32);
+    impl_deser_numeric_key!(deserialize_i64);
+    impl_deser_numeric_key!(deserialize_u8);
+    impl_deser_numeric_key!(deserialize_u16);
+    impl_deser_numeric_key!(deserialize_u32);
+    impl_deser_numeric_key!(deserialize_u64);
+    impl_deser_numeric_key!(deserialize_f64);
+    impl_deser_numeric_key!(deserialize_f32);
+    impl_deser_numeric_key!(deserialize_i128);
+    impl_deser_numeric_key!(deserialize_u128);
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.key
+            .into_deserializer()
+            .deserialize_enum(name, variants, visitor)
+    }
+
+    forward_to_deserialize_any! {
+        char str string bytes byte_buf unit unit_struct seq tuple tuple_struct
+        map struct identifier ignored_any
+    }
+}
+
+struct MapKeyStrDeserializer<'de> {
+    key: Cow<'de, str>,
+}
+
+impl<'de> From<Cow<'de, str>> for MapKeyStrDeserializer<'de> {
+    fn from(value: Cow<'de, str>) -> Self {
+        Self { key: value }
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for MapKeyStrDeserializer<'de> {
+    type Error = serde_json::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.key {
+            Cow::Owned(s) => visitor.visit_string(s),
+            Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_enum(self)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct identifier ignored_any
+    }
+}
+
+impl<'de> EnumAccess<'de> for MapKeyStrDeserializer<'de> {
+    type Variant = UnitEnum;
+    type Error = serde_json::Error;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        Ok((seed.deserialize(self)?, UnitEnum))
+    }
+}
+
+struct UnitEnum;
+
+impl<'de> VariantAccess<'de> for UnitEnum {
+    type Error = serde_json::Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(serde_json::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"tuple variant",
+        ))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(serde_json::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"struct variant",
+        ))
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        Err(serde_json::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"newtype variant",
+        ))
+    }
+}
+
+fn unexpected_value(v: &Value) -> Unexpected<'_> {
+    match v {
+        Value::Null => Unexpected::Unit,
+        Value::Bool(b) => Unexpected::Bool(*b),
+        Value::Number(n) => {
+            if let Some(n) = n.as_u64() {
+                Unexpected::Unsigned(n)
+            } else if let Some(n) = n.as_i64() {
+                Unexpected::Signed(n)
+            } else if let Some(n) = n.as_f64() {
+                Unexpected::Float(n)
+            } else {
+                Unexpected::Other("non-unsigned, non-signed, non-float number")
+            }
+        }
+        Value::String(s) => Unexpected::Str(s),
+        Value::Array(_) => Unexpected::Seq,
+        Value::Object(_) => Unexpected::Map,
+    }
+}
+
+/// Converts a [`serde_json::Value`], with optional binary payloads into an arbitrary data type.
+///
+/// # Arguments
+///
+/// - `value` - a [`serde_json::Value`], with any binary blobs replaced with socket.io placeholder
+///             objects
+/// - `binary_payloads` - a [`Vec`] of binary payloads, in the order specified by the `num` fields
+///                       of the placeholder objecst in `value`
+pub fn from_value<'de, 'a, T: serde::Deserialize<'de> + 'a>(
+    value: Value,
+    binary_payloads: &'a [Bytes],
+) -> Result<T, serde_json::Error> {
+    let payload = Deserializer {
+        value,
+        binary_payloads,
+        _phantom: PhantomData::<T>,
+    };
+
+    T::deserialize(payload)
+}

--- a/socketioxide/src/value/mod.rs
+++ b/socketioxide/src/value/mod.rs
@@ -1,0 +1,179 @@
+pub(crate) mod de;
+pub(crate) mod ser;
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Value};
+
+    use super::de::from_value;
+    use super::ser::to_value;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestSubPayload {
+        more_binary: Bytes,
+        opt_int: Option<i32>,
+        opt_float: Option<f32>,
+        opt_string: Option<String>,
+        opt_boolean: Option<bool>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestPayload {
+        uint: u32,
+        float: f64,
+        binary: Bytes,
+        string: String,
+        boolean: bool,
+        array: Vec<String>,
+        sub_payload: TestSubPayload,
+    }
+
+    const BINARY_PAYLOAD: &[u8] = &[1, 2, 3, 4, 5, 6, 7];
+    const MORE_BINARY_PAYLOAD: &[u8] = &[10, 9, 8, 7, 6, 5];
+
+    fn build_bins() -> Vec<Bytes> {
+        vec![
+            Bytes::from_static(BINARY_PAYLOAD),
+            Bytes::from_static(MORE_BINARY_PAYLOAD),
+        ]
+    }
+
+    fn build_test_payload(fill_options: bool) -> TestPayload {
+        let fill_options = fill_options.then_some(true);
+        TestPayload {
+            uint: 42,
+            float: 1.75,
+            binary: Bytes::from_static(BINARY_PAYLOAD),
+            string: "test string".to_string(),
+            boolean: true,
+            array: ["one", "two", "three"]
+                .into_iter()
+                .map(ToString::to_string)
+                .collect(),
+            sub_payload: TestSubPayload {
+                more_binary: Bytes::from_static(MORE_BINARY_PAYLOAD),
+                opt_int: fill_options.map(|_| 99),
+                opt_float: fill_options.map(|_| 2.5),
+                opt_string: fill_options.map(|_| "another test string".to_string()),
+                opt_boolean: fill_options,
+            },
+        }
+    }
+
+    fn build_test_value(fill_options: bool) -> Value {
+        let sub_payload = if fill_options {
+            json!({
+                "more_binary": {
+                    "_placeholder": true,
+                    "num": 1
+                },
+                "opt_int": 99,
+                "opt_float": 2.5,
+                "opt_string": "another test string",
+                "opt_boolean": true
+            })
+        } else {
+            json!({
+                "more_binary": {
+                    "_placeholder": true,
+                    "num": 1
+                },
+                "opt_int": null,
+                "opt_float": null,
+                "opt_string": null,
+                "opt_boolean": null
+            })
+        };
+
+        let mut main_payload = json!({
+            "uint": 42,
+            "float": 1.75,
+            "binary": {
+                "_placeholder": true,
+                "num": 0
+            },
+            "string": "test string",
+            "boolean": true,
+            "array": [
+                "one",
+                "two",
+                "three"
+            ]
+        });
+
+        if let Value::Object(ref mut o) = &mut main_payload {
+            o.insert("sub_payload".to_string(), sub_payload);
+        } else {
+            panic!("test bug: not an object");
+        }
+
+        main_payload
+    }
+
+    #[test]
+    pub fn test_value_from_data() {
+        let (value, bins) = to_value(build_test_payload(true)).unwrap();
+        assert_eq!(build_test_value(true), value);
+        assert_eq!(bins.len(), 2);
+        assert_eq!(bins[0], Bytes::from_static(BINARY_PAYLOAD));
+        assert_eq!(bins[1], Bytes::from_static(MORE_BINARY_PAYLOAD));
+    }
+
+    #[test]
+    pub fn test_value_into_data() {
+        let data: TestPayload =
+            from_value(build_test_value(true), build_bins().as_slice()).unwrap();
+        assert_eq!(data, build_test_payload(true));
+    }
+
+    /*
+
+    #[test]
+    pub fn test_payload_value_to_json_value() {
+        let payload_value = build_test_payload_value(true, false);
+        let json = payload_value.to_value().unwrap();
+        assert_eq!(json, build_test_payload_json_value(true));
+
+        let payload_value = build_test_payload_value(false, false);
+        let json = payload_value.to_value().unwrap();
+        assert_eq!(json, build_test_payload_json_value(false));
+    }
+
+    #[test]
+    pub fn test_payload_value_from_json_value() {
+        let json = build_test_payload_json_value(true);
+        let payload_value: PayloadValue = serde_json::from_value(json).unwrap();
+        assert_eq!(payload_value, build_test_payload_value(true, false));
+
+        let json = build_test_payload_json_value(false);
+        let payload_value: PayloadValue = serde_json::from_value(json).unwrap();
+        assert_eq!(payload_value, build_test_payload_value(false, false));
+    }
+
+    #[test]
+    pub fn test_count_payloads() {
+        let payload_value = build_test_payload_value(true, false);
+        assert_eq!(payload_value.count_payloads(), 2);
+    }
+
+    #[test]
+    pub fn test_extract_binary_payloads() {
+        let test_payload = build_test_payload(true);
+        let payload_value = build_test_payload_value(true, true);
+        let bins = payload_value.get_binary_payloads();
+
+        assert_eq!(bins.len(), 2);
+        assert_eq!(bins[0], *test_payload.binary);
+        assert_eq!(bins[1], *test_payload.sub_payload.more_binary);
+    }
+
+    #[test]
+    pub fn test_payload_value_redeser() {
+        let payload_value_again: PayloadValue =
+            build_test_payload_value(true, true).into_data().unwrap();
+        assert_eq!(build_test_payload_value(true, true), payload_value_again);
+    }
+    */
+}

--- a/socketioxide/src/value/ser.rs
+++ b/socketioxide/src/value/ser.rs
@@ -1,0 +1,547 @@
+use bytes::Bytes;
+use serde::ser::{Error, Impossible, SerializeSeq};
+use serde_json::{Map, Value};
+
+const KEY_STRING_ERROR: &str = "key must be a string";
+
+macro_rules! forward_ser_impl {
+    ($method:ident, $ty:ty) => {
+        fn $method(self, v: $ty) -> Result<Self::Ok, Self::Error> {
+            serde_json::value::Serializer.$method(v)
+        }
+    };
+}
+
+#[derive(Default)]
+struct Serializer {
+    binary_payloads: Vec<(usize, Bytes)>,
+    next_binary_payload_num: usize,
+}
+
+impl<'a> serde::Serializer for &'a mut Serializer {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    type SerializeSeq = SerializeVec<'a>;
+    type SerializeTuple = SerializeVec<'a>;
+    type SerializeTupleVariant = SerializeTupleVariant<'a>;
+    type SerializeMap = SerializeMap<'a>;
+    type SerializeStruct = SerializeMap<'a>;
+    type SerializeStructVariant = SerializeStructVariant<'a>;
+    type SerializeTupleStruct = SerializeVec<'a>;
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        serde_json::value::Serializer.serialize_unit()
+    }
+
+    forward_ser_impl!(serialize_bool, bool);
+    forward_ser_impl!(serialize_i8, i8);
+    forward_ser_impl!(serialize_u8, u8);
+    forward_ser_impl!(serialize_i16, i16);
+    forward_ser_impl!(serialize_u16, u16);
+    forward_ser_impl!(serialize_i32, i32);
+    forward_ser_impl!(serialize_u32, u32);
+    forward_ser_impl!(serialize_i64, i64);
+    forward_ser_impl!(serialize_u64, u64);
+    forward_ser_impl!(serialize_i128, i128);
+    forward_ser_impl!(serialize_u128, u128);
+    forward_ser_impl!(serialize_f32, f32);
+    forward_ser_impl!(serialize_f64, f64);
+    forward_ser_impl!(serialize_char, char);
+    forward_ser_impl!(serialize_str, &str);
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        let num = self.next_binary_payload_num;
+        self.next_binary_payload_num += 1;
+        self.binary_payloads.push((num, Bytes::copy_from_slice(v)));
+        Ok(Value::Object(
+            [
+                ("_placeholder".to_string(), Value::Bool(true)),
+                ("num".to_string(), Value::Number(num.into())),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        serde_json::value::Serializer.serialize_unit_struct(name)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        serde_json::value::Serializer.serialize_unit_variant(name, variant_index, variant)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        serde_json::value::Serializer.serialize_none()
+    }
+
+    fn serialize_some<T: ?Sized + serde::Serialize>(
+        self,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(SerializeVec {
+            root_ser: self,
+            elements: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(SerializeTupleVariant {
+            root_ser: self,
+            name: String::from(variant),
+            elements: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(SerializeMap {
+            root_ser: self,
+            map: Map::new(),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(SerializeStructVariant {
+            root_ser: self,
+            name: String::from(variant),
+            map: Map::new(),
+        })
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        let mut obj = Map::new();
+        obj.insert(name.to_string(), value.serialize(self)?);
+        Ok(Value::Object(obj))
+    }
+
+    fn collect_str<T: ?Sized + std::fmt::Display>(
+        self,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::String(value.to_string()))
+    }
+}
+
+struct SerializeVec<'a> {
+    root_ser: &'a mut Serializer,
+    elements: Vec<Value>,
+}
+
+impl<'a> SerializeSeq for SerializeVec<'a> {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    fn serialize_element<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        let element = value.serialize(&mut *self.root_ser)?;
+        self.elements.push(element);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Array(self.elements))
+    }
+}
+
+impl<'a> serde::ser::SerializeTuple for SerializeVec<'a> {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    fn serialize_element<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+impl<'a> serde::ser::SerializeTupleStruct for SerializeVec<'a> {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+struct SerializeTupleVariant<'a> {
+    root_ser: &'a mut Serializer,
+    name: String,
+    elements: Vec<Value>,
+}
+
+impl<'a> serde::ser::SerializeTupleVariant for SerializeTupleVariant<'a> {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        let element = value.serialize(&mut *self.root_ser)?;
+        self.elements.push(element);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut obj = Map::new();
+        obj.insert(self.name, Value::Array(self.elements));
+        Ok(Value::Object(obj))
+    }
+}
+
+struct SerializeMap<'a> {
+    root_ser: &'a mut Serializer,
+    map: Map<String, Value>,
+    next_key: Option<String>,
+}
+
+impl<'a> serde::ser::SerializeMap for SerializeMap<'a> {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    fn serialize_key<T: ?Sized + serde::Serialize>(&mut self, key: &T) -> Result<(), Self::Error> {
+        self.next_key = Some(key.serialize(MapKeySerializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized + serde::Serialize>(
+        &mut self,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        if let Some(key) = self.next_key.take() {
+            self.map.insert(key, value.serialize(&mut *self.root_ser)?);
+            Ok(())
+        } else {
+            panic!("serialize_value() called before serialize_key()");
+        }
+    }
+
+    fn serialize_entry<K: ?Sized + serde::Serialize, V: ?Sized + serde::Serialize>(
+        &mut self,
+        key: &K,
+        value: &V,
+    ) -> Result<(), Self::Error> {
+        self.map.insert(
+            key.serialize(MapKeySerializer)?,
+            value.serialize(&mut *self.root_ser)?,
+        );
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Object(self.map))
+    }
+}
+
+impl<'a> serde::ser::SerializeStruct for SerializeMap<'a> {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        serde::ser::SerializeMap::serialize_entry(self, key, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        serde::ser::SerializeMap::end(self)
+    }
+}
+
+struct SerializeStructVariant<'a> {
+    root_ser: &'a mut Serializer,
+    name: String,
+    map: Map<String, Value>,
+}
+
+impl<'a> serde::ser::SerializeStructVariant for SerializeStructVariant<'a> {
+    type Ok = Value;
+    type Error = serde_json::Error;
+
+    fn serialize_field<T: ?Sized + serde::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        self.map
+            .insert(key.to_string(), value.serialize(&mut *self.root_ser)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let mut obj = Map::new();
+        obj.insert(self.name, Value::Object(self.map));
+        Ok(Value::Object(obj))
+    }
+}
+
+struct MapKeySerializer;
+
+impl serde::Serializer for MapKeySerializer {
+    type Ok = String;
+    type Error = serde_json::Error;
+
+    type SerializeSeq = Impossible<String, Self::Error>;
+    type SerializeMap = Impossible<String, Self::Error>;
+    type SerializeTuple = Impossible<String, Self::Error>;
+    type SerializeStruct = Impossible<String, Self::Error>;
+    type SerializeTupleStruct = Impossible<String, Self::Error>;
+    type SerializeTupleVariant = Impossible<String, Self::Error>;
+    type SerializeStructVariant = Impossible<String, Self::Error>;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_some<T: ?Sized + serde::Serialize>(
+        self,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::custom(KEY_STRING_ERROR))
+    }
+}
+
+/// Converts an arbitrary data type to a [`serde_json::Value`], extracting any binary payloads.
+///
+/// Binary data should be represented using the type [`bytes::Bytes`], or any other type that
+/// implements [`serde::Serialize`] by serializing to bytes.  You can also use
+/// `#[serde(serialize_with = "...")]` on a custom or existing type.
+///
+/// # Arguments
+///
+/// - `data` - a data type that implements [`serde::Serialize`]
+pub fn to_value<T: serde::Serialize>(data: T) -> Result<(Value, Vec<Bytes>), serde_json::Error> {
+    let mut ser = Serializer::default();
+    let value = data.serialize(&mut ser)?;
+
+    ser.binary_payloads
+        .sort_by(|(num_a, _), (num_b, _)| num_a.cmp(num_b));
+
+    Ok((
+        value,
+        ser.binary_payloads
+            .into_iter()
+            .map(|(_, bin)| bin)
+            .collect(),
+    ))
+}

--- a/socketioxide/tests/concurrent_emit.rs
+++ b/socketioxide/tests/concurrent_emit.rs
@@ -6,7 +6,7 @@ mod utils;
 
 use bytes::Bytes;
 use engineioxide::Packet::*;
-use socketioxide::{extract::SocketRef, SocketIo};
+use socketioxide::{extract::SocketRef, packet::create_binary_placeholder, SocketIo};
 
 #[tokio::test]
 pub async fn emit() {
@@ -21,7 +21,14 @@ pub async fn emit() {
                         Bytes::from_static(&[1, 2, 3]),
                         Bytes::from_static(&[4, 5, 6]),
                     ])
-                    .emit("test", "bin".into())
+                    .emit(
+                        "test",
+                        serde_json::Value::Array(vec![
+                            "bin".into(),
+                            create_binary_placeholder(0),
+                            create_binary_placeholder(1),
+                        ]),
+                    )
                     .unwrap();
                 }
             });

--- a/socketioxide/tests/concurrent_emit.rs
+++ b/socketioxide/tests/concurrent_emit.rs
@@ -21,7 +21,7 @@ pub async fn emit() {
                         Bytes::from_static(&[1, 2, 3]),
                         Bytes::from_static(&[4, 5, 6]),
                     ])
-                    .emit("test", "bin")
+                    .emit("test", "bin".into())
                     .unwrap();
                 }
             });

--- a/socketioxide/tests/connect.rs
+++ b/socketioxide/tests/connect.rs
@@ -2,6 +2,7 @@ mod utils;
 
 use bytes::Bytes;
 use engineioxide::Packet::*;
+use serde_json::Value;
 use socketioxide::{extract::SocketRef, handler::ConnectHandler, SendError, SocketError, SocketIo};
 use tokio::sync::mpsc;
 
@@ -17,7 +18,7 @@ pub async fn connect_middleware() {
 
             assert!(matches!(
                 s.emit("test", ()),
-                Err(SendError::Socket(SocketError::Closed(())))
+                Err(SendError::Socket(SocketError::Closed(Value::Null)))
             ));
 
             assert!(matches!(
@@ -27,13 +28,13 @@ pub async fn connect_middleware() {
 
             assert!(matches!(
                 s.bin(vec![Bytes::from_static(&[0, 1, 2, 3])])
-                    .emit("test", ()),
-                Err(SendError::Socket(SocketError::Closed(())))
+                    .emit("test", Value::Null),
+                Err(SendError::Socket(SocketError::Closed(Value::Null)))
             ));
             assert!(matches!(
                 s.bin(vec![Bytes::from_static(&[0, 1, 2, 3])])
-                    .emit_with_ack::<(), ()>("test", ()),
-                Err(SendError::Socket(SocketError::Closed(())))
+                    .emit_with_ack::<()>("test", Value::Null),
+                Err(SendError::Socket(SocketError::Closed(Value::Null)))
             ));
 
             tx1.try_send(i).unwrap();


### PR DESCRIPTION
This allows users to create a payload struct (that implements `Serialize`/`Deserialize`) that has any binary payload data embedded in the struct directly, rather than needing to look in a "side" `Vec` of payload data, and have to guess what order the binary payloads fit into their data model.

To accomplish this, there are new `Serializer` and `Deserializer` implementations that mostly wrap the Ser/Deser impls provided for `serde_json::Value`.  Unfortunately `serde_json` doesn't expose everything necessary to do this in a truly simple way; some duplication of `serde_json`'s functionality is needed.

~~NB: due to difficulties with lifetimes, the deserializer has to currently clone the `Vec` of binary payloads as they get passed around to sub-deserializers.  While this isn't the worst thing (cloning `Bytes` is cheap), it's not free, and this needs to be revisited and fixed.~~
    
Depends on #285.
Closes #276.
Supersedes #283.

I also took the opportunity to migrate both socketioxide and engineioxide from representing binary payloads as `Vec<u8>` to `bytes::Bytes`.  This is more or less necessary in socketioxide, but isn't strictly necessary for engineioxide, though IMO it's nice to be consistent.  I can move that to a separate PR if you'd prefer.

Some notes:

* ~~Aside from the very basic tests I wrote, I haven't tested this.~~ I've done a little more ad-hoc testing and have fixed up all of the unit/doc/e2e tests, so I feel a bit more confident about the code.
* I haven't benchmarked this; ~~would like to solve the lifetimes issue so I can stop cloning the binary payloads first.~~
* There's probably some documentation that needs to be updated, will need to go through it.  At the very least there should be a mention that if anyone has a data type that contains binary payloads and wants to convert to a `serde_json::Value`, they should use `socketioxide::to_value()` instead of `serde_json::to_value()`, as the former will extract binary bits and replace with placeholders, while the latter will serialize the binary bits to a JSON array of numbers.
* With this new implementation, we don't remove the `Bin` extractor or the `.bin()` methods on the socket/ack/etc.  If the user is using `serde_json::Value` instead of a custom struct with embedded `Bytes` members, they'll need both of those things.
* Despite `Bin` still being there, it maybe should implement `FromMessageParts`, since cloning `Bytes` is cheap, and (hopefully) the most common usage should be `Data` with a custom struct with embedded `Bytes` members.  `Data`, in this case, should probably implement `FromMessage` only.  As discussed before, I think `TryData` should remain as `FromMessageParts` in case users need to attempt to deserialize more than once.  I haven't implemented these changes.