### PR TITLE
chore: remove salvo deps and corresponding doctest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,3 @@ pin-project-lite = "0.2.13"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 axum = "0.7.2"
-salvo = { version = "0.67.0", features = ["tower-compat"] }

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -47,7 +47,6 @@ state = ["dep:state"]
 engineioxide = { path = "../engineioxide", features = ["v3", "tracing"] }
 tokio-tungstenite.workspace = true
 axum.workspace = true
-salvo.workspace = true
 tokio = { workspace = true, features = [
     "macros",
     "parking_lot",

--- a/socketioxide/src/layer.rs
+++ b/socketioxide/src/layer.rs
@@ -16,25 +16,6 @@
 //! // Spawn axum server
 //!
 //! ```
-//!
-//! #### Example with salvo :
-//! ```no_run
-//! # use salvo::prelude::*;
-//! # use socketioxide::SocketIo;
-//!
-//! #[handler]
-//! async fn hello() -> &'static str {
-//!     "Hello World"
-//! }
-//!  // Create a socket.io layer
-//! let (layer, io) = SocketIo::new_layer();
-//!
-//! // Add io namespaces and events...
-//!
-//! let layer = layer.compat();
-//! let router = Router::with_path("/socket.io").hoop(layer).goal(hello);
-//! // Spawn salvo server
-//! ```
 use std::sync::Arc;
 
 use tower::Layer;


### PR DESCRIPTION
The salvo dep introduce **A lot** of dependencies and it is only use for a small doc example.
Because there is real example in the example folder it is better to remove it to lighten the dev env.