### PR TITLE
feat(socketio): on_fallback handler and Event extractor

### DIFF
--- a/crates/socketioxide/src/extract/data.rs
+++ b/crates/socketioxide/src/extract/data.rs
@@ -105,5 +105,22 @@ where
     }
 }
 
+/// An Extractor that returns the event name related to the incoming message.
+pub struct Event(pub String);
+impl<A> FromMessageParts<A> for Event
+where
+    A: Adapter,
+{
+    type Error = ParserError;
+    fn from_message_parts(
+        s: &Arc<Socket<A>>,
+        v: &mut Value,
+        _: &Option<i64>,
+    ) -> Result<Self, ParserError> {
+        Ok(Event(s.parser.read_event(v)?.to_string()))
+    }
+}
+
 super::__impl_deref!(TryData<T>: Result<T, ParserError>);
 super::__impl_deref!(Data);
+super::__impl_deref!(Event: str);

--- a/crates/socketioxide/src/extract/mod.rs
+++ b/crates/socketioxide/src/extract/mod.rs
@@ -9,6 +9,7 @@
 //! * [`TryData`]: extracts and deserialize from the any received data but with a `Result` type in case of error:
 //!     - for [`ConnectHandler`] and [`ConnectMiddleware`]: extracts and deserialize from the incoming auth data
 //!     - for [`MessageHandler`]: extracts and deserialize from the incoming message data
+//! * [`Event`]: extracts the message event name.
 //! * [`SocketRef`]: extracts a reference to the [`Socket`](crate::socket::Socket).
 //! * [`SocketIo`](crate::SocketIo): extracts a reference to the whole socket.io server context.
 //! * [`AckSender`]: Can be used to send an ack response to the current message event.


### PR DESCRIPTION
## Motivation
There is currently no way do dynamically handle events. (See issue #498).

The Socket.io JS implementation has catch-all handlers however I don't think it is a good design for socketioxide as it adds a lot of complexity (see the complete list of variant to cover all cases: https://socket.io/docs/v4/listening-to-events/#catch-all-listeners).

## Solution
A simple `on_fallback` handler that will be called for *unknown* events like a HTTP 404 handler.
A new `Event` extractor will be also available to extract the event name. 
This let the user manage events as he wants and we avoid a lot of complexity that would be introduced by `catch-all` handlers.

> This does not replace the need for a middleware feature with wrapping capabilities, however it is a much bigger task. I will add a tracking issue for this. 