### PR TITLE
test(socketio): mock http/ws connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ rustversion = "1"
 
 # Dev deps
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["io"], default-features = false }
 criterion = { version = "0.5", features = [
     "rayon",
     "html_reports",

--- a/crates/engineioxide/Cargo.toml
+++ b/crates/engineioxide/Cargo.toml
@@ -54,9 +54,8 @@ tracing-subscriber.workspace = true
 hyper = { workspace = true, features = ["server", "http1"] }
 criterion.workspace = true
 axum.workspace = true
-tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["io"], default-features = false }
-
+tokio-stream.workspace = true
+tokio-util.workspace = true
 [features]
 v3 = ["memchr", "unicode-segmentation", "itoa"]
 tracing = ["dep:tracing"]

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -61,9 +61,9 @@ tokio = { workspace = true, features = [
 ] }
 tracing-subscriber.workspace = true
 criterion.workspace = true
-hyper = { workspace = true, features = ["server", "http1"] }
-hyper-util = { workspace = true, features = ["tokio", "client-legacy"] }
 http-body-util.workspace = true
+tokio-stream.workspace = true
+tokio-util.workspace = true
 rand = { version = "0.8", default-features = false }
 
 # docs.rs-specific configuration

--- a/crates/socketioxide/src/service.rs
+++ b/crates/socketioxide/src/service.rs
@@ -150,3 +150,31 @@ impl<A: Adapter, S: Clone> Clone for SocketIoService<S, A> {
         }
     }
 }
+
+#[cfg(feature = "__test_harness")]
+#[doc(hidden)]
+impl<Svc, A> SocketIoService<Svc, A>
+where
+    Svc: Clone,
+    A: Adapter,
+{
+    /// Create a new socket.io conn over websocket through a raw stream.
+    /// Mostly used for testing.
+    pub fn ws_init<S>(
+        &self,
+        conn: S,
+        protocol: crate::ProtocolVersion,
+        sid: Option<crate::socket::Sid>,
+        req_data: http::request::Parts,
+    ) -> impl std::future::Future<Output = ()>
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+    {
+        let svc = self.engine_svc.clone();
+        async move {
+            if let Err(e) = svc.ws_init(conn, protocol.into(), sid, req_data).await {
+                eprintln!("Error initializing websocket connection {e}");
+            }
+        }
+    }
+}

--- a/crates/socketioxide/tests/fixture.rs
+++ b/crates/socketioxide/tests/fixture.rs
@@ -2,24 +2,31 @@
 
 use std::{
     collections::VecDeque,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    io,
+    pin::Pin,
+    task::{Context, Poll},
     time::Duration,
 };
 
+use bytes::Bytes;
 use engineioxide::service::NotFoundService;
-use futures_util::{SinkExt, StreamExt};
+use futures_util::SinkExt;
 use http::Request;
 use http_body_util::{BodyExt, Either, Empty, Full};
-use hyper::server::conn::http1;
-use hyper_util::{
-    client::legacy::Client,
-    rt::{TokioExecutor, TokioIo},
-};
 
 use serde::{Deserialize, Serialize};
-use socketioxide::{adapter::LocalAdapter, service::SocketIoService, SocketIo};
-use tokio::net::{TcpListener, TcpStream};
-use tokio_tungstenite::{tungstenite::Message, MaybeTlsStream, WebSocketStream};
+use socketioxide::{service::SocketIoService, ProtocolVersion, SocketIo};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::mpsc,
+};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_tungstenite::{
+    tungstenite::{handshake::client::generate_key, protocol::Role, Message},
+    WebSocketStream,
+};
+use tokio_util::io::StreamReader;
+use tower_service::Service;
 
 /// An OpenPacket is used to initiate a connection
 #[derive(Debug, Serialize, Deserialize, PartialEq, PartialOrd)]
@@ -34,7 +41,7 @@ struct OpenPacket {
 
 /// Params should be in the form of `key1=value1&key2=value2`
 pub async fn send_req(
-    port: u16,
+    svc: &SocketIoService<NotFoundService>,
     params: String,
     method: http::Method,
     body: Option<String>,
@@ -45,17 +52,10 @@ pub async fn send_req(
     };
     let req = Request::builder()
         .method(method)
-        .uri(format!(
-            "http://127.0.0.1:{port}/socket.io/?EIO=4&{}",
-            params
-        ))
+        .uri(format!("http://127.0.0.1/socket.io/?EIO=4&{}", params))
         .body(body)
         .unwrap();
-    let mut res = Client::builder(TokioExecutor::new())
-        .build_http()
-        .request(req)
-        .await
-        .unwrap();
+    let mut res = svc.clone().call(req).await.unwrap();
     let is_json = res
         .headers()
         .get("Content-Type")
@@ -73,9 +73,9 @@ pub async fn send_req(
     }
 }
 
-pub async fn create_polling_connection(port: u16) -> String {
+pub async fn create_polling_connection(svc: &SocketIoService<NotFoundService>) -> String {
     let body = send_req(
-        port,
+        svc,
         "transport=polling".to_string(),
         http::Method::GET,
         None,
@@ -84,68 +84,106 @@ pub async fn create_polling_connection(port: u16) -> String {
     let open_packet: OpenPacket = serde_json::from_str(&body).unwrap();
 
     send_req(
-        port,
+        svc,
         format!("transport=polling&sid={}", open_packet.sid),
         http::Method::POST,
         Some("40{}".to_string()),
     )
     .await;
 
-    open_packet.sid
-}
-pub async fn create_ws_connection(port: u16) -> WebSocketStream<MaybeTlsStream<TcpStream>> {
-    let mut ws = tokio_tungstenite::connect_async(format!(
-        "ws://127.0.0.1:{port}/socket.io/?EIO=4&transport=websocket"
-    ))
-    .await
-    .unwrap()
-    .0;
-
-    assert!(matches!(ws.next().await, Some(Ok(Message::Text(msg))) if msg.starts_with("0"))); // engine.io connect.
-    assert!(matches!(ws.next().await, Some(Ok(Message::Text(msg))) if msg == "2")); // engine.io ping.
-    ws.send(Message::Text("40{}".into())).await.unwrap();
-
-    // wait the time that the socket is connected.
+    // wait for the server to process messages and call handlers
     tokio::time::sleep(Duration::from_millis(10)).await;
 
+    open_packet.sid
+}
+
+pin_project_lite::pin_project! {
+    pub struct StreamImpl {
+        tx: mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        #[pin]
+        rx: StreamReader<UnboundedReceiverStream<Result<Bytes, io::Error>>, Bytes>,
+    }
+}
+impl StreamImpl {
+    pub fn new(
+        tx: mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        rx: mpsc::UnboundedReceiver<Result<Bytes, io::Error>>,
+    ) -> Self {
+        Self {
+            tx,
+            rx: StreamReader::new(UnboundedReceiverStream::new(rx)),
+        }
+    }
+}
+
+impl AsyncRead for StreamImpl {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.project().rx.poll_read(cx, buf)
+    }
+}
+impl AsyncWrite for StreamImpl {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let len = buf.len();
+        self.project()
+            .tx
+            .send(Ok(Bytes::copy_from_slice(buf)))
+            .unwrap();
+        Poll::Ready(Ok(len))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+pub async fn create_ws_connection(
+    svc: &SocketIoService<NotFoundService>,
+) -> WebSocketStream<StreamImpl> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let (tx1, rx1) = mpsc::unbounded_channel();
+
+    let parts = Request::builder()
+        .method("GET")
+        .header("Host", "127.0.0.1")
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Key", generate_key())
+        .uri("ws://127.0.0.1/socket.io/?EIO=4&transport=websocket")
+        .body(http_body_util::Empty::<Bytes>::new())
+        .unwrap()
+        .into_parts()
+        .0;
+    tokio::spawn(svc.ws_init(StreamImpl::new(tx, rx1), ProtocolVersion::V5, None, parts));
+
+    let mut ws = tokio_tungstenite::WebSocketStream::from_raw_socket(
+        StreamImpl::new(tx1, rx),
+        Role::Client,
+        Default::default(),
+    )
+    .await;
+    ws.send(Message::text("40{}")).await.unwrap();
+    // wait for the server to process messages and call handlers
+    tokio::time::sleep(Duration::from_millis(10)).await;
     ws
 }
 
-pub async fn create_server(port: u16) -> SocketIo {
-    let (svc, io) = SocketIo::builder()
+pub async fn create_server() -> (SocketIoService<NotFoundService>, SocketIo) {
+    SocketIo::builder()
         .ping_interval(Duration::from_millis(300))
         .ping_timeout(Duration::from_millis(200))
         .max_buffer_size(100000)
-        .build_svc();
-
-    spawn_server(port, svc).await;
-    io
-}
-
-async fn spawn_server(port: u16, svc: SocketIoService<NotFoundService, LocalAdapter>) {
-    let addr = &SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    let listener = TcpListener::bind(&addr).await.unwrap();
-    tokio::spawn(async move {
-        // We start a loop to continuously accept incoming connections
-        loop {
-            let (stream, _) = listener.accept().await.unwrap();
-
-            // Use an adapter to access something implementing `tokio::io` traits as if they implement
-            // `hyper::rt` IO traits.
-            let io = TokioIo::new(stream);
-            let svc = svc.clone();
-
-            // Spawn a tokio task to serve multiple connections concurrently
-            tokio::task::spawn(async move {
-                // Finally, we bind the incoming connection to our `hello` service
-                if let Err(err) = http1::Builder::new()
-                    .serve_connection(io, svc)
-                    .with_upgrades()
-                    .await
-                {
-                    println!("Error serving connection: {:?}", err);
-                }
-            });
-        }
-    });
+        .build_svc()
 }


### PR DESCRIPTION
## Motivation
Use the new `ws_init` provided by engineioxide to correctly mock http/ws connections without spawning real servers.