### PR TITLE
chore(deps): prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.15.0
+## socketioxide
+* **(Breaking)**: New parsing system. You can now serialize and deserialize binary data inside your own types.
+It also improve performances by avoiding unnecessary allocations.
+* fix: missing extractor error logs for async message handlers.
+* feat: add custom compiler error for unimplemented handler traits.
+* deps: switch from `tower` to `tower-service` and `tower-layer` subcrates.
+* deps: bump `tokio` to 1.40.
+* deps: bump `http` to 1.1.
+* deps: bump `hyper` to 1.5.
+
 # 0.14.0
 
 ## socketioxide

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]

--- a/crates/parser-common/Cargo.toml
+++ b/crates/parser-common/Cargo.toml
@@ -15,7 +15,7 @@ bytes.workspace = true
 itoa.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-socketioxide-core = { version = "0.14.1", path = "../socketioxide-core" }
+socketioxide-core = { version = "0.15.0", path = "../socketioxide-core" }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/parser-msgpack/Cargo.toml
+++ b/crates/parser-msgpack/Cargo.toml
@@ -16,7 +16,7 @@ itoa.workspace = true
 serde.workspace = true
 rmp = "0.8"
 rmp-serde = "1.3.0"
-socketioxide-core = { version = "0.14.1", path = "../socketioxide-core" }
+socketioxide-core = { version = "0.15.0", path = "../socketioxide-core" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/socketioxide-core/Cargo.toml
+++ b/crates/socketioxide-core/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 
 [dependencies]
 bytes.workspace = true
-engineioxide = { version = "0.14.1", path = "../engineioxide" }
+engineioxide = { version = "0.15.0", path = "../engineioxide" }
 serde.workspace = true
 thiserror.workspace = true
 arbitrary = { version = "1.3.2", features = ["derive"], optional = true }

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -14,8 +14,8 @@ readme = "../README.md"
 
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.14.1" }
-socketioxide-core = { path = "../socketioxide-core", version = "0.14.1" }
+engineioxide = { path = "../engineioxide", version = "0.15.0" }
+socketioxide-core = { path = "../socketioxide-core", version = "0.15.0" }
 
 bytes.workspace = true
 futures-core.workspace = true


### PR DESCRIPTION
## socketioxide
* **(Breaking)**: New parsing system. You can now serialize and deserialize binary data inside your own types.
It also improve performances by avoiding unnecessary allocations.
* fix: missing extractor error logs for async message handlers.
* feat: add custom compiler error for unimplemented handler traits.
* deps: switch from `tower` to `tower-service` and `tower-layer` subcrates.
* deps: bump `tokio` to 1.40.
* deps: bump `http` to 1.1.
* deps: bump `hyper` to 1.5.