### PR TITLE
feat(core): switch to a new type for server `Uid`

### DIFF
--- a/crates/socketioxide-core/src/adapter.rs
+++ b/crates/socketioxide-core/src/adapter.rs
@@ -23,7 +23,7 @@ use crate::{
     errors::{AdapterError, BroadcastError, SocketError},
     packet::Packet,
     parser::Parse,
-    Value,
+    Uid, Value,
 };
 
 /// A room identifier
@@ -52,7 +52,7 @@ pub struct BroadcastOptions {
     /// The target server id can be used to optimize the broadcast.
     /// More specifically when we use broadcasting to apply a single action on a remote socket.
     /// We now the server_id of the remote socket, so we can send the action directly to the server.
-    pub server_id: Option<Sid>,
+    pub server_id: Option<Uid>,
 }
 impl BroadcastOptions {
     /// Add any flags to the options.
@@ -206,7 +206,7 @@ pub trait SocketEmitter: Send + Sync + 'static {
     /// Get the parser of the namespace.
     fn parser(&self) -> impl Parse;
     /// Get the unique server id.
-    fn server_id(&self) -> Sid;
+    fn server_id(&self) -> Uid;
 }
 
 /// An adapter is responsible for managing the state of the namespace.
@@ -507,7 +507,7 @@ impl<E: SocketEmitter> CoreLocalAdapter<E> {
         self.sockets.parser()
     }
     /// Get the unique server identifier
-    pub fn server_id(&self) -> Sid {
+    pub fn server_id(&self) -> Uid {
         self.sockets.server_id()
     }
 }
@@ -644,7 +644,7 @@ pub struct RemoteSocketData {
     /// The id of the remote socket.
     pub id: Sid,
     /// The server id this socket is connected to.
-    pub server_id: Sid,
+    pub server_id: Uid,
     /// The namespace this socket is connected to.
     pub ns: Str,
 }

--- a/crates/socketioxide-core/src/lib.rs
+++ b/crates/socketioxide-core/src/lib.rs
@@ -37,11 +37,32 @@ pub mod errors;
 pub mod packet;
 pub mod parser;
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, ops::Deref};
 
 use bytes::Bytes;
 pub use engineioxide::{sid::Sid, Str};
 use serde::{Deserialize, Serialize};
+
+/// Represents a unique identifier for a server.
+#[derive(Clone, Serialize, Deserialize, Debug, Copy, PartialEq, Eq, Default)]
+pub struct Uid(Sid);
+impl Deref for Uid {
+    type Target = Sid;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl std::fmt::Display for Uid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl Uid {
+    /// Create a new unique identifier.
+    pub fn new() -> Self {
+        Self(Sid::new())
+    }
+}
 
 /// Represents a value that can be sent over the engine.io wire as an engine.io packet
 /// or the data that can be outputed by a binary parser (e.g. [`MsgPackParser`](../socketioxide_parser_msgpack/index.html))

--- a/crates/socketioxide/src/io.rs
+++ b/crates/socketioxide/src/io.rs
@@ -7,7 +7,10 @@ use engineioxide::{
     TransportType,
 };
 use serde::Serialize;
-use socketioxide_core::adapter::{Room, RoomParam};
+use socketioxide_core::{
+    adapter::{Room, RoomParam},
+    Uid,
+};
 use socketioxide_parser_common::CommonParser;
 #[cfg(feature = "msgpack")]
 use socketioxide_parser_msgpack::MsgPackParser;
@@ -66,7 +69,7 @@ pub struct SocketIoConfig {
     pub(crate) parser: Parser,
 
     /// A global server identifier
-    pub server_id: Sid,
+    pub server_id: Uid,
 }
 
 impl Default for SocketIoConfig {
@@ -79,7 +82,7 @@ impl Default for SocketIoConfig {
             ack_timeout: Duration::from_secs(5),
             connect_timeout: Duration::from_secs(45),
             parser: Parser::default(),
-            server_id: Sid::new(),
+            server_id: Uid::new(),
         }
     }
 }
@@ -622,7 +625,7 @@ impl<A: Adapter> SocketIo<A> {
     #[doc = include_str!("../docs/operators/broadcast.md")]
     #[inline]
     pub fn broadcast(&self) -> BroadcastOperators<A> {
-        self.get_default_op().broadcast()
+        self.get_default_op()
     }
 
     #[cfg(feature = "state")]

--- a/crates/socketioxide/src/ns.rs
+++ b/crates/socketioxide/src/ns.rs
@@ -20,7 +20,7 @@ use socketioxide_core::{
     errors::SocketError,
     packet::{ConnectPacket, Packet, PacketData},
     parser::Parse,
-    Value,
+    Uid, Value,
 };
 
 /// A [`Namespace`] constructor used for dynamic namespaces
@@ -219,7 +219,7 @@ impl<A: Adapter> Namespace<A> {
 /// Otherwise it creates a cyclic dependency between the namespace, the emitter and the adapter.
 trait InnerEmitter: Send + Sync + 'static {
     /// Get the remote socket data from the socket ids.
-    fn get_remote_sockets(&self, sids: BroadcastIter<'_>, uid: Sid) -> Vec<RemoteSocketData>;
+    fn get_remote_sockets(&self, sids: BroadcastIter<'_>, uid: Uid) -> Vec<RemoteSocketData>;
     /// Get all the socket ids in the namespace.
     fn get_all_sids(&self, filter: &dyn Fn(&Sid) -> bool) -> Vec<Sid>;
     /// Send data to the list of socket ids.
@@ -236,7 +236,7 @@ trait InnerEmitter: Send + Sync + 'static {
 }
 
 impl<A: Adapter> InnerEmitter for Namespace<A> {
-    fn get_remote_sockets(&self, sids: BroadcastIter<'_>, uid: Sid) -> Vec<RemoteSocketData> {
+    fn get_remote_sockets(&self, sids: BroadcastIter<'_>, uid: Uid) -> Vec<RemoteSocketData> {
         let sockets = self.sockets.read().unwrap();
         sids.filter_map(|sid| sockets.get(&sid))
             .map(|socket| RemoteSocketData {
@@ -314,7 +314,7 @@ pub struct Emitter {
     parser: Parser,
     path: Str,
     ack_timeout: Duration,
-    uid: Sid,
+    uid: Uid,
 }
 
 impl Emitter {
@@ -323,7 +323,7 @@ impl Emitter {
         parser: Parser,
         path: Str,
         ack_timeout: Duration,
-        uid: Sid,
+        uid: Uid,
     ) -> Self {
         Self {
             ns,
@@ -380,7 +380,7 @@ impl SocketEmitter for Emitter {
     fn parser(&self) -> impl Parse {
         self.parser
     }
-    fn server_id(&self) -> Sid {
+    fn server_id(&self) -> Uid {
         self.uid
     }
     fn path(&self) -> &Str {


### PR DESCRIPTION
## Motivation
To avoid bugs, the server id type should not be the same that the socket (`Sid`).

## Solution
A new wrapper type named `Uid` will define a server id.
