### PR TITLE
Prepare release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# engineioxide 0.16.1
+* feat: add `Config::ws_read_buffer_size` to set the read buffer size for each websocket.
+It will default to 4KiB (previously 128KiB). You can increase it if you have high message throughput and less sockets.
+
+# socketioxide 0.16.1
+* feat: add `Config::ws_read_buffer_size` to set the read buffer size for each websocket.
+* deps: bump `engineioxide` to 0.16.1.
+
+# socketioxide-parser-common 0.16.1
+* fix: clone partial packets when keeping them to avoid holding a reference to the ws read buffer for too long. Otherwise it cause the
+ws read buffer to grows indefinitely in a many binary packets scenario.
+
+# socketioxide-redis 0.2
+* deps: bump `redis` to 0.28.2
+* feat(*breaking*): the redis cluster adapter constructor now takes a `&redis::cluster::ClusterClient`
+to match all other adapter constructors.
+
 _From now all crate versions are disjoined._
 
 # socketioxide 0.16.0

--- a/crates/engineioxide/Cargo.toml
+++ b/crates/engineioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engineioxide"
 description = "Engine IO server implementation in rust as a Tower Service."
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/parser-common/Cargo.toml
+++ b/crates/parser-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide-parser-common"
 description = "Common parser for the socketioxide protocol"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/socketioxide-redis/Cargo.toml
+++ b/crates/socketioxide-redis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide-redis"
 description = "Redis adapter for the socket.io protocol"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide"
 description = "Socket IO server implementation in rust as a Tower Service."
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -13,7 +13,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.16" }
+engineioxide = { path = "../engineioxide", version = "0.16.1" }
 socketioxide-core = { path = "../socketioxide-core", version = "0.16" }
 
 bytes.workspace = true


### PR DESCRIPTION
# Changelog

## engineioxide 0.16.1
* feat: add `Config::ws_read_buffer_size` to set the read buffer size for each websocket.
It will default to 4KiB (previously 128KiB). You can increase it if you have high message throughput and less sockets.

## socketioxide 0.16.1
* feat: add `Config::ws_read_buffer_size` to set the read buffer size for each websocket.
* deps: bump `engineioxide` to 0.16.1.

## socketioxide-parser-common 0.16.1
* fix: clone partial packets when keeping them to avoid holding a reference to the ws read buffer for too long. Otherwise it cause the ws read buffer to grows indefinitely in a many binary packets scenario.

## socketioxide-redis 0.2
* deps: bump `redis` to 0.28.2
* feat(*breaking*): the redis cluster adapter constructor now takes a `&redis::cluster::ClusterClient`
to match all other adapter constructors.
