### PR TITLE
doc(socketio): improve extractor docs

### DIFF
--- a/crates/socketioxide-core/src/lib.rs
+++ b/crates/socketioxide-core/src/lib.rs
@@ -41,7 +41,9 @@ pub use engineioxide::{sid::Sid, Str};
 
 /// Represents a value that can be sent over the engine.io wire as an engine.io packet
 /// or the data that can be outputed by a binary parser (e.g. [`MsgPackParser`](../socketioxide_parser_msgpack/index.html))
-/// or a string parser (e.g. [`CommonParser`](../socketioxide_parser_common/index.html)))
+/// or a string parser (e.g. [`CommonParser`](../socketioxide_parser_common/index.html))).
+///
+/// If you want to deserialize this value to a specific type. You should manually call the `Data` extractor.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     /// A string payload that will be sent as a string engine.io packet.

--- a/crates/socketioxide/src/extract/mod.rs
+++ b/crates/socketioxide/src/extract/mod.rs
@@ -1,4 +1,5 @@
-//! ### Extractors for [`ConnectHandler`], [`ConnectMiddleware`], [`MessageHandler`] and [`DisconnectHandler`](crate::handler::DisconnectHandler).
+//! ### Extractors for [`ConnectHandler`], [`ConnectMiddleware`],
+//! [`MessageHandler`] and [`DisconnectHandler`](crate::handler::DisconnectHandler).
 //!
 //! They can be used to extract data from the context of the handler and get specific params. Here are some examples of extractors:
 //! * [`Data`]: extracts and deserialize from any receieved data, if a deserialization error occurs the handler won't be called:
@@ -22,9 +23,13 @@
 //!   (Similar to axum's [`extract::Extension`](https://docs.rs/axum/latest/axum/struct.Extension.html)
 //! * [`MaybeHttpExtension`]: extracts an http extension of the given type if it exists or [`None`] otherwise.
 //!
-//! ### You can also implement your own Extractor with the [`FromConnectParts`], [`FromMessageParts`] and [`FromDisconnectParts`] traits
-//! When implementing these traits, if you clone the [`Arc<Socket>`](crate::socket::Socket) make sure that it is dropped at least when the socket is disconnected.
-//! Otherwise it will create a memory leak. It is why the [`SocketRef`] extractor is used instead of cloning the socket for common usage.
+//! ### You can also implement your own Extractor with the [`FromConnectParts`], [`FromMessageParts`] and
+//! [`FromDisconnectParts`] traits
+//! When implementing these traits, if you clone the [`Arc<Socket>`](crate::socket::Socket) make sure
+//! that it is dropped at least when the socket is disconnected.
+//! Otherwise it will create a memory leak. It is why the [`SocketRef`] extractor is used instead of cloning
+//! the socket for common usage.
+//! If you want to deserialize the [`Value`] data you must manually call the `Data` extractor to deserialize it.
 //!
 //! [`FromConnectParts`]: crate::handler::FromConnectParts
 //! [`FromMessageParts`]: crate::handler::FromMessageParts

--- a/crates/socketioxide/src/handler/mod.rs
+++ b/crates/socketioxide/src/handler/mod.rs
@@ -11,6 +11,8 @@ pub(crate) use disconnect::BoxedDisconnectHandler;
 pub use disconnect::{DisconnectHandler, FromDisconnectParts};
 pub(crate) use message::BoxedMessageHandler;
 pub use message::{FromMessage, FromMessageParts, MessageHandler};
+pub use socketioxide_core::Value;
+
 /// A struct used to erase the type of a [`ConnectHandler`] or [`MessageHandler`] so it can be stored in a map
 pub(crate) struct MakeErasedHandler<H, A, T> {
     handler: H,


### PR DESCRIPTION
Related to #374.
Slightly improve doc for extractors and re-export the `socketioxide_core::Value` type.