### PR TITLE
fix(engineio/socket): heartbeat delay causing ping burst

### DIFF
--- a/crates/engineioxide/src/socket.rs
+++ b/crates/engineioxide/src/socket.rs
@@ -374,7 +374,7 @@ where
             .expect("Pong rx should be locked only once");
 
         #[cfg(feature = "tracing")]
-        tracing::debug!("[sid={}] heartbeat receiver routine started", self.id);
+        tracing::debug!(sid = ?self.id, "heartbeat receiver routine started");
 
         loop {
             tokio::time::timeout(interval + timeout, heartbeat_rx.recv())
@@ -383,7 +383,7 @@ where
                 .ok_or(Error::HeartbeatTimeout)?;
 
             #[cfg(feature = "tracing")]
-            tracing::debug!("[sid={}] ping received, sending pong", self.id);
+            tracing::trace!(sid = ?self.id, "ping received, sending pong");
             self.internal_tx
                 .try_send(smallvec![Packet::Pong])
                 .map_err(|_| Error::HeartbeatTimeout)?;

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -26,7 +26,6 @@ tower-layer.workspace = true
 http.workspace = true
 http-body.workspace = true
 thiserror.workspace = true
-smallvec.workspace = true
 hyper.workspace = true
 matchit.workspace = true
 pin-project-lite.workspace = true


### PR DESCRIPTION
## Motivation
Fixes:
* #390

First ping is sent two times because tokio interval default mode is `Bursting`. Because the first tick is missed, the next one is sent two times.

## Solution
Initiate the tokio interval struct _after_ the initial delay