### PR TITLE
tests: Improve test bed

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -18,7 +18,9 @@ jobs:
             toolchain: stable
             components: rustfmt
         - run: cargo fmt --all -- --check
-  
+          env:
+            RUSTFLAGS: --cfg=socketioxide_test
+    
   test:
     runs-on: ubuntu-latest
     
@@ -37,7 +39,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo test --tests --all-features --workspace
-
+        env:
+          RUSTFLAGS: --cfg=socketioxide_test
   udeps:
     runs-on: ubuntu-latest
     steps:
@@ -87,6 +90,8 @@ jobs:
 
       - name: check crates
         run: cargo check -p socketioxide -p engineioxide --all-features
+        env:
+          RUSTFLAGS: --cfg=socketioxide_test
 
   feature_set:
     runs-on: ubuntu-latest
@@ -111,7 +116,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: check --feature-powerset
-        run: cargo hack check --feature-powerset --no-dev-deps --skip test-utils -p socketioxide -p engineioxide
+        run: cargo hack check --feature-powerset --no-dev-deps -p socketioxide -p engineioxide
 
   doctest:
     runs-on: ubuntu-latest
@@ -165,6 +170,8 @@ jobs:
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
+        env:
+          RUSTFLAGS: --cfg=socketioxide_test
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -118,6 +118,24 @@ jobs:
       - name: check --feature-powerset
         run: cargo hack check --feature-powerset --no-dev-deps -p socketioxide -p engineioxide
 
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            examples/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-examples
+      - run: cd examples && cargo check --all-features
+
   doctest:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,11 @@ You will need [rustc and cargo](www.rust-lang.org/tools/install).
     ```shell
     git clone https://github.com/totodore/socketioxide
     ```
+2. To test socketioxide don't forget to enable the flag `socketioxide-test` through the `RUSTFLAGS` environment variable:
 
+    ```shell
+    export RUSTFLAGS="--cfg socketioxide-test"
+    ```
 2. Depending on what you want to change, clone the [socketio/engine.io-protocol](https://github.com/socketio/engine.io-protocol) repo or the [socketio/socket.io-protocol](https://github.com/socketio/socket.io-protocol) repo or both
     ```shell
     git clone https://github.com/socketio/engine.io-protocol

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
 license = "MIT"
 
 [workspace]
-members = ["engineioxide", "socketioxide", "e2e/*", "examples/*"]
+members = ["engineioxide", "socketioxide", "e2e/*"]
 default-members = ["engineioxide", "socketioxide"]
 resolver = "2"
 
@@ -40,4 +40,3 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 axum = "0.7.2"
 salvo = { version = "0.66.0", features = ["tower-compat"] }
-rust_socketio = { version = "0.4.2", features = ["async"] }

--- a/engineioxide/Cargo.toml
+++ b/engineioxide/Cargo.toml
@@ -54,7 +54,6 @@ hyper-util = { workspace = true, features = ["tokio", "client-legacy"] }
 
 [features]
 v3 = ["memchr", "unicode-segmentation"]
-test-utils = []
 tracing = ["dep:tracing"]
 
 [[bench]]

--- a/engineioxide/src/lib.rs
+++ b/engineioxide/src/lib.rs
@@ -35,7 +35,7 @@
 pub use service::{ProtocolVersion, TransportType};
 pub use socket::{DisconnectReason, Socket};
 
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, socketioxide_test))]
 pub use packet::*;
 
 pub mod config;

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -488,7 +488,7 @@ where
         sid: Sid,
         close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
     ) -> Arc<Socket<D>> {
-        self.new_dummy_piped(sid, close_fn).0
+        Socket::new_dummy_piped(sid, close_fn).0
     }
 
     /// Create a dummy socket for testing purpose with a

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -488,7 +488,7 @@ where
         sid: Sid,
         close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
     ) -> Arc<Socket<D>> {
-        Socket::new_dummy_piped(sid, close_fn).0
+        Socket::new_dummy_piped(sid, close_fn, 1024).0
     }
 
     /// Create a dummy socket for testing purpose with a
@@ -496,9 +496,9 @@ where
     pub fn new_dummy_piped(
         sid: Sid,
         close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
+        buffer_size: usize,
     ) -> (Arc<Socket<D>>, tokio::sync::mpsc::Receiver<Packet>) {
-        const BUFFER_SIZE: usize = 1024;
-        let (internal_tx, internal_rx) = mpsc::channel(BUFFER_SIZE);
+        let (internal_tx, internal_rx) = mpsc::channel(buffer_size);
         let (heartbeat_tx, heartbeat_rx) = mpsc::channel(1);
 
         let sock = Self {
@@ -522,7 +522,7 @@ where
         };
         let sock = Arc::new(sock);
 
-        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
+        let (tx, rx) = mpsc::channel(buffer_size);
         let sock_clone = sock.clone();
         tokio::spawn(async move {
             let mut internal_rx = sock_clone.internal_rx.try_lock().unwrap();

--- a/engineioxide/src/socket.rs
+++ b/engineioxide/src/socket.rs
@@ -467,7 +467,7 @@ impl<D: Default + Send + Sync + 'static> std::fmt::Debug for Socket<D> {
     }
 }
 
-#[cfg(feature = "test-utils")]
+#[cfg(socketioxide_test)]
 impl<D> Drop for Socket<D>
 where
     D: Default + Send + Sync + 'static,
@@ -478,7 +478,7 @@ where
     }
 }
 
-#[cfg(feature = "test-utils")]
+#[cfg(any(socketioxide_test, test))]
 impl<D> Socket<D>
 where
     D: Default + Send + Sync + 'static,
@@ -487,11 +487,21 @@ where
     pub fn new_dummy(
         sid: Sid,
         close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
-    ) -> Socket<D> {
-        let (internal_tx, internal_rx) = mpsc::channel(200);
+    ) -> Arc<Socket<D>> {
+        self.new_dummy_piped(sid, close_fn).0
+    }
+
+    /// Create a dummy socket for testing purpose with a
+    /// receiver to get the packets sent to the client
+    pub fn new_dummy_piped(
+        sid: Sid,
+        close_fn: Box<dyn Fn(Sid, DisconnectReason) + Send + Sync>,
+    ) -> (Arc<Socket<D>>, tokio::sync::mpsc::Receiver<Packet>) {
+        const BUFFER_SIZE: usize = 1024;
+        let (internal_tx, internal_rx) = mpsc::channel(BUFFER_SIZE);
         let (heartbeat_tx, heartbeat_rx) = mpsc::channel(1);
 
-        Self {
+        let sock = Self {
             id: sid,
             protocol: ProtocolVersion::V4,
             transport: AtomicU8::new(TransportType::Websocket as u8),
@@ -509,6 +519,20 @@ where
 
             #[cfg(feature = "v3")]
             supports_binary: true,
-        }
+        };
+        let sock = Arc::new(sock);
+
+        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
+        let sock_clone = sock.clone();
+        tokio::spawn(async move {
+            let mut internal_rx = sock_clone.internal_rx.try_lock().unwrap();
+            while let Some(packets) = internal_rx.recv().await {
+                for packet in packets {
+                    tx.send(packet).await.unwrap();
+                }
+            }
+        });
+
+        (sock, rx)
     }
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+members = ["*"]
+exclude = ["target"]
+resolver = "2"
+
+[workspace.dependencies]
+futures = "0.3.27"
+tokio = "1.35.0"
+serde = { version = "1.0.193", features = ["derive"] }
+serde_json = "1.0.108"
+tower = { version = "0.4.13", default-features = false }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.18"
+axum = "0.7.5"
+hyper-util.version = "0.1.1"
+hyper = { version = "1.0.1", features = ["http1", "http2", "server"] }

--- a/examples/salvo-echo/Cargo.toml
+++ b/examples/salvo-echo/Cargo.toml
@@ -8,13 +8,13 @@ rust-version = "1.67" # required by salvo
 
 [dependencies]
 socketioxide = { path = "../../socketioxide", features = ["tracing"] }
-salvo.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
 tower.workspace = true
 tower-http = { version = "0.5.0", features = ["cors"] }
+salvo = { version = "0.66", features = ["tower-compat"] }
 
 [[bin]]
 name = "salvo-echo"

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -38,19 +38,13 @@ state = { version = "0.6.0", optional = true }
 
 [features]
 v4 = ["engineioxide/v3"]
-test-utils = []
 tracing = ["dep:tracing", "engineioxide/tracing"]
 extensions = ["dep:dashmap"]
 state = ["dep:state"]
 
 [dev-dependencies]
-engineioxide = { path = "../engineioxide", features = [
-    "v3",
-    "tracing",
-    "test-utils",
-] }
+engineioxide = { path = "../engineioxide", features = ["v3", "tracing"] }
 tokio-tungstenite.workspace = true
-rust_socketio.workspace = true
 axum.workspace = true
 salvo.workspace = true
 tokio = { workspace = true, features = [

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -150,10 +150,11 @@ impl<A: Adapter> Client<A> {
         tokio::sync::mpsc::Sender<engineioxide::Packet>,
         tokio::sync::mpsc::Receiver<engineioxide::Packet>,
     ) {
+        let buffer_size = self.config.engine_config.max_buffer_size;
         let sid = Sid::new();
-        let (esock, rx) = EIoSocket::new_dummy_piped(sid, Box::new(|_, _| {}));
+        let (esock, rx) = EIoSocket::new_dummy_piped(sid, Box::new(|_, _| {}), buffer_size);
 
-        let (tx1, mut rx1) = tokio::sync::mpsc::channel(1024);
+        let (tx1, mut rx1) = tokio::sync::mpsc::channel(buffer_size);
         tokio::spawn({
             let esock = esock.clone();
             let client = self.clone();

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -140,6 +140,53 @@ impl<A: Adapter> Client<A> {
         #[cfg(feature = "tracing")]
         tracing::debug!("all namespaces closed");
     }
+
+    #[cfg(socketioxide_test)]
+    pub async fn new_dummy_sock(
+        self: Arc<Self>,
+        ns: &'static str,
+        auth: impl serde::Serialize,
+    ) -> (
+        tokio::sync::mpsc::Sender<engineioxide::Packet>,
+        tokio::sync::mpsc::Receiver<engineioxide::Packet>,
+    ) {
+        let sid = Sid::new();
+        let (esock, rx) = EIoSocket::new_dummy_piped(sid, Box::new(|_, _| {}));
+
+        let (tx1, mut rx1) = tokio::sync::mpsc::channel(1024);
+        tokio::spawn({
+            let esock = esock.clone();
+            let client = self.clone();
+            async move {
+                while let Some(packet) = rx1.recv().await {
+                    match packet {
+                        engineioxide::Packet::Message(msg) => {
+                            client.on_message(msg, esock.clone());
+                        }
+                        engineioxide::Packet::Close => {
+                            client
+                                .on_disconnect(esock.clone(), EIoDisconnectReason::TransportClose);
+                        }
+                        engineioxide::Packet::Binary(bin) => {
+                            client.on_binary(bin, esock.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        });
+        let p = Packet {
+            ns: ns.into(),
+            inner: PacketData::Connect(Some(serde_json::to_string(&auth).unwrap())),
+        }
+        .into();
+        self.on_message(p, esock.clone());
+
+        // wait for the socket to be connected to the namespace
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        (tx1, rx)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -290,6 +337,7 @@ fn apply_payload_on_packet(data: Vec<u8>, socket: &EIoSocket<SocketData>) -> boo
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use tokio::sync::mpsc;
 
     use crate::adapter::LocalAdapter;
@@ -305,13 +353,12 @@ mod test {
         client
     }
 
-    use super::*;
     #[tokio::test]
     async fn connect_timeout_fail() {
         let client = create_client();
         let (tx, mut rx) = mpsc::channel(1);
         let close_fn = Box::new(move |_, _| tx.try_send(()).unwrap());
-        let sock = Arc::new(EIoSocket::new_dummy(Sid::new(), close_fn));
+        let sock = EIoSocket::new_dummy(Sid::new(), close_fn);
         client.on_connect(sock.clone());
         tokio::time::timeout(CONNECT_TIMEOUT * 2, rx.recv())
             .await
@@ -324,7 +371,7 @@ mod test {
         let client = create_client();
         let (tx, mut rx) = mpsc::channel(1);
         let close_fn = Box::new(move |_, _| tx.try_send(()).unwrap());
-        let sock = Arc::new(EIoSocket::new_dummy(Sid::new(), close_fn));
+        let sock = EIoSocket::new_dummy(Sid::new(), close_fn);
         client.on_connect(sock.clone());
         client.on_message("0".into(), sock.clone());
         tokio::time::timeout(CONNECT_TIMEOUT * 2, rx.recv())

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -800,6 +800,19 @@ impl<A: Adapter> SocketIo<A> {
     fn get_default_op(&self) -> BroadcastOperators<A> {
         self.get_op("/").expect("default namespace not found")
     }
+
+    #[cfg(any(test, socketioxide_test))]
+    #[doc(hidden)]
+    pub async fn new_dummy_sock(
+        &self,
+        ns: &'static str,
+        auth: impl serde::Serialize,
+    ) -> (
+        tokio::sync::mpsc::Sender<engineioxide::Packet>,
+        tokio::sync::mpsc::Receiver<engineioxide::Packet>,
+    ) {
+        self.0.clone().new_dummy_sock(ns, auth).await
+    }
 }
 
 impl<A: Adapter> Clone for SocketIo<A> {
@@ -840,8 +853,7 @@ mod tests {
         let sid = Sid::new();
         let (_, io) = SocketIo::builder().build_svc();
         io.ns("/", || {});
-
-        let socket = Socket::new_dummy(sid, Box::new(|_, _| {})).into();
+        let socket = Socket::new_dummy(sid, Box::new(|_, _| {}));
         let config = SocketIoConfig::default().into();
         io.0.get_ns("/")
             .unwrap()

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -800,9 +800,18 @@ impl<A: Adapter> SocketIo<A> {
     fn get_default_op(&self) -> BroadcastOperators<A> {
         self.get_op("/").expect("default namespace not found")
     }
+}
 
-    #[cfg(any(test, socketioxide_test))]
-    #[doc(hidden)]
+impl<A: Adapter> Clone for SocketIo<A> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+#[cfg(any(test, socketioxide_test))]
+impl<A: Adapter> SocketIo<A> {
+    /// Create a dummy socket for testing purpose with a
+    /// receiver to get the packets sent to the client
     pub async fn new_dummy_sock(
         &self,
         ns: &'static str,
@@ -812,12 +821,6 @@ impl<A: Adapter> SocketIo<A> {
         tokio::sync::mpsc::Receiver<engineioxide::Packet>,
     ) {
         self.0.clone().new_dummy_sock(ns, auth).await
-    }
-}
-
-impl<A: Adapter> Clone for SocketIo<A> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
     }
 }
 

--- a/socketioxide/src/ns.rs
+++ b/socketioxide/src/ns.rs
@@ -65,6 +65,9 @@ impl<A: Adapter> Namespace<A> {
         }
 
         self.sockets.write().unwrap().insert(sid, socket.clone());
+        #[cfg(feature = "tracing")]
+        tracing::trace!(?socket.id, ?self.path, "socket added to namespace");
+
         let protocol = esocket.protocol.into();
 
         if let Err(_e) = socket.send(Packet::connect(&self.path, socket.id, protocol)) {
@@ -129,7 +132,7 @@ impl<A: Adapter> Namespace<A> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, socketioxide_test))]
 impl<A: Adapter> Namespace<A> {
     pub fn new_dummy<const S: usize>(sockets: [Sid; S]) -> Arc<Self> {
         let ns = Namespace::new(Cow::Borrowed("/"), || {});

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -809,14 +809,14 @@ impl<A: Adapter> PartialEq for Socket<A> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, socketioxide_test))]
 impl<A: Adapter> Socket<A> {
     pub fn new_dummy(sid: Sid, ns: Arc<Namespace<A>>) -> Socket<A> {
         let close_fn = Box::new(move |_, _| ());
         let s = Socket::new(
             sid,
             ns,
-            engineioxide::Socket::new_dummy(sid, close_fn).into(),
+            engineioxide::Socket::new_dummy(sid, close_fn),
             Arc::new(SocketIoConfig::default()),
         );
         s.set_connected(true);
@@ -834,7 +834,7 @@ mod test {
         let ns = Namespace::<LocalAdapter>::new_dummy([sid]).into();
         let socket: Arc<Socket> = Socket::new_dummy(sid, ns).into();
         // Saturate the channel
-        for _ in 0..200 {
+        for _ in 0..1024 {
             socket
                 .send(Packet::event("test", "test", Value::Null))
                 .unwrap();

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -811,6 +811,7 @@ impl<A: Adapter> PartialEq for Socket<A> {
 
 #[cfg(any(test, socketioxide_test))]
 impl<A: Adapter> Socket<A> {
+    /// Creates a dummy socket for testing purposes
     pub fn new_dummy(sid: Sid, ns: Arc<Namespace<A>>) -> Socket<A> {
         let close_fn = Box::new(move |_, _| ());
         let s = Socket::new(

--- a/socketioxide/tests/extractors.rs
+++ b/socketioxide/tests/extractors.rs
@@ -5,53 +5,52 @@ use serde_json::json;
 use socketioxide::extract::{Data, SocketRef, State, TryData};
 use tokio::sync::mpsc;
 
-use fixture::{create_server, create_server_with_state};
-
-use crate::fixture::socketio_client;
-
+use engineioxide::Packet as EioPacket;
+use socketioxide::packet::Packet;
+use socketioxide::SocketIo;
 mod fixture;
 mod utils;
 
+async fn timeout_rcv<T: std::fmt::Debug>(srx: &mut tokio::sync::mpsc::Receiver<T>) -> T {
+    tokio::time::timeout(Duration::from_millis(200), srx.recv())
+        .await
+        .unwrap()
+        .unwrap()
+}
+
 #[tokio::test]
 pub async fn state_extractor() {
-    const PORT: u16 = 2000;
-    const TIMEOUT: Duration = Duration::from_millis(200);
     let state = 1112i32;
-    let io = create_server_with_state(PORT, state).await;
-    let (tx, mut rx) = mpsc::channel::<i32>(4);
-    io.ns("/", move |socket: SocketRef, state: State<i32>| {
-        assert_ok!(tx.try_send(*state));
-        socket.on("test", move |State(state): State<i32>| {
-            assert_ok!(tx.try_send(*state))
+    let (_, io) = SocketIo::builder().with_state(state).build_svc();
+
+    io.ns("/", |socket: SocketRef, State(state): State<i32>| {
+        assert_ok!(socket.emit("state", state));
+        socket.on("test", |socket: SocketRef, State(state): State<i32>| {
+            assert_ok!(socket.emit("state", state));
         });
     });
-    let client = assert_ok!(socketio_client(PORT, ()).await);
-    assert_eq!(
-        tokio::time::timeout(TIMEOUT, rx.recv())
-            .await
-            .unwrap()
-            .unwrap(),
-        state
-    );
+    let res_packet = EioPacket::Message(Packet::event("/", "state", state.into()).into());
 
-    assert_ok!(client.emit("test", json!("foo")).await);
-    assert_eq!(
-        tokio::time::timeout(TIMEOUT, rx.recv())
-            .await
-            .unwrap()
-            .unwrap(),
-        state
-    );
+    // Connect packet
+    let (stx, mut srx) = io.new_dummy_sock("/", ()).await;
+    srx.recv().await;
 
-    assert_ok!(client.disconnect().await);
+    // First echoed res packet from connect handler
+    assert_eq!(timeout_rcv(&mut srx).await, res_packet);
+
+    let packet = EioPacket::Message(Packet::event("/", "test", json!("foo")).into());
+    assert_ok!(stx.try_send(packet));
+
+    // second echoed res packet from test event handler
+    assert_eq!(timeout_rcv(&mut srx).await, res_packet);
 }
 
 #[tokio::test]
 pub async fn data_extractor() {
-    const PORT: u16 = 2001;
-    let io = create_server(PORT).await;
+    let (_, io) = SocketIo::new_svc();
     let (tx, mut rx) = mpsc::channel::<String>(4);
     let tx1 = tx.clone();
+
     io.ns("/", move |socket: SocketRef, Data(data): Data<String>| {
         assert_ok!(tx.try_send(data));
         socket.on("test", move |Data(data): Data<String>| {
@@ -59,29 +58,36 @@ pub async fn data_extractor() {
         });
     });
 
-    assert_ok!(socketio_client(PORT, ()).await);
-    assert_ok!(socketio_client(PORT, 1321).await);
+    io.new_dummy_sock("/", ()).await;
+    assert!(matches!(
+        rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    io.new_dummy_sock("/", 1321).await;
+    assert!(matches!(
+        rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
 
     // Capacity should be the same as the handler should not be called
     assert_eq!(tx1.capacity(), 4);
 
-    let client = assert_ok!(socketio_client(PORT, "foo").await);
-    assert_eq!(rx.recv().await.unwrap(), "foo");
+    let (stx, _rtx) = io.new_dummy_sock("/", "foo").await;
+    assert_eq!(timeout_rcv(&mut rx).await, "foo");
 
-    assert_ok!(client.emit("test", json!("oof")).await);
-    assert_eq!(rx.recv().await.unwrap(), "oof");
+    let packet = EioPacket::Message(Packet::event("/", "test", json!("oof")).into());
+    assert_ok!(stx.try_send(packet));
+    assert_eq!(timeout_rcv(&mut rx).await, "oof");
 
-    assert_ok!(client.emit("test", json!({ "test": 132 })).await);
+    let packet = EioPacket::Message(Packet::event("/", "test", json!({ "test": 132 })).into());
+    assert_ok!(stx.try_send(packet));
     // Capacity should be the same as the handler should not be called
     assert_eq!(tx1.capacity(), 4);
-
-    assert_ok!(client.disconnect().await);
 }
 
 #[tokio::test]
 pub async fn try_data_extractor() {
-    const PORT: u16 = 2002;
-    let io = create_server(PORT).await;
+    let (_, io) = SocketIo::new_svc();
     let (tx, mut rx) = mpsc::channel::<Result<String, serde_json::Error>>(4);
     io.ns("/", move |s: SocketRef, TryData(data): TryData<String>| {
         assert_ok!(tx.try_send(data));
@@ -91,24 +97,24 @@ pub async fn try_data_extractor() {
     });
 
     // Non deserializable data
-    assert_ok!(socketio_client(PORT, ()).await);
-    assert_err!(rx.recv().await.unwrap());
+    io.new_dummy_sock("/", ()).await;
+    assert_err!(timeout_rcv(&mut rx).await);
 
     // Non deserializable data
-    assert_ok!(socketio_client(PORT, 1321).await);
-    assert_err!(rx.recv().await.unwrap());
+    io.new_dummy_sock("/", 1321).await;
+    assert_err!(timeout_rcv(&mut rx).await);
 
-    let client = assert_ok!(socketio_client(PORT, "foo").await);
-    let res = assert_ok!(rx.recv().await.unwrap());
+    let (stx, _rtx) = io.new_dummy_sock("/", "foo").await;
+    let res = assert_ok!(timeout_rcv(&mut rx).await);
     assert_eq!(res, "foo");
 
-    assert_ok!(client.emit("test", json!("oof")).await);
-    let res = assert_ok!(rx.recv().await.unwrap());
+    let packet = EioPacket::Message(Packet::event("/", "test", json!("oof")).into());
+    assert_ok!(stx.try_send(packet));
+    let res = assert_ok!(timeout_rcv(&mut rx).await);
     assert_eq!(res, "oof");
 
     // Non deserializable data
-    assert_ok!(client.emit("test", json!({ "test": 132 })).await);
-    assert_err!(rx.recv().await.unwrap());
-
-    assert_ok!(client.disconnect().await);
+    let packet = EioPacket::Message(Packet::event("/", "test", json!({ "test": 132 })).into());
+    assert_ok!(stx.try_send(packet));
+    assert_err!(timeout_rcv(&mut rx).await);
 }

--- a/socketioxide/tests/fixture.rs
+++ b/socketioxide/tests/fixture.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use engineioxide::service::NotFoundService;
-use futures::{future::BoxFuture, SinkExt};
+use futures::SinkExt;
 use http::Request;
 use http_body_util::{BodyExt, Either, Empty, Full};
 use hyper::server::conn::http1;
@@ -15,10 +15,7 @@ use hyper_util::{
     client::legacy::Client,
     rt::{TokioExecutor, TokioIo},
 };
-use rust_socketio::{
-    asynchronous::{Client as SocketIoClient, ClientBuilder},
-    Payload,
-};
+
 use serde::{Deserialize, Serialize};
 use socketioxide::{adapter::LocalAdapter, service::SocketIoService, SocketIo};
 use tokio::net::{TcpListener, TcpStream};
@@ -103,18 +100,6 @@ pub async fn create_ws_connection(port: u16) -> WebSocketStream<MaybeTlsStream<T
     ws
 }
 
-pub async fn create_server_with_state<T: Send + Sync + 'static>(port: u16, state: T) -> SocketIo {
-    let (svc, io) = SocketIo::builder()
-        .ping_interval(Duration::from_millis(300))
-        .ping_timeout(Duration::from_millis(200))
-        .with_state(state)
-        .build_svc();
-
-    spawn_server(port, svc).await;
-
-    io
-}
-
 pub async fn create_server(port: u16) -> SocketIo {
     let (svc, io) = SocketIo::builder()
         .ping_interval(Duration::from_millis(300))
@@ -124,31 +109,6 @@ pub async fn create_server(port: u16) -> SocketIo {
 
     spawn_server(port, svc).await;
     io
-}
-
-pub async fn socketio_client_with_handler<F>(
-    port: u16,
-    event: &str,
-    callback: F,
-    auth: impl Into<serde_json::Value>,
-) -> Result<SocketIoClient, rust_socketio::Error>
-where
-    F: FnMut(Payload, SocketIoClient) -> BoxFuture<'static, ()> + Send + Sync + 'static,
-{
-    ClientBuilder::new(format!("http://127.0.0.1:{}", port))
-        .on(event, callback)
-        .auth(auth)
-        .connect()
-        .await
-}
-pub async fn socketio_client(
-    port: u16,
-    auth: impl Into<serde_json::Value>,
-) -> Result<SocketIoClient, rust_socketio::Error> {
-    ClientBuilder::new(format!("http://127.0.0.1:{}", port))
-        .auth(auth)
-        .connect()
-        .await
 }
 
 async fn spawn_server(port: u16, svc: SocketIoService<NotFoundService, LocalAdapter>) {

--- a/socketioxide/tests/utils.rs
+++ b/socketioxide/tests/utils.rs
@@ -44,10 +44,7 @@ macro_rules! assert_err {
 
 #[macro_export]
 macro_rules! assert_some {
-    ($e:expr) => {
-        assert_some!($e,);
-    };
-    ($e:expr,) => {{
+    ($e:expr) => {{
         use std::option::Option::*;
         match $e {
             Some(v) => v,


### PR DESCRIPTION
* Add a custom `new_dummy_socket` with tx/rx to send and receive packet without creating a real connexion.
* Remove dep `socket_io` client.
* Remove the feature `test-utils` in favor of a rust cfg flag `socketioxide-test`
* Move all the examples to a separate workspace to avoid dependency bloat / useless checks when working on socketioxide. A separate job actions in now dedicated to checking the example code. 