### PR TITLE
feat(socketio/packet): switch to `Str` type for ns path storage

### DIFF
--- a/engineioxide/src/str.rs
+++ b/engineioxide/src/str.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use bytes::Bytes;
 
 /// A custom [`Bytes`] wrapper to efficiently store string packets
@@ -43,6 +45,23 @@ impl From<String> for Str {
     fn from(s: String) -> Self {
         let vec = s.into_bytes();
         Str(Bytes::from(vec))
+    }
+}
+
+impl From<Cow<'static, str>> for Str {
+    fn from(s: Cow<'static, str>) -> Self {
+        match s {
+            Cow::Borrowed(s) => Str::from(s),
+            Cow::Owned(s) => Str::from(s),
+        }
+    }
+}
+impl From<&Cow<'static, str>> for Str {
+    fn from(s: &Cow<'static, str>) -> Self {
+        match s {
+            Cow::Borrowed(s) => Str::from(*s),
+            Cow::Owned(s) => Str(Bytes::copy_from_slice(s.as_bytes())),
+        }
     }
 }
 

--- a/socketioxide/src/extract/socket.rs
+++ b/socketioxide/src/extract/socket.rs
@@ -122,7 +122,7 @@ impl<A: Adapter> AckSender<A> {
                     return Err(e.with_value(data).into());
                 }
             };
-            let ns = self.socket.ns();
+            let ns = &self.socket.ns.path;
             let data = serde_json::to_value(data)?;
             let packet = if self.binary.is_empty() {
                 Packet::ack(ns, data, ack_id)

--- a/socketioxide/src/socket.rs
+++ b/socketioxide/src/socket.rs
@@ -319,7 +319,7 @@ impl<A: Adapter> Socket<A> {
             }
         };
 
-        let ns = self.ns();
+        let ns = &self.ns.path;
         let data = serde_json::to_value(data)?;
         permit.send(Packet::event(ns, event.into(), data));
         Ok(())
@@ -392,8 +392,9 @@ impl<A: Adapter> Socket<A> {
                 return Err(e.with_value(data).into());
             }
         };
+        let ns = &self.ns.path;
         let data = serde_json::to_value(data)?;
-        let packet = Packet::event(self.ns(), event.into(), data);
+        let packet = Packet::event(ns, event.into(), data);
         let rx = self.send_with_ack_permit(packet, permit);
         let stream = AckInnerStream::send(rx, self.get_io().config().ack_timeout, self.id);
         Ok(AckStream::<V>::from(stream))

--- a/socketioxide/tests/connect.rs
+++ b/socketioxide/tests/connect.rs
@@ -7,7 +7,11 @@ use socketioxide::{
 };
 use tokio::sync::mpsc;
 
-fn create_msg(ns: &str, event: &str, data: impl Into<serde_json::Value>) -> engineioxide::Packet {
+fn create_msg(
+    ns: &'static str,
+    event: &str,
+    data: impl Into<serde_json::Value>,
+) -> engineioxide::Packet {
     let packet: String = Packet::event(ns, event, data.into()).into();
     Message(packet.into())
 }

--- a/socketioxide/tests/extractors.rs
+++ b/socketioxide/tests/extractors.rs
@@ -25,7 +25,7 @@ async fn timeout_rcv_err<T: std::fmt::Debug>(srx: &mut tokio::sync::mpsc::Receiv
         .unwrap_err();
 }
 
-fn create_msg(ns: &str, event: &str, data: impl Into<serde_json::Value>) -> EioPacket {
+fn create_msg(ns: &'static str, event: &str, data: impl Into<serde_json::Value>) -> EioPacket {
     let packet: String = Packet::event(ns, event, data.into()).into();
     EioPacket::Message(packet.into())
 }


### PR DESCRIPTION
## Motivation
Currently the namespace path is decoded from a `Str` payload, meaning that we can extract it in a zero copy manner by slicing the `Str` and storing it like that.
It also fixes a lifetime issue for PR #333 with path params. Because the path need to outlive the decoded params from the matchit router as long as they are not decoded by the user.

## Solution
* Switch the namespace path to a `Str`.
* Add some implementation of `From` for `Str` for the construction of new outgoing packets.