### PR TITLE
Socketioxide v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
+# 0.13.0
+
+## socketioxide
+* fix: issue #311, the `delete_ns` fn was deadlocking the entire server when called from inside a `disconnec_handler`.
+* feat: the `delete_ns` is now gracefully closing the adapter as well as all its sockets before being removed.
+* feat: the API use `Bytes` rather than `Vec<u8>` to represent binary payloads. This allow to avoid unnecessary copies.
+* deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.
+
+## engineioxide
+* feat: the API use `Bytes/Str` rather than `Vec<u8>` and `String` to represent payloads. This allow to avoid unnecessary copies.
+* deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.
+
 # 0.12.0
 **MSRV**: Minimum supported Rust version is now 1.75.
 
-# socketioxide
+## socketioxide
 * **(Breaking)**: Introduction of [connect middlewares](https://docs.rs/socketioxide/latest/socketioxide/#middlewares). It allows to execute code before the connection to the namespace is established. It is useful to check the request, to authenticate the user, to log the connection etc. It is possible to add multiple middlewares and to chain them.
 * The `SocketRef` extractor is now `Clone`. Be careful to drop clones when the socket is disconnected to avoid any memory leak.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 
 [dependencies]
 bytes.workspace = true
-engineioxide = { path = "../engineioxide", version = "0.12.0" }
+engineioxide = { path = "../engineioxide", version = "0.13.0" }
 futures-core.workspace = true
 futures-util.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }


### PR DESCRIPTION
# 0.13.0

## socketioxide
* fix: issue #311, the `delete_ns` fn was deadlocking the entire server when called from inside a `disconnec_handler`.
* feat: the `delete_ns` is now gracefully closing the adapter as well as all its sockets before being removed.
* feat: the API use `Bytes` rather than `Vec<u8>` to represent binary payloads. This allow to avoid unnecessary copies.
* deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.

## engineioxide
* feat: the API use `Bytes/Str` rather than `Vec<u8>` and `String` to represent payloads. This allow to avoid unnecessary copies.
* deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.
