### PR TITLE
v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.1
+## socketioxide
+* fix(#232): under heavy traffic, the adjacent binary packet to the head packet requirement for engine.io was not respected. It was leading to a protocol error. 
+
 # 0.11.0
 ## socketioxide
 * fix: a panic was raised sometimes under heavy traffic with socketio v5 when the connect timeout handler is destroyed but that the chan sender is still alive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.12.0
+**MSRV**: Minimum supported Rust version is now 1.75.
+
+# socketioxide
+* **(Breaking)**: Introduction of [connect middlewares](https://docs.rs/socketioxide/latest/socketioxide/#middlewares). It allows to execute code before the connection to the namespace is established. It is useful to check the request, to authenticate the user, to log the connection etc. It is possible to add multiple middlewares and to chain them.
+* The `SocketRef` extractor is now `Clone`. Be careful to drop clones when the socket is disconnected to avoid any memory leak.
+
 # 0.11.1
 ## socketioxide
 * fix(#232): under heavy traffic, the adjacent binary packet to the head packet requirement for engine.io was not respected. It was leading to a protocol error. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]
@@ -7,9 +7,9 @@ repository = "https://github.com/totodore/socketioxide"
 homepage = "https://github.com/totodore/socketioxide"
 keywords = ["socketio", "tower", "axum", "hyper", "websocket"]
 categories = [
-	"asynchronous",
-	"network-programming",
-	"web-programming::websocket",
+    "asynchronous",
+    "network-programming",
+    "web-programming::websocket",
 ]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.11.0" }
+engineioxide = { path = "../engineioxide", version = "0.11.1" }
 futures.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 serde.workspace = true
@@ -45,18 +45,18 @@ state = ["dep:state"]
 
 [dev-dependencies]
 engineioxide = { path = "../engineioxide", features = [
-	"v3",
-	"tracing",
-	"test-utils",
+    "v3",
+    "tracing",
+    "test-utils",
 ] }
 tokio-tungstenite.workspace = true
 rust_socketio.workspace = true
 axum.workspace = true
 salvo.workspace = true
 tokio = { workspace = true, features = [
-	"macros",
-	"parking_lot",
-	"rt-multi-thread",
+    "macros",
+    "parking_lot",
+    "rt-multi-thread",
 ] }
 tracing-subscriber.workspace = true
 criterion.workspace = true

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.11.1" }
+engineioxide = { path = "../engineioxide", version = "0.12.0" }
 futures.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 serde.workspace = true


### PR DESCRIPTION
**MSRV**: Minimum supported Rust version is now 1.75.

# socketioxide
* **(Breaking)**: Introduction of [connect middlewares](https://docs.rs/socketioxide/latest/socketioxide/#middlewares). It allows to execute code before the connection to the namespace is established. It is useful to check the request, to authenticate the user, to log the connection etc. It is possible to add multiple middlewares and to chain them.
* The `SocketRef` extractor is now `Clone`. Be careful to drop clones when the socket is disconnected to avoid any memory leak.