### PR TITLE
chore(deps): prepare v0.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,8 @@ jobs:
             path: crates/parser-msgpack
           - crate: socketioxide
             path: crates/socketioxide
+          - crate: socketioxide_redis
+            path: crates/socketioxide-redis
     steps:
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+_From now all crate versions are disjoined._
+
+# socketioxide 0.16.0
+* feat(*breaking*): remote adapters, see [this article](https://github.com/Totodore/socketioxide/discussions/440) for more details.
+* deps: bump `thiserror` to 2.0
+* deps: bump `axum` to 0.8
+* deps: bump `engineioxide` to 0.16.0
+* docs: fix grammar/typos
+
+# socketioxide-parser-msgpack 0.16.0
+* feat(*breaking*): remote adapters
+
+# socketioxide-parser-common 0.16.0
+* feat(*breaking*): remote adapters
+
+# socketioxide-core 0.16.0
+* feat(*breaking*): remote adapters
+
+# socketioxide-redis 0.1.0
+* Initial release!
+
+# engineioxide 0.16.0
+* deps: bump `thiserror` to 2.0
+* deps: bump `tokio-tungstenite` to 0.26
+* docs: fix grammar/typos
+* fix(engineio): heartbeat start delay
+
 # 0.15.1
 ## socketioxide
 * deps: remove smallvec deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace.package]
-version = "0.15.1"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Théodore Prévot <"]

--- a/crates/engineioxide/Cargo.toml
+++ b/crates/engineioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engineioxide"
 description = "Engine IO server implementation in rust as a Tower Service."
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/parser-common/Cargo.toml
+++ b/crates/parser-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide-parser-common"
 description = "Common parser for the socketioxide protocol"
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -17,7 +17,7 @@ bytes.workspace = true
 itoa.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-socketioxide-core = { version = "0.15.0", path = "../socketioxide-core" }
+socketioxide-core = { version = "0.16", path = "../socketioxide-core" }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/parser-msgpack/Cargo.toml
+++ b/crates/parser-msgpack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide-parser-msgpack"
 description = "Msgpack parser for the socketioxide protocol"
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -17,7 +17,7 @@ bytes.workspace = true
 serde.workspace = true
 rmp-serde.workspace = true
 rmp.workspace = true
-socketioxide-core = { version = "0.15.0", path = "../socketioxide-core" }
+socketioxide-core = { version = "0.16", path = "../socketioxide-core" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/socketioxide-core/Cargo.toml
+++ b/crates/socketioxide-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide-core"
 description = "Core of the socketioxide library. Contains basic types and interfaces for the socketioxide crate and all other related sub-crates."
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ readme.workspace = true
 
 [dependencies]
 bytes.workspace = true
-engineioxide = { version = "0.15", path = "../engineioxide" }
+engineioxide = { version = "0.16", path = "../engineioxide" }
 serde.workspace = true
 thiserror.workspace = true
 futures-core.workspace = true

--- a/crates/socketioxide-redis/Cargo.toml
+++ b/crates/socketioxide-redis/Cargo.toml
@@ -19,7 +19,7 @@ fred = ["dep:fred"]
 default = ["redis"]
 
 [dependencies]
-socketioxide-core = { version = "0.15", path = "../socketioxide-core" }
+socketioxide-core = { version = "0.16", path = "../socketioxide-core" }
 futures-core.workspace = true
 futures-util.workspace = true
 pin-project-lite.workspace = true

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide"
 description = "Socket IO server implementation in rust as a Tower Service."
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -13,8 +13,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.15" }
-socketioxide-core = { path = "../socketioxide-core", version = "0.15" }
+engineioxide = { path = "../engineioxide", version = "0.16" }
+socketioxide-core = { path = "../socketioxide-core", version = "0.16" }
 
 bytes.workspace = true
 futures-core.workspace = true
@@ -32,8 +32,8 @@ pin-project-lite.workspace = true
 rustversion.workspace = true
 
 # Parsers
-socketioxide-parser-common = { path = "../parser-common", version = "0.15.1" }
-socketioxide-parser-msgpack = { path = "../parser-msgpack", version = "0.15.1", optional = true }
+socketioxide-parser-common = { path = "../parser-common", version = "0.16" }
+socketioxide-parser-msgpack = { path = "../parser-msgpack", version = "0.16", optional = true }
 
 # Tracing
 tracing = { workspace = true, optional = true }

--- a/e2e/engineioxide/Cargo.toml
+++ b/e2e/engineioxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engineioxide-e2e"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/e2e/socketioxide/Cargo.toml
+++ b/e2e/socketioxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socketioxide-e2e"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
# News
<img align="right" src="https://github.com/user-attachments/assets/e710fe8a-7598-42ea-8dcc-c0afa26f97ab" />

* Socketioxide has a new logo!
* Remote adapters are finally here! You can use them to scale your socket.io application easily. 
See [this article](https://github.com/Totodore/socketioxide/discussions/440) for more info.
* Thanks to @dollannn and @BrianWiz for their sponsoring!


# Changelog
_From now all crate versions are disjoined._

## socketioxide 0.16.0
* feat(*breaking*): remote adapters, see [this article](https://github.com/Totodore/socketioxide/discussions/440) for more details.
* deps: bump `thiserror` to 2.0
* deps: bump `axum` to 0.8
* deps: bump `engineioxide` to 0.16.0
* docs: fix grammar/typos

## socketioxide-parser-msgpack 0.16.0
* feat(*breaking*): remote adapters

## socketioxide-parser-common 0.16.0
* feat(*breaking*): remote adapters

## socketioxide-core 0.16.0
* feat(*breaking*): remote adapters

## socketioxide-redis 0.1.0
* Initial release!

## engineioxide 0.16.0
* deps: bump `thiserror` to 2.0
* deps: bump `tokio-tungstenite` to 0.26
* docs: fix grammar/typos
* fix(engineio): heartbeat start delay
