### PR TITLE
chore(docs): add documentation for async adapters

### DIFF
--- a/crates/socketioxide-core/src/lib.rs
+++ b/crates/socketioxide-core/src/lib.rs
@@ -88,6 +88,7 @@ impl<'de> Deserialize<'de> for Value {
 }
 
 #[cfg(feature = "fuzzing")]
+#[doc(hidden)]
 impl arbitrary::Arbitrary<'_> for Value {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let res = match u.arbitrary::<bool>()? {

--- a/crates/socketioxide/src/extract/mod.rs
+++ b/crates/socketioxide/src/extract/mod.rs
@@ -1,5 +1,4 @@
-//! ### Extractors for [`ConnectHandler`], [`ConnectMiddleware`],
-//! [`MessageHandler`] and [`DisconnectHandler`](crate::handler::DisconnectHandler).
+//! ### Extractors for [`ConnectHandler`], [`ConnectMiddleware`], [`MessageHandler`] and [`DisconnectHandler`](crate::handler::DisconnectHandler).
 //!
 //! They can be used to extract data from the context of the handler and get specific params. Here are some examples of extractors:
 //! * [`Data`]: extracts and deserialize from any receieved data, if a deserialization error occurs the handler won't be called:
@@ -10,29 +9,34 @@
 //! * [`TryData`]: extracts and deserialize from the any received data but with a `Result` type in case of error:
 //!     - for [`ConnectHandler`] and [`ConnectMiddleware`]: extracts and deserialize from the incoming auth data
 //!     - for [`MessageHandler`]: extracts and deserialize from the incoming message data
-//! * [`SocketRef`]: extracts a reference to the [`Socket`](crate::socket::Socket)
+//! * [`SocketRef`]: extracts a reference to the [`Socket`](crate::socket::Socket).
 //! * [`SocketIo`](crate::SocketIo): extracts a reference to the whole socket.io server context.
-//! * [`AckSender`]: Can be used to send an ack response to the current message event
-//! * [`ProtocolVersion`](crate::ProtocolVersion): extracts the protocol version
-//! * [`TransportType`](crate::TransportType): extracts the transport type
-//! * [`DisconnectReason`](crate::socket::DisconnectReason): extracts the reason of the disconnection
+//! * [`AckSender`]: Can be used to send an ack response to the current message event.
+//! * [`ProtocolVersion`](crate::ProtocolVersion): extracts the protocol version.
+//! * [`TransportType`](crate::TransportType): extracts the transport type.
+//! * [`DisconnectReason`](crate::socket::DisconnectReason): extracts the reason of the disconnection.
 //! * [`State`]: extracts a [`Clone`] of a state previously set with [`SocketIoBuilder::with_state`](crate::io::SocketIoBuilder).
 //! * [`Extension`]: extracts an extension of the given type stored on the called socket by cloning it.
-//! * [`MaybeExtension`]: extracts an extension of the given type if it exists or [`None`] otherwise
-//! * [`HttpExtension`]: extracts an http extension of the given type coming from the request.
-//!   (Similar to axum's [`extract::Extension`](https://docs.rs/axum/latest/axum/struct.Extension.html)
+//! * [`MaybeExtension`]: extracts an extension of the given type if it exists or [`None`] otherwise.
+//! * [`HttpExtension`]: extracts an http extension of the given type coming from the request
+//!   (Similar to axum's [`extract::Extension`](https://docs.rs/axum/latest/axum/struct.Extension.html).
 //! * [`MaybeHttpExtension`]: extracts an http extension of the given type if it exists or [`None`] otherwise.
 //!
-//! ### You can also implement your own Extractor with the [`FromConnectParts`], [`FromMessageParts`] and
-//! [`FromDisconnectParts`] traits
+//! ### You can also implement your own Extractor!
+//! Implement the [`FromConnectParts`], [`FromMessageParts`], [`FromMessage`] and [`FromDisconnectParts`] traits
+//! on any type to extract data from the context of the handler.
+//!
 //! When implementing these traits, if you clone the [`Arc<Socket>`](crate::socket::Socket) make sure
 //! that it is dropped at least when the socket is disconnected.
 //! Otherwise it will create a memory leak. It is why the [`SocketRef`] extractor is used instead of cloning
 //! the socket for common usage.
-//! If you want to deserialize the [`Value`](socketioxide_core::Value) data you must manually call the `Data` extractor to deserialize it.
+//!
+//! If you want to deserialize the [`Value`](socketioxide_core::Value) data you must manually call
+//! the `Data` extractor to deserialize it.
 //!
 //! [`FromConnectParts`]: crate::handler::FromConnectParts
 //! [`FromMessageParts`]: crate::handler::FromMessageParts
+//! [`FromMessage`]: crate::handler::FromMessage
 //! [`FromDisconnectParts`]: crate::handler::FromDisconnectParts
 //! [`ConnectHandler`]: crate::handler::ConnectHandler
 //! [`ConnectMiddleware`]: crate::handler::ConnectMiddleware
@@ -42,14 +46,12 @@
 //! #### Example that extracts a user id from the query params
 //! ```rust
 //! # use bytes::Bytes;
-//! # use socketioxide::handler::{FromConnectParts, FromMessageParts};
+//! # use socketioxide::handler::{FromConnectParts, FromMessageParts, Value};
 //! # use socketioxide::adapter::Adapter;
 //! # use socketioxide::socket::Socket;
 //! # use std::sync::Arc;
 //! # use std::convert::Infallible;
 //! # use socketioxide::SocketIo;
-//! # use socketioxide_core::Value;
-//!
 //! struct UserId(String);
 //!
 //! #[derive(Debug)]

--- a/crates/socketioxide/src/extract/socket.rs
+++ b/crates/socketioxide/src/extract/socket.rs
@@ -11,6 +11,9 @@ use serde::Serialize;
 use socketioxide_core::{errors::SocketError, packet::Packet, parser::Parse, Value};
 
 /// An Extractor that returns a reference to a [`Socket`].
+///
+/// It is generic over the [`Adapter`] type. If you plan to use it with another adapter than the default,
+/// make sure to have a handler that is [generic over the adapter type](crate#adapters).
 #[derive(Debug)]
 pub struct SocketRef<A: Adapter = LocalAdapter>(Arc<Socket<A>>);
 
@@ -75,6 +78,9 @@ impl<A: Adapter> SocketRef<A> {
 
 /// An Extractor to send an ack response corresponding to the current event.
 /// If the client sent a normal message without expecting an ack, the ack callback will do nothing.
+///
+/// It is generic over the [`Adapter`] type. If you plan to use it with another adapter than the default,
+/// make sure to have a handler that is [generic over the adapter type](crate#adapters).
 #[derive(Debug)]
 pub struct AckSender<A: Adapter = LocalAdapter> {
     socket: Arc<Socket<A>>,

--- a/crates/socketioxide/src/handler/connect.rs
+++ b/crates/socketioxide/src/handler/connect.rs
@@ -171,6 +171,7 @@ pub trait FromConnectParts<A: Adapter>: Sized {
         note = "This function is not a ConnectMiddleware. Check that:
 * It is a clonable sync or async `FnOnce` that returns `Result<(), E> where E: Display`.
 * All its arguments are valid connect extractors.
+* If you use a custom adapter, it must be generic over the adapter type.
 See `https://docs.rs/socketioxide/latest/socketioxide/extract/index.html` for details.\n",
         label = "Invalid ConnectMiddleware"
     )
@@ -200,6 +201,7 @@ pub trait ConnectMiddleware<A: Adapter, T>: Sized + Clone + Send + Sync + 'stati
         note = "This function is not a ConnectHandler. Check that:
 * It is a clonable sync or async `FnOnce` that returns nothing.
 * All its arguments are valid connect extractors.
+* If you use a custom adapter, it must be generic over the adapter type.
 See `https://docs.rs/socketioxide/latest/socketioxide/extract/index.html` for details.\n",
         label = "Invalid ConnectHandler"
     )

--- a/crates/socketioxide/src/handler/disconnect.rs
+++ b/crates/socketioxide/src/handler/disconnect.rs
@@ -127,6 +127,7 @@ pub trait FromDisconnectParts<A: Adapter>: Sized {
         note = "This function is not a DisconnectHandler. Check that:
 * It is a clonable sync or async `FnOnce` that returns nothing.
 * All its arguments are valid disconnect extractors.
+* If you use a custom adapter, it must be generic over the adapter type.
 See `https://docs.rs/socketioxide/latest/socketioxide/extract/index.html` for details.\n",
         label = "Invalid DisconnectHandler"
     )

--- a/crates/socketioxide/src/handler/message.rs
+++ b/crates/socketioxide/src/handler/message.rs
@@ -96,6 +96,7 @@ pub(crate) trait ErasedMessageHandler<A: Adapter>: Send + Sync + 'static {
         note = "This function is not a MessageHandler. Check that:
 * It is a clonable sync or async `FnOnce` that returns nothing.
 * All its arguments are valid message extractors.
+* If you use a custom adapter, it must be generic over the adapter type.
 See `https://docs.rs/socketioxide/latest/socketioxide/extract/index.html` for details.\n",
         label = "Invalid MessageHandler"
     )

--- a/crates/socketioxide/src/io.rs
+++ b/crates/socketioxide/src/io.rs
@@ -283,6 +283,9 @@ impl Default for SocketIoBuilder {
 /// It can be used as the main handle to access the whole socket.io context.
 ///
 /// You can also use it as an extractor for all your [`handlers`](crate::handler).
+///
+/// It is generic over the [`Adapter`] type. If you plan to use it with another adapter than the default,
+/// make sure to have a handler that is [generic over the adapter type](crate#adapters).
 pub struct SocketIo<A: Adapter = LocalAdapter>(Arc<Client<A>>);
 
 impl SocketIo<LocalAdapter> {

--- a/crates/socketioxide/src/lib.rs
+++ b/crates/socketioxide/src/lib.rs
@@ -105,7 +105,8 @@
 //! }
 //! ```
 //! ## Initialisation
-//! The [`SocketIo`] struct is the main entry point of the library. It is used to create a [`Layer`](tower_layer::Layer) or a [`Service`](tower_service::Service).
+//! The [`SocketIo`] struct is the main entry point of the library. It is used to create
+//! a [`Layer`](tower_layer::Layer) or a [`Service`](tower_service::Service).
 //! Later it can be used as the equivalent of the `io` object in the JS API.
 //!
 //! When creating your [`SocketIo`] instance, you can use the builder pattern to configure it with the [`SocketIoBuilder`] struct.
@@ -287,15 +288,43 @@
 //! You can enable the `state` feature and use [`SocketIoBuilder::with_state`](SocketIoBuilder) method to set
 //! multiple global states for the server. You can then access them from any handler with the [`State`] extractor.
 //!
-//! The state is stored in the [`SocketIo`] handle and is shared between all the sockets. The only limitation is that all the provided state types must be clonable.
+//! The state is stored in the [`SocketIo`] handle and is shared between all the sockets. The only limitation is that all the
+//! provided state types must be clonable.
 //! Therefore it is recommended to use the [`Arc`](std::sync::Arc) type to share the state between the handlers.
 //!
 //! You can then use the [`State`] extractor to access the state in the handlers.
 //!
 //! ## Adapters
-//! This library is designed to work with clustering. It uses the [`Adapter`] trait to abstract the underlying storage.
-//! By default it uses the [`LocalAdapter`] which is a simple in-memory adapter.
-//! Currently there is no other adapters available but more will be added in the future.
+//! This library is designed to support clustering through the use of adapters.
+//! Adapters enable broadcasting messages and managing socket room memberships across nodes
+//! without requiring changes to your code. The [`Adapter`] trait abstracts the underlying system,
+//! making it easy to integrate with different implementations.
+//!
+//! Adapters typically interact with third-party systems like Redis, Postgres, Kafka, etc.,
+//! to facilitate message exchange between nodes.
+//!
+//! The default adapter is the [`LocalAdapter`], a simple in-memory implementation. If you intend
+//! to use a different adapter, ensure that extractors are either generic over the adapter type
+//! or explicitly specify the adapter type for each extractor that requires it.
+//!
+//! #### Write this:
+//! ```
+//! # use socketioxide::{SocketIo, adapter::Adapter, extract::SocketRef};
+//! fn my_handler<A: Adapter>(s: SocketRef<A>, io: SocketIo<A>) { }
+//! let (layer, io) = SocketIo::new_layer();
+//! io.ns("/", my_handler);
+//! ```
+//! #### Instead of that:
+//! ```
+//! # use socketioxide::{SocketIo, adapter::Adapter, extract::SocketRef};
+//! fn my_handler(s: SocketRef, io: SocketIo) { }
+//! let (layer, io) = SocketIo::new_layer();
+//! io.ns("/", my_handler);
+//! ```
+//!
+//! Refer to the [README](https://github.com/totodore/socketioxide) for a list of available adapters and
+//! the [examples](https://github.com/totodore/socketioxide/tree/main/examples) for detailed usage guidance.
+//! You can also consult specific adapter crate documentation for more information.
 //!
 //! ## Parsers
 //! This library uses the socket.io common parser which is the default for all the socket.io implementations.
@@ -328,13 +357,13 @@
 //! [`AckSender`]: extract::AckSender
 //! [`AckSender::send`]: extract::AckSender#method.send
 //! [`io`]: SocketIo
-pub mod adapter;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
 #[cfg(feature = "extensions")]
 pub mod extensions;
 
 pub mod ack;
+pub mod adapter;
 pub mod extract;
 pub mod handler;
 pub mod layer;


### PR DESCRIPTION
* Add more details on adapters on the docs home page
* Add error case for the `unimplemented` compiler hint for handlers.
* Add more details about adapters for extractors.