### PR TITLE
chore(deps): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
+# 0.14.0
+
+## socketioxide
+* **(Breaking)**: State reworked to avoid having unsafe global mutable state (issue [#317](https://github.com/Totodore/socketioxide/issues/317)). Therefore State types must now implement `Clone` and will be cloned for each handler where the state is used.
+* **(Breaking)**: Extensions reworked to avoid `Send` + `Sync` requirements on extensions (issue [#295](https://github.com/Totodore/socketioxide/issues/295)). They are now extracted by `Cloning`. Therefore all the type must implement `Clone`. An `Extension` extractor is available to get an extension directly without calling `socket.extensions.get()`.
+* feat: New `HttpExtension` types to extract extensions from the http request.
+* feat: `SocketIo` can now be used as an extractor. So you can now easily access the entire socket.io context from your handlers.
+* feat: Dynamic namespaces. You can know set dynamic namespaces with the [`dyn_ns`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIo.html#method.dyn_ns) function. You can specify patterns with the `{name}` syntax thanks to the [matchit](https://github.com/ibraheemdev/matchit) crate. The dynamic namespace will create a child namespace for any path that matches the given pattern with the given handler.
+
+## engineioxide
+* deps: bump `tokio-tungstenite` from `0.21.0` to `0.23.0`.
+
 # 0.13.1
 
 ## engineioxide
-* fix: issue #320. Remove unnecessary panic when receiving unexpected websocket messages. This might happen with some specific socket.io clients.
+* fix: issue [#320](https://github.com/Totodore/socketioxide/issues/320). Remove unnecessary panic when receiving unexpected websocket messages. This might happen with some specific socket.io clients.
 
 # 0.13.0
 
 ## socketioxide
-* fix: issue #311, the `delete_ns` fn was deadlocking the entire server when called from inside a `disconnect_handler`.
+* fix: issue [#311](https://github.com/Totodore/socketioxide/issues/311), the `delete_ns` fn was deadlocking the entire server when called from inside a `disconnect_handler`.
 * feat: the `delete_ns` is now gracefully closing the adapter as well as all its sockets before being removed.
 * feat: the API use `Bytes` rather than `Vec<u8>` to represent binary payloads. This allow to avoid unnecessary copies.
 * deps: use `futures-util` and `futures-core` rather than the whole `futures` crate.
@@ -24,7 +36,7 @@
 
 # 0.11.1
 ## socketioxide
-* fix(#232): under heavy traffic, the adjacent binary packet to the head packet requirement for engine.io was not respected. It was leading to a protocol error. 
+* fix(#232): under heavy traffic, the adjacent binary packet to the head packet requirement for engine.io was not respected. It was leading to a protocol error.
 
 # 0.11.0
 ## socketioxide

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]

--- a/socketioxide/Cargo.toml
+++ b/socketioxide/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 
 [dependencies]
 bytes.workspace = true
-engineioxide = { path = "../engineioxide", version = "0.13.1" }
+engineioxide = { path = "../engineioxide", version = "0.14.0" }
 futures-core.workspace = true
 futures-util.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }

--- a/socketioxide/src/extract/mod.rs
+++ b/socketioxide/src/extract/mod.rs
@@ -11,6 +11,7 @@
 //! extracts and deserialize to json the auth data
 //!     - for [`MessageHandler`]: extracts and deserialize to json the message data
 //! * [`SocketRef`]: extracts a reference to the [`Socket`](crate::socket::Socket)
+//! * [`SocketIo`](crate::SocketIo): extracts a reference to the whole socket.io server context.
 //! * [`Bin`]: extract a binary payload for a given message. Because it consumes the event it should be the last argument
 //! * [`AckSender`]: Can be used to send an ack response to the current message event
 //! * [`ProtocolVersion`](crate::ProtocolVersion): extracts the protocol version

--- a/socketioxide/src/io.rs
+++ b/socketioxide/src/io.rs
@@ -234,6 +234,8 @@ impl Default for SocketIoBuilder {
 
 /// The [`SocketIo`] instance can be cheaply cloned and moved around everywhere in your program.
 /// It can be used as the main handle to access the whole socket.io context.
+///
+/// You can also use it as an extractor for all your [`handlers`](crate::handler).
 #[derive(Debug)]
 pub struct SocketIo<A: Adapter = LocalAdapter>(Arc<Client<A>>);
 


### PR DESCRIPTION
# 0.14.0

## socketioxide
* **(Breaking)**: State reworked to avoid having unsafe global mutable state (issue [#317](https://github.com/Totodore/socketioxide/issues/317)). Therefore State types must now implement `Clone` and will be cloned for each handler where the state is used.
* **(Breaking)**: Extensions reworked to avoid `Send` + `Sync` requirements on extensions (issue [#295](https://github.com/Totodore/socketioxide/issues/295)). They are now extracted by `Cloning`. Therefore all the type must implement `Clone`. An `Extension` extractor is available to get an extension directly without calling `socket.extensions.get()`.
* feat: New `HttpExtension` types to extract extensions from the http request.
* feat: `SocketIo` can now be used as an extractor. So you can now easily access the entire socket.io context from your handlers.
* feat: Dynamic namespaces. You can know set dynamic namespaces with the [`dyn_ns`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIo.html#method.dyn_ns) function. You can specify patterns with the `{name}` syntax thanks to the [matchit](https://github.com/ibraheemdev/matchit) crate. The dynamic namespace will create a child namespace for any path that matches the given pattern with the given handler.

## engineioxide
* deps: bump `tokio-tungstenite` from `0.21.0` to `0.23.0`.
