### PR TITLE
feat(adapter): add a remote socket API

### DIFF
--- a/crates/socketioxide-core/src/adapter.rs
+++ b/crates/socketioxide-core/src/adapter.rs
@@ -425,8 +425,7 @@ impl<E: SocketEmitter> CoreLocalAdapter<E> {
     pub fn fetch_sockets(&self, opts: BroadcastOptions) -> Vec<RemoteSocketData> {
         let rooms = self.rooms.read().unwrap();
         let sids = self.apply_opts(&opts, &rooms);
-        let sockets = self.sockets.get_remote_sockets(sids);
-        sockets
+        self.sockets.get_remote_sockets(sids)
     }
 
     //TODO: make this operation O(1)
@@ -480,7 +479,7 @@ impl<E: SocketEmitter> CoreLocalAdapter<E> {
         for sid in sids {
             for (room, sockets) in rooms.iter() {
                 if sockets.contains(&sid) {
-                    room_result.insert(room.to_owned());
+                    room_result.insert(room.clone());
                 }
             }
         }

--- a/crates/socketioxide-core/src/adapter.rs
+++ b/crates/socketioxide-core/src/adapter.rs
@@ -174,8 +174,7 @@ pub trait SocketEmitter: Send + Sync + 'static {
 
     /// Get all the socket ids in the namespace.
     fn get_all_sids(&self, filter: impl Fn(&Sid) -> bool) -> Vec<Sid>;
-    /// Get the sockets that match the list of socket ids
-    /// and encode the data with the given serializer.
+    /// Get the socket data that match the list of socket ids.
     fn get_remote_sockets(&self, sids: BroadcastIter<'_>) -> Vec<RemoteSocketData>;
     /// Send data to the list of socket ids.
     fn send_many(&self, sids: BroadcastIter<'_>, data: Value) -> Result<(), Vec<SocketError>>;

--- a/crates/socketioxide-core/src/adapter.rs
+++ b/crates/socketioxide-core/src/adapter.rs
@@ -174,6 +174,9 @@ pub trait SocketEmitter: Send + Sync + 'static {
 
     /// Get all the socket ids in the namespace.
     fn get_all_sids(&self, filter: impl Fn(&Sid) -> bool) -> Vec<Sid>;
+    /// Get the sockets that match the list of socket ids
+    /// and encode the data with the given serializer.
+    fn get_remote_sockets(&self, sids: BroadcastIter<'_>) -> Vec<RemoteSocketData>;
     /// Send data to the list of socket ids.
     fn send_many(&self, sids: BroadcastIter<'_>, data: Value) -> Result<(), Vec<SocketError>>;
     /// Send data to the list of socket ids and get a stream of acks and the number of expected acks.
@@ -184,11 +187,15 @@ pub trait SocketEmitter: Send + Sync + 'static {
         timeout: Option<Duration>,
     ) -> (Self::AckStream, u32);
     /// Disconnect all the sockets in the list.
-    fn disconnect_many(&self, sids: BroadcastIter<'_>) -> Result<(), Vec<SocketError>>;
+    /// TODO: take a [`BroadcastIter`]. Currently it is impossible because it may create deadlocks
+    /// with Adapter::del_all call.
+    fn disconnect_many(&self, sids: Vec<Sid>) -> Result<(), Vec<SocketError>>;
     /// Get the path of the namespace.
     fn path(&self) -> &Str;
     /// Get the parser of the namespace.
     fn parser(&self) -> impl Parse;
+    /// Get the unique server id.
+    fn server_id(&self) -> Sid;
 }
 
 /// An adapter is responsible for managing the state of the namespace.
@@ -283,16 +290,26 @@ pub trait CoreAdapter<E: SocketEmitter>: Sized + Send + Sync + 'static {
         )
     }
 
-    /// Returns all the rooms for this adapter.
-    fn rooms(&self) -> impl Future<Output = Result<Vec<Room>, Self::Error>> + Send {
-        future::ready(Ok(self.get_local().rooms()))
+    /// Fetches rooms that match the [`BroadcastOptions`]
+    fn rooms(
+        &self,
+        opts: BroadcastOptions,
+    ) -> impl Future<Output = Result<Vec<Room>, Self::Error>> + Send {
+        future::ready(Ok(self.get_local().rooms(opts).into_iter().collect()))
+    }
+
+    /// Fetches remote sockets that match the [`BroadcastOptions`].
+    fn fetch_sockets(
+        &self,
+        opts: BroadcastOptions,
+    ) -> impl Future<Output = Result<Vec<RemoteSocketData>, Self::Error>> + Send {
+        future::ready(Ok(self.get_local().fetch_sockets(opts)))
     }
 
     /// Returns the local adapter. Used to enable default behaviors.
     fn get_local(&self) -> &CoreLocalAdapter<E>;
 
     //TODO: implement
-    // fn fetch_sockets(&self, opts: BroadcastOptions) -> Result<Vec<RemoteSocket>, Error>;
     // fn server_side_emit(&self, packet: Packet, opts: BroadcastOptions) -> Result<u64, Error>;
     // fn persist_session(&self, sid: i64);
     // fn restore_session(&self, sid: i64) -> Session;
@@ -404,6 +421,14 @@ impl<E: SocketEmitter> CoreLocalAdapter<E> {
             .collect()
     }
 
+    /// Returns the sockets ids that match the [`BroadcastOptions`].
+    pub fn fetch_sockets(&self, opts: BroadcastOptions) -> Vec<RemoteSocketData> {
+        let rooms = self.rooms.read().unwrap();
+        let sids = self.apply_opts(&opts, &rooms);
+        let sockets = self.sockets.get_remote_sockets(sids);
+        sockets
+    }
+
     //TODO: make this operation O(1)
     /// Returns the rooms of the socket.
     pub fn socket_rooms(&self, sid: Sid) -> Vec<Cow<'static, str>> {
@@ -441,14 +466,25 @@ impl<E: SocketEmitter> CoreLocalAdapter<E> {
 
     /// Disconnects the sockets that match the [`BroadcastOptions`].
     pub fn disconnect_socket(&self, opts: BroadcastOptions) -> Result<(), Vec<SocketError>> {
-        let room_map = self.rooms.read().unwrap();
-        let sids = self.apply_opts(&opts, &room_map);
+        let sids = self
+            .apply_opts(&opts, &self.rooms.read().unwrap())
+            .collect();
         self.sockets.disconnect_many(sids)
     }
 
     /// Returns all the rooms for this adapter.
-    pub fn rooms(&self) -> Vec<Room> {
-        self.rooms.read().unwrap().keys().cloned().collect()
+    pub fn rooms(&self, opts: BroadcastOptions) -> HashSet<Room> {
+        let rooms = self.rooms.read().unwrap();
+        let sids = self.apply_opts(&opts, &rooms);
+        let mut room_result = HashSet::new();
+        for sid in sids {
+            for (room, sockets) in rooms.iter() {
+                if sockets.contains(&sid) {
+                    room_result.insert(room.to_owned());
+                }
+            }
+        }
+        room_result
     }
 
     /// Get the namespace path.
@@ -459,6 +495,10 @@ impl<E: SocketEmitter> CoreLocalAdapter<E> {
     /// Get the parser of the namespace.
     pub fn parser(&self) -> impl Parse + '_ {
         self.sockets.parser()
+    }
+    /// Get the unique server identifier
+    pub fn server_id(&self) -> Sid {
+        self.sockets.server_id()
     }
 }
 
@@ -588,6 +628,17 @@ impl Iterator for InnerBroadcastIter<'_> {
     }
 }
 
+/// Represent the data of a remote socket.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
+pub struct RemoteSocketData {
+    /// The id of the remote socket.
+    pub id: Sid,
+    /// The server id this socket is connected to.
+    pub server_id: Sid,
+    /// The namespace this socket is connected to.
+    pub ns: Str,
+}
+
 #[cfg(test)]
 mod test {
 
@@ -638,13 +689,21 @@ mod test {
     impl SocketEmitter for StubSockets {
         type AckError = StubError;
         type AckStream = StubAckStream;
-
         fn get_all_sids(&self, filter: impl Fn(&Sid) -> bool) -> Vec<Sid> {
             self.sockets
                 .iter()
                 .copied()
                 .filter(|id| filter(id))
                 .collect()
+        }
+
+        fn get_remote_sockets(&self, sids: BroadcastIter<'_>) -> Vec<RemoteSocketData> {
+            sids.map(|id| RemoteSocketData {
+                id,
+                server_id: Sid::ZERO,
+                ns: self.path.clone(),
+            })
+            .collect()
         }
 
         fn send_many(&self, _: BroadcastIter<'_>, _: Value) -> Result<(), Vec<SocketError>> {
@@ -660,7 +719,7 @@ mod test {
             (StubAckStream, 0)
         }
 
-        fn disconnect_many(&self, _: BroadcastIter<'_>) -> Result<(), Vec<SocketError>> {
+        fn disconnect_many(&self, _: Vec<Sid>) -> Result<(), Vec<SocketError>> {
             Ok(())
         }
 
@@ -670,6 +729,9 @@ mod test {
         fn parser(&self) -> impl Parse {
             crate::parser::test::StubParser
         }
+        fn server_id(&self) -> Sid {
+            Sid::ZERO
+        }
     }
 
     fn create_adapter<const S: usize>(sockets: [Sid; S]) -> CoreLocalAdapter<StubSockets> {
@@ -677,7 +739,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_all() {
+    fn add_all() {
         let socket = Sid::new();
         let adapter = create_adapter([socket]);
         adapter.add_all(socket, ["room1", "room2"]);
@@ -688,7 +750,7 @@ mod test {
     }
 
     #[test]
-    fn test_del() {
+    fn del() {
         let socket = Sid::new();
         let adapter = create_adapter([socket]);
         adapter.add_all(socket, ["room1", "room2"]);
@@ -706,7 +768,7 @@ mod test {
     }
 
     #[test]
-    fn test_del_all() {
+    fn del_all() {
         let socket = Sid::new();
         let adapter = create_adapter([socket]);
         adapter.add_all(socket, ["room1", "room2"]);
@@ -723,7 +785,7 @@ mod test {
     }
 
     #[test]
-    fn test_socket_room() {
+    fn socket_room() {
         let sid1 = Sid::new();
         let sid2 = Sid::new();
         let sid3 = Sid::new();
@@ -738,7 +800,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_socket() {
+    fn add_socket() {
         let socket = Sid::new();
         let adapter = create_adapter([socket]);
         adapter.add_all(socket, ["room1"]);
@@ -754,7 +816,7 @@ mod test {
     }
 
     #[test]
-    fn test_del_socket() {
+    fn del_socket() {
         let socket = Sid::new();
         let adapter = create_adapter([socket]);
         adapter.add_all(socket, ["room1"]);
@@ -785,7 +847,7 @@ mod test {
     }
 
     #[test]
-    fn test_sockets() {
+    fn sockets() {
         let socket0 = Sid::new();
         let socket1 = Sid::new();
         let socket2 = Sid::new();
@@ -817,7 +879,7 @@ mod test {
     }
 
     #[test]
-    fn test_disconnect_socket() {
+    fn disconnect_socket() {
         let socket0 = Sid::new();
         let socket1 = Sid::new();
         let socket2 = Sid::new();
@@ -838,43 +900,58 @@ mod test {
         assert!(sockets.contains(&socket0));
     }
     #[test]
-    fn test_apply_opts() {
+    fn disconnect_empty_opts() {
+        let adapter = create_adapter([]);
+        let opts = BroadcastOptions::default();
+        adapter.disconnect_socket(opts).unwrap();
+    }
+
+    #[test]
+    fn apply_opts() {
         let mut sockets: [Sid; 3] = array::from_fn(|_| Sid::new());
         sockets.sort();
         let adapter = create_adapter(sockets);
-        // Add socket 0 to room1 and room2
+
         adapter.add_all(sockets[0], ["room1", "room2"]);
-        // Add socket 1 to room1 and room3
         adapter.add_all(sockets[1], ["room1", "room3"]);
-        // Add socket 2 to room2 and room3
         adapter.add_all(sockets[2], ["room1", "room2", "room3"]);
 
         // socket 2 is the sender
         let mut opts = BroadcastOptions::new(sockets[2]);
         opts.rooms = smallvec!["room1".into()];
         opts.except = smallvec!["room2".into()];
-        let sids = adapter.sockets(opts);
+        let sids = adapter
+            .apply_opts(&opts, &adapter.rooms.read().unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(sids, [sockets[1]]);
 
         let mut opts = BroadcastOptions::new(sockets[2]);
         opts.add_flag(BroadcastFlags::Broadcast);
-        let mut sids = adapter.sockets(opts);
+        let mut sids = adapter
+            .apply_opts(&opts, &adapter.rooms.read().unwrap())
+            .collect::<Vec<_>>();
         sids.sort();
         assert_eq!(sids, [sockets[0], sockets[1]]);
 
         let mut opts = BroadcastOptions::new(sockets[2]);
         opts.add_flag(BroadcastFlags::Broadcast);
         opts.except = smallvec!["room2".into()];
-        let sids = adapter.sockets(opts);
+        let sids = adapter
+            .apply_opts(&opts, &adapter.rooms.read().unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(sids.len(), 1);
 
         let opts = BroadcastOptions::new(sockets[2]);
-        let sids = adapter.sockets(opts);
+        let sids = adapter
+            .apply_opts(&opts, &adapter.rooms.read().unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(sids.len(), 1);
         assert_eq!(sids[0], sockets[2]);
 
         let opts = BroadcastOptions::new(Sid::new());
-        let sids = adapter.sockets(opts);
+        let sids = adapter
+            .apply_opts(&opts, &adapter.rooms.read().unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(sids.len(), 1);
     }
 }

--- a/crates/socketioxide-core/src/adapter.rs
+++ b/crates/socketioxide-core/src/adapter.rs
@@ -49,6 +49,10 @@ pub struct BroadcastOptions {
     pub except: SmallVec<[Room; 4]>,
     /// The socket id of the sender.
     pub sid: Option<Sid>,
+    /// The target server id can be used to optimize the broadcast.
+    /// More specifically when we use broadcasting to apply a single action on a remote socket.
+    /// We now the server_id of the remote socket, so we can send the action directly to the server.
+    pub server_id: Option<Sid>,
 }
 impl BroadcastOptions {
     /// Add any flags to the options.
@@ -69,6 +73,14 @@ impl BroadcastOptions {
     pub fn new(sid: Sid) -> Self {
         Self {
             sid: Some(sid),
+            ..Default::default()
+        }
+    }
+    /// Create a new broadcast options from a remote socket data.
+    pub fn new_remote(data: &RemoteSocketData) -> Self {
+        Self {
+            sid: Some(data.id),
+            server_id: Some(data.server_id),
             ..Default::default()
         }
     }

--- a/crates/socketioxide-core/src/errors.rs
+++ b/crates/socketioxide-core/src/errors.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::parser::ParserError;
 
 /// Error type when using the underlying engine.io socket
-#[derive(Debug, thiserror::Error, Serialize, Deserialize)]
+#[derive(Debug, thiserror::Error, Serialize, Deserialize, Clone)]
 pub enum SocketError {
     /// The socket channel is full.
     /// You might need to increase the channel size with the [`SocketIoBuilder::max_buffer_size`] method.
@@ -37,6 +37,7 @@ impl From<Infallible> for AdapterError {
 /// Error type for broadcast operations.
 #[derive(thiserror::Error, Debug)]
 pub enum BroadcastError {
+    // This type should never constructed with an empty vector!
     /// An error occurred while sending packets.
     #[error("Error sending data through the engine.io socket: {0:?}")]
     Socket(Vec<SocketError>),
@@ -52,6 +53,10 @@ pub enum BroadcastError {
 
 impl From<Vec<SocketError>> for BroadcastError {
     fn from(value: Vec<SocketError>) -> Self {
+        assert!(
+            !value.is_empty(),
+            "Cannot construct a BroadcastError from an empty vec of SocketError"
+        );
         Self::Socket(value)
     }
 }

--- a/crates/socketioxide/docs/operators/emit_with_ack.md
+++ b/crates/socketioxide/docs/operators/emit_with_ack.md
@@ -1,4 +1,4 @@
-# Emit a message to the client and wait for one or more acknowledgments.
+# Emit a message to one or many clients and wait for one or more acknowledgments.
 
 See [`emit()`](#method.emit) for more details on emitting messages.
 

--- a/crates/socketioxide/docs/operators/fetch_sockets.md
+++ b/crates/socketioxide/docs/operators/fetch_sockets.md
@@ -1,0 +1,44 @@
+# Get all the local and remote sockets selected with the previous operators.
+
+<div class="warning">
+    Use <code>sockets()</code> if you only have a single node.
+</div>
+
+Avoid using this method if you want to immediately perform actions on the sockets.
+Instead, directly apply the actions using operators:
+
+## Correct Approach
+```rust
+# use socketioxide::{SocketIo, extract::*};
+# async fn doc_main() {
+# let (_, io) = SocketIo::new_svc();
+io.within("room1").emit("foo", "bar").await.unwrap();
+io.within("room1").disconnect().await.unwrap();
+# }
+```
+
+## Incorrect Approach
+```rust
+# use socketioxide::{SocketIo, extract::*};
+# async fn doc_main() {
+# let (_, io) = SocketIo::new_svc();
+let sockets = io.within("room1").fetch_sockets().await.unwrap();
+for socket in sockets {
+    println!("Socket id: {:?}", socket.id());
+    socket.emit("test", &"Hello").await.unwrap();
+    socket.leave("room1").await.unwrap();
+}
+# }
+```
+
+# Example
+```rust
+# use socketioxide::{SocketIo, extract::*};
+# async fn doc_main() {
+let (_, io) = SocketIo::new_svc();
+let sockets = io.within("room1").fetch_sockets().await.unwrap();
+for socket in sockets {
+    println!("Socket ID: {:?}", socket.data().id);
+}
+# }
+```

--- a/crates/socketioxide/docs/operators/fetch_sockets.md
+++ b/crates/socketioxide/docs/operators/fetch_sockets.md
@@ -24,7 +24,6 @@ io.within("room1").disconnect().await.unwrap();
 # let (_, io) = SocketIo::new_svc();
 let sockets = io.within("room1").fetch_sockets().await.unwrap();
 for socket in sockets {
-    println!("Socket id: {:?}", socket.id());
     socket.emit("test", &"Hello").await.unwrap();
     socket.leave("room1").await.unwrap();
 }

--- a/crates/socketioxide/docs/operators/get_socket.md
+++ b/crates/socketioxide/docs/operators/get_socket.md
@@ -1,5 +1,5 @@
 # Get a local [`SocketRef`] by the specified [`Sid`].
 
 <div class="warning">
-    This will only work for local sockets. Currently, you can't get a socket from another node.
+    This will only work for local sockets. Use <code>fetch_socket</code> to get remote sockets.
 </div>

--- a/crates/socketioxide/docs/operators/rooms.md
+++ b/crates/socketioxide/docs/operators/rooms.md
@@ -1,4 +1,4 @@
-# Get all room names across all nodes in the current namespace.
+# Get all the rooms selected with the previous operators.
 
 This will return a `Future` that must be awaited because socket.io may communicate with remote instances
 if you use horizontal scaling through remote adapters.

--- a/crates/socketioxide/docs/operators/sockets.md
+++ b/crates/socketioxide/docs/operators/sockets.md
@@ -3,7 +3,7 @@
 This can be used to retrieve any extension data (with the `extensions` feature enabled) from the sockets or to make certain sockets join other rooms.
 
 <div class="warning">
-    This will only work for local sockets. Currently, you can't get a socket from another node.
+    This will only work for local sockets. Use <code>fetch_sockets</code> to get remote sockets.
 </div>
 
 # Example

--- a/crates/socketioxide/src/ack.rs
+++ b/crates/socketioxide/src/ack.rs
@@ -1,8 +1,4 @@
 //! Acknowledgement related types and functions.
-//!
-//! Here is the main type:
-//!
-//! - [`AckStream`]: A [`Stream`]/[`Future`] of data received from the client.
 use std::{
     pin::Pin,
     sync::Arc,
@@ -29,7 +25,7 @@ pub(crate) type AckResult<T> = Result<T, AckError>;
 pin_project_lite::pin_project! {
     /// A [`Future`] of [`AckResponse`] received from the client with its corresponding [`Sid`].
     /// It is used internally by [`AckStream`] and **should not** be used directly.
-    pub struct AckResultWithId<T> {
+    struct AckResultWithId<T> {
         id: Sid,
         #[pin]
         result: Timeout<Receiver<AckResult<T>>>,
@@ -110,10 +106,9 @@ pin_project_lite::pin_project! {
 }
 
 pin_project_lite::pin_project! {
-    #[allow(missing_docs)]
+    #[doc(hidden)]
     #[project = InnerProj]
-    /// An internal stream used by [`AckStream`]. It should not be used directly except when implementing the
-    /// [`Adapter`](crate::adapter::Adapter) trait.
+    /// An internal stream used by [`AckStream`].
     pub enum AckInnerStream {
         Stream {
             #[pin]

--- a/crates/socketioxide/src/adapter.rs
+++ b/crates/socketioxide/src/adapter.rs
@@ -10,7 +10,7 @@ use socketioxide_core::{
 use std::{convert::Infallible, time::Duration};
 
 pub use crate::ns::Emitter;
-
+pub use socketioxide_core::errors::AdapterError;
 /// An adapter is responsible for managing the state of the namespace.
 /// This adapter can be implemented to share the state between multiple servers.
 /// The default adapter is the [`LocalAdapter`], which stores the state in memory.

--- a/crates/socketioxide/src/client.rs
+++ b/crates/socketioxide/src/client.rs
@@ -86,10 +86,10 @@ impl<A: Adapter> Client<A> {
             let this = self.clone();
             let esocket = esocket.clone();
             tokio::spawn(async move {
-                if let Err(e) = ns.adapter.clone().init().await {
+                if let Err(_e) = ns.adapter.clone().init().await {
                     let _path = path.as_str();
                     #[cfg(feature = "tracing")]
-                    tracing::error!(_path, "adapter error while initializing namespace: {}", e);
+                    tracing::error!(_path, "adapter error while initializing namespace: {}", _e);
                     return;
                 }
                 this.nsps.write().unwrap().insert(path, ns.clone());
@@ -162,10 +162,10 @@ impl<A: Adapter> Client<A> {
         // The best solution would be to make the fn async and returning the error to the user.
         // However this would require all .ns() calls to be async.
         let mut fut = Box::pin(ns.adapter.clone().init());
-        let on_err = move |err| {
-            let _path = path.as_ref();
+        let on_err = move |_err| {
+            let _p = path.as_ref();
             #[cfg(feature = "tracing")]
-            tracing::error!(_path, "adapter error while initializing namespace: {}", err);
+            tracing::error!(_p, "adapter error while initializing namespace: {}", _err);
         };
         // This is a hack to avoid spawning the future if it is already resolved.
         // In test env (doctests mostly) this allows to avoid tokio::test::block_on.

--- a/crates/socketioxide/src/io.rs
+++ b/crates/socketioxide/src/io.rs
@@ -22,6 +22,7 @@ use crate::{
     operators::BroadcastOperators,
     parser::Parser,
     service::SocketIoService,
+    socket::RemoteSocket,
     BroadcastError, EmitWithAckError,
 };
 
@@ -63,6 +64,9 @@ pub struct SocketIoConfig {
 
     /// The parser to use to encode and decode socket.io packets
     pub(crate) parser: Parser,
+
+    /// A global server identifier
+    pub server_id: Sid,
 }
 
 impl Default for SocketIoConfig {
@@ -75,6 +79,7 @@ impl Default for SocketIoConfig {
             ack_timeout: Duration::from_secs(5),
             connect_timeout: Duration::from_secs(45),
             parser: Parser::default(),
+            server_id: Sid::new(),
         }
     }
 }
@@ -567,6 +572,13 @@ impl<A: Adapter> SocketIo<A> {
     #[inline]
     pub fn sockets(&self) -> Vec<SocketRef<A>> {
         self.get_default_op().sockets()
+    }
+
+    /// _Alias for `io.of("/").unwrap().fetch_sockets()`_. If the **default namespace "/" is not found** this fn will panic!
+    #[doc = include_str!("../docs/operators/fetch_sockets.md")]
+    #[inline]
+    pub async fn fetch_sockets(&self) -> Result<Vec<RemoteSocket<A>>, A::Error> {
+        self.get_default_op().fetch_sockets().await
     }
 
     /// _Alias for `io.of("/").unwrap().disconnect()`_. If the **default namespace "/" is not found** this fn will panic!

--- a/crates/socketioxide/src/ns.rs
+++ b/crates/socketioxide/src/ns.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use engineioxide::{sid::Sid, Str};
 use socketioxide_core::{
-    adapter::{BroadcastIter, CoreLocalAdapter, SocketEmitter},
+    adapter::{BroadcastIter, CoreLocalAdapter, RemoteSocketData, SocketEmitter},
     errors::SocketError,
     packet::{ConnectPacket, Packet, PacketData},
     parser::Parse,
@@ -82,6 +82,7 @@ impl<A: Adapter> Namespace<A> {
     ) -> Arc<Self> {
         let parser = config.parser;
         let ack_timeout = config.ack_timeout;
+        let uid = config.server_id;
         Arc::new_cyclic(|ns| Self {
             path: path.clone(),
             handler,
@@ -89,7 +90,7 @@ impl<A: Adapter> Namespace<A> {
             sockets: HashMap::new().into(),
             adapter: Arc::new(A::new(
                 adapter_state,
-                CoreLocalAdapter::new(Emitter::new(ns.clone(), parser, path, ack_timeout)),
+                CoreLocalAdapter::new(Emitter::new(ns.clone(), parser, path, ack_timeout, uid)),
             )),
         })
     }
@@ -217,6 +218,7 @@ impl<A: Adapter> Namespace<A> {
 /// A type erased emitter to discard the adapter type parameter `A`.
 /// Otherwise it creates a cyclic dependency between the namespace, the emitter and the adapter.
 trait InnerEmitter: Send + Sync + 'static {
+    fn get_remote_sockets(&self, sids: BroadcastIter<'_>, uid: Sid) -> Vec<RemoteSocketData>;
     /// Get all the socket ids in the namespace.
     fn get_all_sids(&self, filter: &dyn Fn(&Sid) -> bool) -> Vec<Sid>;
     /// Send data to the list of socket ids.
@@ -229,10 +231,20 @@ trait InnerEmitter: Send + Sync + 'static {
         timeout: Duration,
     ) -> (AckInnerStream, u32);
     /// Disconnect all the sockets in the list.
-    fn disconnect_many(&self, sids: BroadcastIter<'_>) -> Result<(), Vec<SocketError>>;
+    fn disconnect_many(&self, sids: Vec<Sid>) -> Result<(), Vec<SocketError>>;
 }
 
 impl<A: Adapter> InnerEmitter for Namespace<A> {
+    fn get_remote_sockets(&self, sids: BroadcastIter<'_>, uid: Sid) -> Vec<RemoteSocketData> {
+        let sockets = self.sockets.read().unwrap();
+        sids.filter_map(|sid| sockets.get(&sid))
+            .map(|socket| RemoteSocketData {
+                id: socket.id,
+                ns: self.path.clone(),
+                server_id: uid,
+            })
+            .collect()
+    }
     fn get_all_sids(&self, filter: &dyn Fn(&Sid) -> bool) -> Vec<Sid> {
         self.sockets
             .read()
@@ -267,12 +279,20 @@ impl<A: Adapter> InnerEmitter for Namespace<A> {
         AckInnerStream::broadcast(packet, sockets, timeout)
     }
 
-    fn disconnect_many(&self, sids: BroadcastIter<'_>) -> Result<(), Vec<SocketError>> {
+    fn disconnect_many(&self, sids: Vec<Sid>) -> Result<(), Vec<SocketError>> {
+        if sids.is_empty() {
+            return Ok(());
+        }
         // Here we can't take a ref because this would cause a deadlock.
         // Ideally the disconnect / closing process should be refactored to avoid this.
-        let sock_map = self.sockets.read().unwrap();
-        let sockets: Vec<Arc<Socket<A>>> =
-            sids.filter_map(|sid| sock_map.get(&sid)).cloned().collect();
+        let sockets = {
+            let sock_map = self.sockets.read().unwrap();
+            sids.into_iter()
+                .filter_map(|sid| sock_map.get(&sid))
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
         let errs = sockets
             .into_iter()
             .filter_map(|socket| socket.disconnect().err())
@@ -293,6 +313,7 @@ pub struct Emitter {
     parser: Parser,
     path: Str,
     ack_timeout: Duration,
+    uid: Sid,
 }
 
 impl Emitter {
@@ -301,12 +322,14 @@ impl Emitter {
         parser: Parser,
         path: Str,
         ack_timeout: Duration,
+        uid: Sid,
     ) -> Self {
         Self {
             ns,
             parser,
             path,
             ack_timeout,
+            uid,
         }
     }
 }
@@ -315,8 +338,24 @@ impl SocketEmitter for Emitter {
     type AckError = crate::AckError;
     type AckStream = AckInnerStream;
 
-    fn parser(&self) -> impl Parse {
-        self.parser
+    fn get_all_sids(&self, filter: impl Fn(&Sid) -> bool) -> Vec<Sid> {
+        self.ns
+            .upgrade()
+            .map(|ns| ns.get_all_sids(&filter))
+            .unwrap_or_default()
+    }
+    fn get_remote_sockets(&self, sids: BroadcastIter<'_>) -> Vec<RemoteSocketData> {
+        self.ns
+            .upgrade()
+            .map(|ns| ns.get_remote_sockets(sids, self.uid))
+            .unwrap_or_default()
+    }
+
+    fn send_many(&self, sids: BroadcastIter<'_>, data: Value) -> Result<(), Vec<SocketError>> {
+        match self.ns.upgrade() {
+            Some(ns) => ns.send_many(sids, data),
+            None => Ok(()),
+        }
     }
 
     fn send_many_with_ack(
@@ -331,28 +370,20 @@ impl SocketEmitter for Emitter {
             .unwrap_or((AckInnerStream::empty(), 0))
     }
 
-    fn send_many(&self, sids: BroadcastIter<'_>, data: Value) -> Result<(), Vec<SocketError>> {
-        match self.ns.upgrade() {
-            Some(ns) => ns.send_many(sids, data),
-            None => Ok(()),
-        }
-    }
-
-    fn disconnect_many(&self, sids: BroadcastIter<'_>) -> Result<(), Vec<SocketError>> {
+    fn disconnect_many(&self, sids: Vec<Sid>) -> Result<(), Vec<SocketError>> {
         match self.ns.upgrade() {
             Some(ns) => ns.disconnect_many(sids),
             None => Ok(()),
         }
     }
-
+    fn parser(&self) -> impl Parse {
+        self.parser
+    }
+    fn server_id(&self) -> Sid {
+        self.uid
+    }
     fn path(&self) -> &Str {
         &self.path
-    }
-    fn get_all_sids(&self, filter: impl Fn(&Sid) -> bool) -> Vec<Sid> {
-        self.ns
-            .upgrade()
-            .map(|ns| ns.get_all_sids(&filter))
-            .unwrap_or_default()
     }
 }
 

--- a/crates/socketioxide/src/ns.rs
+++ b/crates/socketioxide/src/ns.rs
@@ -218,6 +218,7 @@ impl<A: Adapter> Namespace<A> {
 /// A type erased emitter to discard the adapter type parameter `A`.
 /// Otherwise it creates a cyclic dependency between the namespace, the emitter and the adapter.
 trait InnerEmitter: Send + Sync + 'static {
+    /// Get the remote socket data from the socket ids.
     fn get_remote_sockets(&self, sids: BroadcastIter<'_>, uid: Sid) -> Vec<RemoteSocketData>;
     /// Get all the socket ids in the namespace.
     fn get_all_sids(&self, filter: &dyn Fn(&Sid) -> bool) -> Vec<Sid>;

--- a/crates/socketioxide/src/socket.rs
+++ b/crates/socketioxide/src/socket.rs
@@ -249,7 +249,7 @@ impl From<BroadcastError> for RemoteActionError {
     fn from(value: BroadcastError) -> Self {
         // This conversion assumes that we broadcast to a single (remote or not) socket.
         match value {
-            BroadcastError::Socket(s) if s.len() > 0 => RemoteActionError::Socket(s[0].clone()),
+            BroadcastError::Socket(s) if !s.is_empty() => RemoteActionError::Socket(s[0].clone()),
             BroadcastError::Socket(_) => {
                 panic!("BroadcastError with an empty socket vec is not permitted")
             }

--- a/crates/socketioxide/src/socket.rs
+++ b/crates/socketioxide/src/socket.rs
@@ -146,10 +146,12 @@ impl<A> RemoteSocket<A> {
         }
     }
     /// Consume the [`RemoteSocket`] and return its underlying data
+    #[inline]
     pub fn into_data(self) -> RemoteSocketData {
         self.data
     }
     /// Get a ref to the underlying data of the socket
+    #[inline]
     pub fn data(&self) -> &RemoteSocketData {
         &self.data
     }
@@ -192,6 +194,7 @@ impl<A: Adapter> RemoteSocket<A> {
     /// # Get all room names this remote socket is connected to.
     ///
     /// See [`Socket::rooms`] for more info.
+    #[inline]
     pub async fn rooms(&self) -> Result<Vec<Room>, A::Error> {
         self.adapter.rooms(self.get_opts()).await
     }
@@ -199,6 +202,7 @@ impl<A: Adapter> RemoteSocket<A> {
     /// # Add the remote socket to the specified room(s).
     ///
     /// See [`Socket::join`] for more info.
+    #[inline]
     pub async fn join(&self, rooms: impl RoomParam) -> Result<(), A::Error> {
         self.adapter.add_sockets(self.get_opts(), rooms).await
     }
@@ -206,6 +210,7 @@ impl<A: Adapter> RemoteSocket<A> {
     /// # Remove the remote socket from the specified room(s).
     ///
     /// See [`Socket::leave`] for more info.
+    #[inline]
     pub async fn leave(&self, rooms: impl RoomParam) -> Result<(), A::Error> {
         self.adapter.del_sockets(self.get_opts(), rooms).await
     }
@@ -213,13 +218,15 @@ impl<A: Adapter> RemoteSocket<A> {
     /// # Disconnect the remote socket from the current namespace,
     ///
     /// See [`Socket::disconnect`] for more info.
+    #[inline]
     pub async fn disconnect(self) -> Result<(), RemoteActionError> {
         self.adapter.disconnect_socket(self.get_opts()).await?;
         Ok(())
     }
 
+    #[inline(always)]
     fn get_opts(&self) -> BroadcastOptions {
-        BroadcastOptions::new(self.data.id)
+        BroadcastOptions::new_remote(&self.data)
     }
 }
 impl<A> fmt::Debug for RemoteSocket<A> {


### PR DESCRIPTION
## Motivation
When working with remote adapter we need a way to manage remote sockets, fetch them and use them (emit, join, leave, disconnect ,etc...).

## Solution
The `Adapter` trait has a new `fetch_sockets(BroadcastOptions)` function that allow the user to get a `RemoteSocket`. The `RemoteSocket` implements a subset of the `Socket` API. He can then get informations about the remote socket (id, server_id, namespace) and use functions like `emit`/`join`/`leave`/`disconnect`.
Internally the actions on the `RemoteSocket` are propagated through the adapter with a `BroadcastOptions` that contains uniquely the sender socket id.

The `rooms` operator is also modified to take into account the `BroadcastOptions` rather than always fetching all the rooms.