### PR TITLE
fix(socketio/handler): trace extractor errors

### DIFF
--- a/crates/socketioxide/src/handler/message.rs
+++ b/crates/socketioxide/src/handler/message.rs
@@ -284,12 +284,20 @@ macro_rules! impl_handler {
                 $(
                     let $ty = match $ty::from_message_parts(&s, &mut v, &ack_id) {
                         Ok(v) => v,
-                        Err(_) => return,
+                        Err(_e) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!("Error while extracting data: {}", _e);
+                            return;
+                        },
                     };
                 )*
                 let last = match $last::from_message(s, v, ack_id) {
                     Ok(v) => v,
-                    Err(_) => return,
+                    Err(_e) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::error!("Error while extracting data: {}", _e);
+                        return;
+                    },
                 };
 
                 (self.clone())($($ty,)* last);


### PR DESCRIPTION
Fix #375 
 
## Motivation
Tracing errors where missing when using extractors in async message handlers.

## Solution
Add the missing error logs.