### PR TITLE
chore(deps): bump hyper to "1.0.3" and remove unused features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0.40"
 tracing = "0.1.37"
 itoa = "1.0.10"
 hyper-util.version = "0.1.1"
-hyper = { version = "1.0.1", features = ["http1", "http2", "server"] }
+hyper = "1.0.3"
 pin-project-lite = "0.2.13"
 
 # Dev deps

--- a/e2e/heaptrack/Cargo.toml
+++ b/e2e/heaptrack/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 socketioxide = { path = "../../socketioxide" }
-hyper = { workspace = true, features = ["server", "http1", "http2"] }
+hyper = { workspace = true, features = ["server", "http1"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 rust_socketio = { version = "0.4.2", features = ["async"] }

--- a/engineioxide/Cargo.toml
+++ b/engineioxide/Cargo.toml
@@ -49,6 +49,7 @@ unicode-segmentation = { version = "1.10.1", optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "parking_lot"] }
 tracing-subscriber.workspace = true
+hyper = { workspace = true, features = ["server", "http1"] }
 criterion.workspace = true
 axum.workspace = true
 hyper-util = { workspace = true, features = ["tokio", "client-legacy"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,4 +13,4 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.18"
 axum = "0.7.5"
 hyper-util.version = "0.1.1"
-hyper = { version = "1.0.1", features = ["http1", "http2", "server"] }
+hyper = { version = "1.0.1", features = ["http1", "server"] }

--- a/examples/hyper-echo/Cargo.toml
+++ b/examples/hyper-echo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 socketioxide = { path = "../../socketioxide", features = ["tracing"] }
-hyper = { workspace = true, features = ["server", "http1", "http2"] }
+hyper = { workspace = true, features = ["server", "http1"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber.workspace = true

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -54,6 +54,7 @@ tokio = { workspace = true, features = [
 ] }
 tracing-subscriber.workspace = true
 criterion.workspace = true
+hyper = { workspace = true, features = ["server", "http1"] }
 hyper-util = { workspace = true, features = ["tokio", "client-legacy"] }
 http-body-util.workspace = true
 


### PR DESCRIPTION
With hyper [`1.0.3`](https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v130-2024-04-15). The `hyper::Service` is exposed without any feature flag. Meaning that we can remove ("server", "http1", "http2"), from the main package (they will only be used in the dev deps. 