### PR TITLE
Fix: deadlocking when calling `close_ns` from inside a `disconnect_handler`

### DIFF
--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -345,7 +345,11 @@ impl<A: Adapter> SocketIo<A> {
     /// Deletes the namespace with the given path.
     ///
     /// This will disconnect all sockets connected to this
-    /// namespace in deferred way.
+    /// namespace in a deferred way.
+    ///
+    /// # Panics
+    /// If the v4 protocol (legacy) is enabled and the namespace to delete is the default namespace "/".
+    /// For v4, the default namespace cannot be deleted. See [official doc](https://socket.io/docs/v3/namespaces/#main-namespace) for more informations.
     #[inline]
     pub fn delete_ns<'a>(&self, path: impl Into<&'a str>) {
         self.0.delete_ns(path.into());

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -342,7 +342,10 @@ impl<A: Adapter> SocketIo<A> {
         self.0.add_ns(path.into(), callback);
     }
 
-    /// Deletes the namespace with the given path
+    /// Deletes the namespace with the given path.
+    ///
+    /// This will disconnect all sockets connected to this
+    /// namespace in deferred way.
     #[inline]
     pub fn delete_ns<'a>(&self, path: impl Into<&'a str>) {
         self.0.delete_ns(path.into());

--- a/socketioxide/src/ns.rs
+++ b/socketioxide/src/ns.rs
@@ -128,9 +128,11 @@ impl<A: Adapter> Namespace<A> {
     /// This function is using .await points only when called with [`DisconnectReason::ClosingServer`]
     pub async fn close(&self, reason: DisconnectReason) {
         use futures_util::future;
-        #[cfg(feature = "tracing")]
         let sockets = self.sockets.read().unwrap().clone();
+
+        #[cfg(feature = "tracing")]
         tracing::debug!(?self.path, "closing {} sockets in namespace", sockets.len());
+
         if reason == DisconnectReason::ClosingServer {
             // When closing the underlying transport, this will indirectly close the socket
             // Therefore there is no need to manually call `s.close()`.

--- a/socketioxide/src/ns.rs
+++ b/socketioxide/src/ns.rs
@@ -85,6 +85,9 @@ impl<A: Adapter> Namespace<A> {
 
     /// Removes a socket from a namespace and propagate the event to the adapter
     pub fn remove_socket(&self, sid: Sid) -> Result<(), AdapterError> {
+        #[cfg(feature = "tracing")]
+        tracing::trace!(?sid, "removing socket from namespace");
+
         self.sockets.write().unwrap().remove(&sid);
         self.adapter
             .del_all(sid)
@@ -158,5 +161,13 @@ impl<A: Adapter + std::fmt::Debug> std::fmt::Debug for Namespace<A> {
             .field("adapter", &self.adapter)
             .field("sockets", &self.sockets)
             .finish()
+    }
+}
+
+#[cfg(feature = "tracing")]
+impl<A: Adapter> Drop for Namespace<A> {
+    fn drop(&mut self) {
+        #[cfg(feature = "tracing")]
+        tracing::debug!("dropping namespace {}", self.path);
     }
 }

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -694,7 +694,8 @@ impl<A: Adapter> Socket<A> {
     pub(crate) fn close(self: Arc<Self>, reason: DisconnectReason) -> Result<(), AdapterError> {
         self.set_connected(false);
 
-        if let Some(handler) = self.disconnect_handler.lock().unwrap().take() {
+        let handler = { self.disconnect_handler.lock().unwrap().take() };
+        if let Some(handler) = handler {
             handler.call(self.clone(), reason);
         }
 

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -64,7 +64,7 @@ pub enum DisconnectReason {
     /// The client has manually disconnected the socket using [`socket.disconnect()`](https://socket.io/fr/docs/v4/client-api/#socketdisconnect)
     ClientNSDisconnect,
 
-    /// The socket was forcefully disconnected from the namespace with [`Socket::disconnect`]
+    /// The socket was forcefully disconnected from the namespace with [`Socket::disconnect`] or with [`SocketIo::delete_ns`](crate::io::SocketIo::delete_ns)
     ServerNSDisconnect,
 
     /// The server is being closed
@@ -696,6 +696,9 @@ impl<A: Adapter> Socket<A> {
 
         let handler = { self.disconnect_handler.lock().unwrap().take() };
         if let Some(handler) = handler {
+            #[cfg(feature = "tracing")]
+            tracing::trace!(?reason, ?self.id, "spawning disconnect handler");
+
             handler.call(self.clone(), reason);
         }
 

--- a/socketioxide/tests/connect.rs
+++ b/socketioxide/tests/connect.rs
@@ -3,10 +3,7 @@ mod utils;
 use bytes::Bytes;
 use engineioxide::Packet::*;
 use socketioxide::{
-    extract::{SocketRef, State},
-    handler::ConnectHandler,
-    packet::Packet,
-    SendError, SocketError, SocketIo,
+    extract::SocketRef, handler::ConnectHandler, packet::Packet, SendError, SocketError, SocketIo,
 };
 use tokio::sync::mpsc;
 
@@ -115,36 +112,94 @@ pub async fn connect_middleware_error() {
 }
 
 #[tokio::test]
-async fn remove_ns() {
-    use tokio::sync::mpsc::Sender;
-
+async fn remove_ns_from_connect_handler() {
     let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(2);
-
-    let (_svc, io) = SocketIo::builder().with_state(tx).build_svc();
+    let (_svc, io) = SocketIo::new_svc();
 
     let io_clone = io.clone();
-    let io_clone2 = io.clone();
-    io.ns("/test1", move |s: SocketRef| {
-        s.on("delete_ns", move |State::<Sender<()>>(tx)| {
-            io_clone2.delete_ns("/test1");
-            tx.try_send(()).unwrap();
-        });
+    io.ns("/test1", move || {
+        tx.try_send(()).unwrap();
+        io_clone.delete_ns("/test1");
     });
-    io.ns("/test2", move |s: SocketRef| {
-        s.on_disconnect(move |State::<Sender<()>>(tx)| {
-            io_clone.delete_ns("/test2");
-            tx.try_send(()).unwrap();
-        })
-    });
+
     let (stx, mut srx) = io.new_dummy_sock("/test1", ()).await;
     timeout_rcv(&mut srx).await;
     assert_ok!(stx.try_send(create_msg("/test1", "delete_ns", ())));
     timeout_rcv(&mut rx).await;
     assert_ok!(stx.try_send(create_msg("/test1", "delete_ns", ())));
     // No response since ns is already deleted
+    let elapsed = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+    assert!(elapsed.is_err() || elapsed.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn remove_ns_from_middleware() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(2);
+    let (_svc, io) = SocketIo::new_svc();
+
+    let io_clone = io.clone();
+    let middleware = move || {
+        tx.try_send(()).unwrap();
+        io_clone.delete_ns("/test1");
+        Ok::<(), std::convert::Infallible>(())
+    };
+    fn handler() {}
+    io.ns("/test1", handler.with(middleware));
+
+    let (stx, mut srx) = io.new_dummy_sock("/test1", ()).await;
+    timeout_rcv(&mut srx).await;
+    assert_ok!(stx.try_send(create_msg("/test1", "delete_ns", ())));
+    timeout_rcv(&mut rx).await;
+    assert_ok!(stx.try_send(create_msg("/test1", "delete_ns", ())));
+    // No response since ns is already deleted
+    let elapsed = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+    assert!(elapsed.is_err() || elapsed.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn remove_ns_from_event_handler() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(2);
+    let (_svc, io) = SocketIo::new_svc();
+
+    let io_clone = io.clone();
+    io.ns("/test1", move |s: SocketRef| {
+        s.on("delete_ns", move || {
+            io_clone.delete_ns("/test1");
+            tx.try_send(()).unwrap();
+        });
+    });
+
+    let (stx, mut srx) = io.new_dummy_sock("/test1", ()).await;
+    timeout_rcv(&mut srx).await;
+    assert_ok!(stx.try_send(create_msg("/test1", "delete_ns", ())));
+    timeout_rcv(&mut rx).await;
+    assert_ok!(stx.try_send(create_msg("/test1", "delete_ns", ())));
+    // No response since ns is already deleted
+    let elapsed = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+    assert!(elapsed.is_err() || elapsed.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn remove_ns_from_disconnect_handler() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<&'static str>(2);
+    let (_svc, io) = SocketIo::new_svc();
+
+    let io_clone = io.clone();
+    io.ns("/test2", move |s: SocketRef| {
+        tx.try_send("connect").unwrap();
+        s.on_disconnect(move || {
+            io_clone.delete_ns("/test2");
+            tx.try_send("disconnect").unwrap();
+        })
+    });
 
     let (stx, mut srx) = io.new_dummy_sock("/test2", ()).await;
+    assert_eq!(timeout_rcv(&mut rx).await, "connect");
     timeout_rcv(&mut srx).await;
     assert_ok!(stx.try_send(Close));
-    timeout_rcv(&mut rx).await;
+    assert_eq!(timeout_rcv(&mut rx).await, "disconnect");
+
+    let (_stx, mut _srx) = io.new_dummy_sock("/test2", ()).await;
+    let elapsed = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+    assert!(elapsed.is_err() || elapsed.unwrap().is_none());
 }


### PR DESCRIPTION
## Motivation
* Gracefully close the namespace rather than just removing it. Meaning that the corresponding namespace adapter will be closed as well as all the sockets in the namespace. Their `disconnect_handler` will be called with a `ServerNSDisconnect` reason.
* Fix deadlock when deleting the namespace from inside a `disconnect_handler`.

Fixes :
* #311 