### PR TITLE
feat(engineio): add a `Str` type for Message packet

### DIFF
--- a/e2e/engineioxide/engineioxide.rs
+++ b/e2e/engineioxide/engineioxide.rs
@@ -8,6 +8,7 @@ use engineioxide::{
     handler::EngineIoHandler,
     service::EngineIoService,
     socket::{DisconnectReason, Socket},
+    Str,
 };
 use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
@@ -28,7 +29,7 @@ impl EngineIoHandler for MyHandler {
         println!("socket disconnect {}: {:?}", socket.id, reason);
     }
 
-    fn on_message(&self, msg: String, socket: Arc<Socket<Self::Data>>) {
+    fn on_message(&self, msg: Str, socket: Arc<Socket<Self::Data>>) {
         println!("Ping pong message {:?}", msg);
         socket.emit(msg).ok();
     }

--- a/engineioxide/Readme.md
+++ b/engineioxide/Readme.md
@@ -23,7 +23,7 @@ engineioxide = { version = "0.3.0", features = ["v3"] }
 use bytes::Bytes;
 use engineioxide::layer::EngineIoLayer;
 use engineioxide::handler::EngineIoHandler;
-use engineioxide::{Socket, DisconnectReason};
+use engineioxide::{Socket, DisconnectReason, Str};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use axum::routing::get;
@@ -50,8 +50,8 @@ impl EngineIoHandler for MyHandler {
         let cnt = self.user_cnt.fetch_sub(1, Ordering::Relaxed) - 1;
         socket.emit(cnt.to_string()).ok();
     }
-    fn on_message(&self, msg: String, socket: Arc<Socket<SocketState>>) { 
-        *socket.data.id.lock().unwrap() = msg; // bind a provided user id to a socket
+    fn on_message(&self, msg: Str, socket: Arc<Socket<SocketState>>) { 
+        *socket.data.id.lock().unwrap() = msg.into(); // bind a provided user id to a socket
     }
     fn on_binary(&self, data: Bytes, socket: Arc<Socket<SocketState>>) { }
 }

--- a/engineioxide/benches/packet_decode.rs
+++ b/engineioxide/benches/packet_decode.rs
@@ -1,31 +1,51 @@
 use bytes::Bytes;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use engineioxide::Packet;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("engineio_packet/decode");
     group.bench_function("Decode packet ping/pong", |b| {
         let packet: String = Packet::Ping.try_into().unwrap();
-        b.iter(|| Packet::try_from(packet.as_str()).unwrap())
+        b.iter_batched(
+            || packet.clone(),
+            |p| Packet::try_from(p).unwrap(),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Decode packet ping/pong upgrade", |b| {
         let packet: String = Packet::PingUpgrade.try_into().unwrap();
-        b.iter(|| Packet::try_from(packet.as_str()).unwrap())
+        b.iter_batched(
+            || packet.clone(),
+            |p| Packet::try_from(p).unwrap(),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Decode packet message", |b| {
-        let packet: String = Packet::Message(black_box("Hello").to_string())
+        let packet: String = Packet::Message(black_box("Hello").into())
             .try_into()
             .unwrap();
-        b.iter(|| Packet::try_from(packet.as_str()).unwrap())
+        b.iter_batched(
+            || packet.clone(),
+            |p| Packet::try_from(p).unwrap(),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Decode packet noop", |b| {
         let packet: String = Packet::Noop.try_into().unwrap();
-        b.iter(|| Packet::try_from(packet.as_str()).unwrap())
+        b.iter_batched(
+            || packet.clone(),
+            |p| Packet::try_from(p).unwrap(),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Decode packet binary b64", |b| {
         const BYTES: Bytes = Bytes::from_static(&[0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
         let packet: String = Packet::Binary(BYTES).try_into().unwrap();
-        b.iter(|| Packet::try_from(packet.clone()).unwrap())
+        b.iter_batched(
+            || packet.clone(),
+            |p| Packet::try_from(p).unwrap(),
+            BatchSize::SmallInput,
+        )
     });
 
     group.finish();

--- a/engineioxide/benches/packet_encode.rs
+++ b/engineioxide/benches/packet_encode.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use engineioxide::{config::EngineIoConfig, sid::Sid, OpenPacket, Packet, TransportType};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -10,28 +10,52 @@ fn criterion_benchmark(c: &mut Criterion) {
             black_box(Sid::ZERO),
             &EngineIoConfig::default(),
         ));
-        b.iter(|| TryInto::<String>::try_into(packet.clone()))
+        b.iter_batched(
+            || packet.clone(),
+            |p| TryInto::<String>::try_into(p),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Encode packet ping/pong", |b| {
         let packet = Packet::Ping;
-        b.iter(|| TryInto::<String>::try_into(packet.clone()))
+        b.iter_batched(
+            || packet.clone(),
+            |p| TryInto::<String>::try_into(p),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Encode packet ping/pong upgrade", |b| {
         let packet = Packet::PingUpgrade;
-        b.iter(|| TryInto::<String>::try_into(packet.clone()))
+        b.iter_batched(
+            || packet.clone(),
+            |p| TryInto::<String>::try_into(p),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Encode packet message", |b| {
-        let packet = Packet::Message(black_box("Hello").to_string());
-        b.iter(|| TryInto::<String>::try_into(packet.clone()))
+        let packet = Packet::Message(black_box("Hello").into());
+        b.iter_batched(
+            || packet.clone(),
+            |p| TryInto::<String>::try_into(p),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Encode packet noop", |b| {
         let packet = Packet::Noop;
-        b.iter(|| TryInto::<String>::try_into(packet.clone()))
+        b.iter_batched(
+            || packet.clone(),
+            |p| TryInto::<String>::try_into(p),
+            BatchSize::SmallInput,
+        )
     });
     group.bench_function("Encode packet binary b64", |b| {
         const BYTES: Bytes = Bytes::from_static(&[0x00, 0x01, 0x02, 0x03, 0x04, 0x05]);
         let packet = Packet::Binary(BYTES);
-        b.iter(|| TryInto::<String>::try_into(packet.clone()))
+        b.iter_batched(
+            || packet.clone(),
+            |p| TryInto::<String>::try_into(p),
+            BatchSize::SmallInput,
+        )
     });
 
     group.finish();

--- a/engineioxide/src/config.rs
+++ b/engineioxide/src/config.rs
@@ -6,7 +6,7 @@
 //! # use engineioxide::service::EngineIoService;
 //! # use engineioxide::handler::EngineIoHandler;
 //! # use std::time::Duration;
-//! # use engineioxide::{Socket, DisconnectReason};
+//! # use engineioxide::{Socket, DisconnectReason, Str};
 //! # use std::sync::Arc;
 //! #[derive(Debug, Clone)]
 //! struct MyHandler;
@@ -15,7 +15,7 @@
 //!     type Data = ();
 //!     fn on_connect(&self, socket: Arc<Socket<()>>) { }
 //!     fn on_disconnect(&self, socket: Arc<Socket<()>>, reason: DisconnectReason) { }
-//!     fn on_message(&self, msg: String, socket: Arc<Socket<()>>) { }
+//!     fn on_message(&self, msg: Str, socket: Arc<Socket<()>>) { }
 //!     fn on_binary(&self, data: Bytes, socket: Arc<Socket<()>>) { }
 //! }
 //!
@@ -131,6 +131,7 @@ impl EngineIoConfigBuilder {
     /// ```
     /// # use bytes::Bytes;
     /// # use engineioxide::{
+    ///     Str,
     ///     layer::EngineIoLayer,
     ///     handler::EngineIoHandler,
     ///     socket::{Socket, DisconnectReason},
@@ -149,7 +150,7 @@ impl EngineIoConfigBuilder {
     ///         println!("socket disconnect {}", socket.id);
     ///     }
     ///
-    ///     fn on_message(&self, msg: String, socket: Arc<Socket<()>>) {
+    ///     fn on_message(&self, msg: Str, socket: Arc<Socket<()>>) {
     ///         println!("Ping pong message {:?}", msg);
     ///         socket.emit(msg).unwrap();
     ///     }

--- a/engineioxide/src/engine.rs
+++ b/engineioxide/src/engine.rs
@@ -95,6 +95,7 @@ impl<H: EngineIoHandler> EngineIo<H> {
 
 #[cfg(test)]
 mod tests {
+    use crate::str::Str;
     use bytes::Bytes;
     use http::Request;
 
@@ -114,7 +115,7 @@ mod tests {
             println!("socket disconnect {} {:?}", socket.id, reason);
         }
 
-        fn on_message(&self, msg: String, socket: Arc<Socket<Self::Data>>) {
+        fn on_message(&self, msg: Str, socket: Arc<Socket<Self::Data>>) {
             println!("Ping pong message {:?}", msg);
             socket.emit(msg).ok();
         }

--- a/engineioxide/src/handler.rs
+++ b/engineioxide/src/handler.rs
@@ -4,7 +4,7 @@
 //! # use bytes::Bytes;
 //! # use engineioxide::service::EngineIoService;
 //! # use engineioxide::handler::EngineIoHandler;
-//! # use engineioxide::{Socket, DisconnectReason};
+//! # use engineioxide::{Socket, DisconnectReason, Str};
 //! # use std::sync::{Arc, Mutex};
 //! # use std::sync::atomic::{AtomicUsize, Ordering};
 //! // Global state
@@ -30,8 +30,8 @@
 //!         let cnt = self.user_cnt.fetch_sub(1, Ordering::Relaxed) - 1;
 //!         socket.emit(cnt.to_string()).ok();
 //!     }
-//!     fn on_message(&self, msg: String, socket: Arc<Socket<SocketState>>) {
-//!         *socket.data.id.lock().unwrap() = msg; // bind a provided user id to a socket
+//!     fn on_message(&self, msg: Str, socket: Arc<Socket<SocketState>>) {
+//!         *socket.data.id.lock().unwrap() = msg.into(); // bind a provided user id to a socket
 //!     }
 //!     fn on_binary(&self, data: Bytes, socket: Arc<Socket<SocketState>>) { }
 //! }
@@ -44,6 +44,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use crate::socket::{DisconnectReason, Socket};
+use crate::str::Str;
 
 /// The [`EngineIoHandler`] trait can be implemented on any struct to handle socket events
 ///
@@ -59,7 +60,7 @@ pub trait EngineIoHandler: std::fmt::Debug + Send + Sync + 'static {
     fn on_disconnect(&self, socket: Arc<Socket<Self::Data>>, reason: DisconnectReason);
 
     /// Called when a message is received from the client.
-    fn on_message(&self, msg: String, socket: Arc<Socket<Self::Data>>);
+    fn on_message(&self, msg: Str, socket: Arc<Socket<Self::Data>>);
 
     /// Called when a binary message is received from the client.
     fn on_binary(&self, data: Bytes, socket: Arc<Socket<Self::Data>>);
@@ -76,7 +77,7 @@ impl<T: EngineIoHandler> EngineIoHandler for Arc<T> {
         (**self).on_disconnect(socket, reason)
     }
 
-    fn on_message(&self, msg: String, socket: Arc<Socket<Self::Data>>) {
+    fn on_message(&self, msg: Str, socket: Arc<Socket<Self::Data>>) {
         (**self).on_message(msg, socket)
     }
 

--- a/engineioxide/src/layer.rs
+++ b/engineioxide/src/layer.rs
@@ -5,7 +5,7 @@
 //! # use bytes::Bytes;
 //! # use engineioxide::layer::EngineIoLayer;
 //! # use engineioxide::handler::EngineIoHandler;
-//! # use engineioxide::{Socket, DisconnectReason};
+//! # use engineioxide::{Socket, DisconnectReason, Str};
 //! # use std::sync::Arc;
 //! # use axum::routing::get;
 //! #[derive(Debug, Clone)]
@@ -15,7 +15,7 @@
 //!     type Data = ();
 //!     fn on_connect(&self, socket: Arc<Socket<()>>) { }
 //!     fn on_disconnect(&self, socket: Arc<Socket<()>>, reason: DisconnectReason) { }
-//!     fn on_message(&self, msg: String, socket: Arc<Socket<()>>) { }
+//!     fn on_message(&self, msg: Str, socket: Arc<Socket<()>>) { }
 //!     fn on_binary(&self, data: Bytes, socket: Arc<Socket<()>>) { }
 //! }
 //! // Create a new engineio layer

--- a/engineioxide/src/lib.rs
+++ b/engineioxide/src/lib.rs
@@ -32,6 +32,7 @@
 )]
 #![doc = include_str!("../Readme.md")]
 
+pub use crate::str::Str;
 pub use service::{ProtocolVersion, TransportType};
 pub use socket::{DisconnectReason, Socket};
 
@@ -50,4 +51,5 @@ mod engine;
 mod errors;
 mod packet;
 mod peekable;
+mod str;
 mod transport;

--- a/engineioxide/src/service/mod.rs
+++ b/engineioxide/src/service/mod.rs
@@ -8,7 +8,7 @@
 //! # use engineioxide::layer::EngineIoLayer;
 //! # use engineioxide::handler::EngineIoHandler;
 //! # use engineioxide::service::EngineIoService;
-//! # use engineioxide::{Socket, DisconnectReason};
+//! # use engineioxide::{Socket, DisconnectReason, Str};
 //! # use std::sync::Arc;
 //! #[derive(Debug)]
 //! struct MyHandler;
@@ -17,7 +17,7 @@
 //!     type Data = ();
 //!     fn on_connect(&self, socket: Arc<Socket<()>>) { }
 //!     fn on_disconnect(&self, socket: Arc<Socket<()>>, reason: DisconnectReason) { }
-//!     fn on_message(&self, msg: String, socket: Arc<Socket<()>>) { }
+//!     fn on_message(&self, msg: Str, socket: Arc<Socket<()>>) { }
 //!     fn on_binary(&self, data: Bytes, socket: Arc<Socket<()>>) { }
 //! }
 //!

--- a/engineioxide/src/str.rs
+++ b/engineioxide/src/str.rs
@@ -1,0 +1,67 @@
+use bytes::Bytes;
+
+/// A custom [`Bytes`] wrapper to efficiently store string packets
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+pub struct Str(Bytes);
+impl Str {
+    /// Efficiently slice string by calling [`Bytes::slice`] on the inner bytes
+    pub fn slice(&self, range: impl std::ops::RangeBounds<usize>) -> Self {
+        Str(self.0.slice(range))
+    }
+    /// Return a &str representation of the string
+    pub fn as_str(&self) -> &str {
+        // SAFETY: Str is always a valid utf8 string
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
+    }
+    /// Get the byte at the specified index
+    pub fn get(&self, index: usize) -> Option<&u8> {
+        self.0.get(index)
+    }
+}
+
+impl std::ops::Deref for Str {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+impl std::fmt::Display for Str {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+impl From<&'static str> for Str {
+    fn from(s: &'static str) -> Self {
+        Str(Bytes::from_static(s.as_bytes()))
+    }
+}
+impl From<String> for Str {
+    fn from(s: String) -> Self {
+        let vec = s.into_bytes();
+        Str(Bytes::from(vec))
+    }
+}
+
+impl From<Str> for Bytes {
+    fn from(s: Str) -> Self {
+        s.0
+    }
+}
+impl From<Str> for String {
+    fn from(s: Str) -> Self {
+        let vec = s.0.into();
+        // SAFETY: Str is always a valid utf8 string
+        unsafe { String::from_utf8_unchecked(vec) }
+    }
+}
+
+impl std::cmp::PartialEq<&str> for Str {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+impl std::cmp::PartialEq<Str> for &str {
+    fn eq(&self, other: &Str) -> bool {
+        *self == other.as_str()
+    }
+}

--- a/engineioxide/src/str.rs
+++ b/engineioxide/src/str.rs
@@ -13,6 +13,10 @@ impl Str {
         // SAFETY: Str is always a valid utf8 string
         unsafe { std::str::from_utf8_unchecked(&self.0) }
     }
+    /// Return a &[u8] representation of the string
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
     /// Get the byte at the specified index
     pub fn get(&self, index: usize) -> Option<&u8> {
         self.0.get(index)

--- a/engineioxide/src/transport/polling/payload/decoder.rs
+++ b/engineioxide/src/transport/polling/payload/decoder.rs
@@ -110,7 +110,7 @@ where
             if separator_found
                 || (state.end_of_stream && state.buffer.remaining() == 0 && !packet_buf.is_empty())
             {
-                let packet = std::str::from_utf8(&packet_buf)
+                let packet = String::from_utf8(packet_buf)
                     .map_err(|_| Error::InvalidPacketLength)
                     .and_then(Packet::try_from); // Convert the packet buffer to a Packet object
                 break Some((packet, state)); // Emit the packet and the updated state
@@ -203,7 +203,7 @@ where
                 reader.read_to_end(&mut packet_buf).unwrap();
                 // Read the packet data
                 let packet = match packet_type.unwrap() {
-                    STRING_PACKET_IDENTIFIER_V3 => std::str::from_utf8(&packet_buf)
+                    STRING_PACKET_IDENTIFIER_V3 => String::from_utf8(packet_buf)
                         .map_err(|_| Error::InvalidPacketLength)
                         .and_then(Packet::try_from), // Convert the packet buffer to a Packet object
                     BINARY_PACKET_IDENTIFIER_V3 => Ok(Packet::BinaryV3(packet_buf.into())),
@@ -335,6 +335,8 @@ pub fn v3_string_decoder(
             // Check if the packet length matches the number of characters
             if let Ok(packet) = std::str::from_utf8(&packet_buf) {
                 if packet.graphemes(true).count() == packet_graphemes_len {
+                    // SAFETY: packet_buf is a valid utf8 string checkd above
+                    let packet = unsafe { String::from_utf8_unchecked(packet_buf) };
                     let packet = Packet::try_from(packet).map_err(|_| Error::InvalidPacketLength);
                     state.yield_packets += 1;
                     break Some((packet, state)); // Emit the packet and the updated state

--- a/engineioxide/tests/disconnect_reason.rs
+++ b/engineioxide/tests/disconnect_reason.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use engineioxide::{
     handler::EngineIoHandler,
     socket::{DisconnectReason, Socket},
+    Str,
 };
 use futures_util::SinkExt;
 use tokio::sync::mpsc;
@@ -38,7 +39,7 @@ impl EngineIoHandler for MyHandler {
         self.disconnect_tx.try_send(reason).unwrap();
     }
 
-    fn on_message(&self, msg: String, socket: Arc<Socket<()>>) {
+    fn on_message(&self, msg: Str, socket: Arc<Socket<()>>) {
         println!("Ping pong message {:?}", msg);
         socket.emit(msg).ok();
     }

--- a/socketioxide/src/client.rs
+++ b/socketioxide/src/client.rs
@@ -253,7 +253,6 @@ impl<A: Adapter> EngineIoHandler for Client<A> {
     fn on_message(&self, msg: Str, socket: Arc<EIoSocket<SocketData>>) {
         #[cfg(feature = "tracing")]
         tracing::debug!("Received message: {:?}", msg);
-        let msg: String = msg.into();
         let packet = match Packet::try_from(msg) {
             Ok(packet) => packet,
             Err(_e) => {

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -9,7 +9,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::errors::Error;
-use engineioxide::sid::Sid;
+use engineioxide::{sid::Sid, Str};
 
 /// The socket.io packet type.
 /// Each packet has a type and a namespace
@@ -439,12 +439,12 @@ fn deserialize_packet<T: DeserializeOwned>(data: &str) -> Result<Option<T>, serd
 /// <packet type>[<# of binary attachments>-][<namespace>,][<acknowledgment id>][JSON-stringified payload without binary]
 /// + binary attachments extracted
 /// ```
-impl<'a> TryFrom<String> for Packet<'a> {
+impl<'a> TryFrom<Str> for Packet<'a> {
     type Error = Error;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        // It is possible to parse the packet from a byte slice because separators are only ASCII
+    fn try_from(value: Str) -> Result<Self, Self::Error> {
         let chars = value.as_bytes();
+        // It is possible to parse the packet from a byte slice because separators are only ASCII
         let mut i = 1;
         let index = (b'0'..=b'6')
             .contains(&chars[0])
@@ -520,12 +520,12 @@ impl<'a> TryFrom<String> for Packet<'a> {
     }
 }
 
-impl<'a> TryFrom<engineioxide::Str> for Packet<'a> {
+#[cfg(any(test, socketioxide_test))]
+impl<'a> TryFrom<String> for Packet<'a> {
     type Error = Error;
 
-    fn try_from(value: engineioxide::Str) -> Result<Self, Self::Error> {
-        let value: String = value.into();
-        Packet::try_from(value)
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Packet::try_from(Str::from(value))
     }
 }
 

--- a/socketioxide/src/packet.rs
+++ b/socketioxide/src/packet.rs
@@ -520,6 +520,15 @@ impl<'a> TryFrom<String> for Packet<'a> {
     }
 }
 
+impl<'a> TryFrom<engineioxide::Str> for Packet<'a> {
+    type Error = Error;
+
+    fn try_from(value: engineioxide::Str) -> Result<Self, Self::Error> {
+        let value: String = value.into();
+        Packet::try_from(value)
+    }
+}
+
 /// Connect packet sent by the client
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConnectPacket {

--- a/socketioxide/tests/acknowledgement.rs
+++ b/socketioxide/tests/acknowledgement.rs
@@ -31,15 +31,15 @@ pub async fn emit_with_ack() {
     assert_some!(srx.recv().await); // NS connect packet
 
     let msg = assert_some!(srx.recv().await);
-    assert_eq!(msg, Message("21[\"test\",\"foo\"]".to_string()));
-    assert_ok!(stx.send(Message("31[\"oof\"]".to_string())).await);
+    assert_eq!(msg, Message("21[\"test\",\"foo\"]".into()));
+    assert_ok!(stx.send(Message("31[\"oof\"]".into())).await);
 
     let ack = rx.recv().await.unwrap();
     assert_eq!(ack[0], "oof");
 
     let msg = assert_some!(srx.recv().await);
-    assert_eq!(msg, Message("22[\"test\",\"foo\"]".to_string()));
-    assert_ok!(stx.send(Message("32[\"oof\"]".to_string())).await);
+    assert_eq!(msg, Message("22[\"test\",\"foo\"]".into()));
+    assert_ok!(stx.send(Message("32[\"oof\"]".into())).await);
 
     let ack = rx.recv().await.unwrap();
     assert_eq!(ack[0], "oof");
@@ -107,7 +107,7 @@ pub async fn broadcast_with_ack() {
                     _ => panic!("Unexpected packet"),
                 };
                 assert_ok!(
-                    stx.send(Message(format!("3{}[\"oof\"]", ack.to_string())))
+                    stx.send(Message(format!("3{}[\"oof\"]", ack.to_string()).into()))
                         .await
                 );
             }

--- a/socketioxide/tests/connect.rs
+++ b/socketioxide/tests/connect.rs
@@ -92,7 +92,7 @@ pub async fn connect_middleware_error() {
     let (_, mut srx) = io.new_dummy_sock("/", ()).await;
 
     let p = assert_some!(srx.recv().await);
-    assert_eq!(p, Message("4{\"message\":\"MyError\"}".to_string()));
+    assert_eq!(p, Message("4{\"message\":\"MyError\"}".into()));
     rx.recv().await.unwrap();
     rx.recv().await.unwrap();
     assert_err!(rx.try_recv());


### PR DESCRIPTION
# Motivation
Currently the `Message` packet variant is backed by a `String`. This leads to a useless data clone when slicing to remove the first byte (the engineio packet type).

## Solution
The `Str` type is backed by a `Bytes` and therefore can be sliced into any number of sub-Bytes.


