### PR TITLE
chore: bump version to v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+# 0.13.1
+
+## engineioxide
+* fix: issue #320. Remove unnecessary panic when receiving unexpected websocket messages. This might happen with some specific socket.io clients.
+
 # 0.13.0
 
 ## socketioxide
-* fix: issue #311, the `delete_ns` fn was deadlocking the entire server when called from inside a `disconnec_handler`.
+* fix: issue #311, the `delete_ns` fn was deadlocking the entire server when called from inside a `disconnect_handler`.
 * feat: the `delete_ns` is now gracefully closing the adapter as well as all its sockets before being removed.
 * feat: the API use `Bytes` rather than `Vec<u8>` to represent binary payloads. This allow to avoid unnecessary copies.
 * deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 
 [dependencies]
 bytes.workspace = true
-engineioxide = { path = "../engineioxide", version = "0.13.0" }
+engineioxide = { path = "../engineioxide", version = "0.13.1" }
 futures-core.workspace = true
 futures-util.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }


### PR DESCRIPTION
# 0.13.1

## engineioxide
* fix: issue #320. Remove unnecessary panic when receiving unexpected websocket messages. This might happen with some specific socket.io clients.
