### PR TITLE
Release/v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.15.1
+## socketioxide
+* deps: remove smallvec deps
+* doc: fix some links
+
+## engineioxide
+* fix: issue [#390](https://github.com/Totodore/socketioxide/issues/390). First ping was sent twice because of tokio interval behavior defaulting to bursting when interval tick is missed.
+
 # 0.15.0
 ## socketioxide
 * **(Breaking)**: New parsing system. You can now serialize and deserialize binary data inside your own types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ A [***`socket.io`***](https://socket.io) server implementation in Rust that inte
 * Ack and emit with ack
 * Binary packets
 * Polling & Websocket transports
+* Common (default) & Msgpack parsers
 * Extensions to add custom data to sockets
 * Memory efficient http payload parsing with streams
 * Flexible axum-like API to handle events. With extractors to extract data from your handlers
-* Well tested with the official [end to end test-suite](https://github.com/totodore/socketioxide/actions) 
+* Well tested with the official [end to end test-suite](https://github.com/totodore/socketioxide/actions)
 * Socket.io versions supported :
   * [🔌protocol v5](https://socket.io/docs/v4/) : socket.io js from v3.0.0..latest, it is enabled by default
   * [🔌protocol v4](https://github.com/socketio/socket.io-protocol/tree/v4) : based on engine.io v3, under the feature flag `v4`, (socket.io js from v1.0.3..latest)

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -13,8 +13,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.15.0" }
-socketioxide-core = { path = "../socketioxide-core", version = "0.15.0" }
+engineioxide = { path = "../engineioxide", version = "0.15.1" }
+socketioxide-core = { path = "../socketioxide-core", version = "0.15.1" }
 
 bytes.workspace = true
 futures-core.workspace = true
@@ -34,8 +34,8 @@ pin-project-lite.workspace = true
 rustversion = "1.0.18"
 
 # Parsers
-socketioxide-parser-common = { path = "../parser-common", version = "0.15.0" }
-socketioxide-parser-msgpack = { path = "../parser-msgpack", version = "0.15.0", optional = true }
+socketioxide-parser-common = { path = "../parser-common", version = "0.15.1" }
+socketioxide-parser-msgpack = { path = "../parser-msgpack", version = "0.15.1", optional = true }
 
 # Tracing
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
# 0.15.1
## socketioxide
* deps: remove smallvec deps
* doc: fix some links

## engineioxide
* fix: issue [#390](https://github.com/Totodore/socketioxide/issues/390). First ping was sent twice because of tokio interval behavior defaulting to bursting when interval tick is missed.
