### PR TITLE
fix(engineio/ws): remove unecessary panic message when receiving unexpected ws packets

### DIFF
--- a/engineioxide/src/transport/ws.rs
+++ b/engineioxide/src/transport/ws.rs
@@ -191,7 +191,11 @@ where
                 Ok(())
             }
             Message::Close(_) => break,
-            _ => panic!("[sid={}] unexpected ws message", socket.id),
+            _ => {
+                #[cfg(feature = "tracing")]
+                tracing::debug!("[sid={}] unexpected ws message", socket.id);
+                Ok(())
+            }
         }?
     }
     Ok(())


### PR DESCRIPTION
Fixes :
* #319 