### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [parser-common](./crates/parser-common/CHANGELOG.md)
 * [parser-msgpack](./crates/parser-msgpack/CHANGELOG.md)
 * [socketioxide-redis](./crates/socketioxide-redis/CHANGELOG.md)
+* [socketioxide-mongodb](./crates/socketioxide-mongodb/CHANGELOG.md)
 * [socketioxide](./crates/socketioxide/CHANGELOG.md)
 * [engineioxide](./crates/engineioxide/CHANGELOG.md)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "engineioxide"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "engineioxide-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "axum",
  "bytes",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-parser-common"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-parser-msgpack"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/crates/engineioxide-core/CHANGELOG.md
+++ b/crates/engineioxide-core/CHANGELOG.md
@@ -1,2 +1,5 @@
+# engineioxide-core 0.2.0
+* MSRV: rust-version is now 1.86 with edition 2024
+
 # engineioxide-core 0.1.0
 * New crate to share engineioxide core types.

--- a/crates/engineioxide-core/Cargo.toml
+++ b/crates/engineioxide-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engineioxide-core"
 description = "Engineioxide core types and utilities"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/engineioxide/CHANGELOG.md
+++ b/crates/engineioxide/CHANGELOG.md
@@ -1,3 +1,6 @@
+# engineioxide 0.17
+* MSRV: rust-version is now 1.86 with edition 2024
+
 # engineioxide 0.16.2
 * fix: pause heartbeat when the socket is being upgraded to avoid the client
 from resending polling requests to respond to ping packets.

--- a/crates/engineioxide/Cargo.toml
+++ b/crates/engineioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engineioxide"
 description = "Engine IO server implementation in rust as a Tower Service."
-version = "0.16.2"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ features = ["v3"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-engineioxide-core = { path = "../engineioxide-core", version = "0.1" }
+engineioxide-core = { path = "../engineioxide-core", version = "0.2" }
 bytes.workspace = true
 futures-core.workspace = true
 futures-util.workspace = true

--- a/crates/parser-common/CHANGELOG.md
+++ b/crates/parser-common/CHANGELOG.md
@@ -1,3 +1,7 @@
+# socketioxide-parser-common 0.17
+* deps: bump `socketioxide-core` to 0.17
+* MSRV: rust-version is now 1.86 with edition 2024
+
 # socketioxide-parser-common 0.16.1
 * fix: clone partial packets when keeping them to avoid holding a reference to the ws read buffer for too long. Otherwise it cause the
 ws read buffer to grows indefinitely in a many binary packets scenario.

--- a/crates/parser-common/Cargo.toml
+++ b/crates/parser-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide-parser-common"
 description = "Common parser for the socketioxide protocol"
-version = "0.16.1"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/parser-msgpack/CHANGELOG.md
+++ b/crates/parser-msgpack/CHANGELOG.md
@@ -1,2 +1,6 @@
+# socketioxide-parser-msgpack 0.17
+* deps: bump `socketioxide-core` to 0.17
+* MSRV: rust-version is now 1.86 with edition 2024
+
 # socketioxide-parser-msgpack 0.16.0
 * feat(*breaking*): remote adapters

--- a/crates/parser-msgpack/Cargo.toml
+++ b/crates/parser-msgpack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide-parser-msgpack"
 description = "Msgpack parser for the socketioxide protocol"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/socketioxide-core/CHANGELOG.md
+++ b/crates/socketioxide-core/CHANGELOG.md
@@ -1,3 +1,8 @@
+# socketioxide-core 0.17.0
+* feat(*breaking*): remote-adapter packets are now refactored in the core crate. Any adapter implementation can use
+it through the `remote-adapter` flag.
+* MSRV: rust-version is now 1.86 with edition 2024
+
 # socketioxide-core 0.16.1
 * deps: use engineioxide-core 0.1 rather than engineioxide
 

--- a/crates/socketioxide-core/Cargo.toml
+++ b/crates/socketioxide-core/Cargo.toml
@@ -17,7 +17,7 @@ remote-adapter = []
 
 [dependencies]
 bytes.workspace = true
-engineioxide-core = { version = "0.1", path = "../engineioxide-core" }
+engineioxide-core = { version = "0.2", path = "../engineioxide-core" }
 serde.workspace = true
 thiserror.workspace = true
 futures-core.workspace = true

--- a/crates/socketioxide-mongodb/CHANGELOG.md
+++ b/crates/socketioxide-mongodb/CHANGELOG.md
@@ -1,0 +1,2 @@
+# socketioxide-mongodb 0.1.0
+* Initial release!

--- a/crates/socketioxide-mongodb/README.md
+++ b/crates/socketioxide-mongodb/README.md
@@ -10,14 +10,14 @@ A [***`socket.io`***](https://socket.io) adapter for [***`Socketioxide`***](http
 
 ## Features
 
-- ✅ **MongoDB Change Stream-based adapter**
-- 📦 **Support for any MongoDB client** via the [`Driver`] abstraction
-- 🧩 Built-in driver for the [mongodb](https://docs.rs/mongodb) crate: [`MongoDbDriver`](https://docs.rs/socketioxide-mongodb/latest/socketioxide_mongodb/drivers/mongodb/struct.MongoDbDriver.html)
-- ⌛ **Message expiration** via:
+- **MongoDB Change Stream-based adapter**
+- **Support for any MongoDB client** via the [`Driver`] abstraction
+- Built-in driver for the [mongodb](https://docs.rs/mongodb) crate: [`MongoDbDriver`](https://docs.rs/socketioxide-mongodb/latest/socketioxide_mongodb/drivers/mongodb/struct.MongoDbDriver.html)
+- **Message expiration** via:
   - **Capped collections**
   - **TTL indexes**
-- 🧵 Fully compatible with the asynchronous Rust ecosystem
-- 🛠️ Implement your own custom driver by implementing the `Driver` trait
+- Fully compatible with the asynchronous Rust ecosystem
+- Implement your own custom driver by implementing the `Driver` trait
 
 > [!WARNING]
 > Change streams require your MongoDB deployment to be a **replica set** or a **sharded cluster**.

--- a/crates/socketioxide-redis/CHANGELOG.md
+++ b/crates/socketioxide-redis/CHANGELOG.md
@@ -1,3 +1,8 @@
+# socketioxide-redis 0.3.0
+* deps: bump `redis` to 0.30.
+* deps: bump `socketioxide-core` to 0.17
+* MSRV: rust-version is now 1.86 with edition 2024
+
 # socketioxide-redis 0.2.1
 * doc: add an incompatibility warning with the `@socket.io/redis-adapter` package.
 

--- a/crates/socketioxide-redis/Cargo.toml
+++ b/crates/socketioxide-redis/Cargo.toml
@@ -39,7 +39,7 @@ fred = { version = "10", features = [
     "subscriber-client",
     "i-pubsub",
 ], default-features = false, optional = true }
-redis = { version = "0.30.0", features = [
+redis = { version = "0.30", features = [
     "aio",
     "tokio-comp",
     "streams",

--- a/crates/socketioxide/CHANGELOG.md
+++ b/crates/socketioxide/CHANGELOG.md
@@ -1,3 +1,10 @@
+# socketioxide 0.17.0
+* deps: bump `socketioxide-core` to 0.17
+* feat: add [`SocketIo::on_fallback`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIo.html#method.on_fallback)
+and [`Event`](https://docs.rs/socketioxide/latest/socketioxide/extract/struct.Event.html) extractor to add a fallback event handler and
+dynamically extract the incoming event.
+* MSRV: rust-version is now 1.86 with edition 2024
+
 # socketioxide 0.16.1
 * feat: add `Config::ws_read_buffer_size` to set the read buffer size for each websocket.
 * deps: bump `engineioxide` to 0.16.1.

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide"
 description = "Socket IO server implementation in rust as a Tower Service."
-version = "0.16.2"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -13,7 +13,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-engineioxide = { path = "../engineioxide", version = "0.16.2" }
+engineioxide = { path = "../engineioxide", version = "0.17" }
 socketioxide-core = { path = "../socketioxide-core", version = "0.17" }
 
 bytes.workspace = true
@@ -31,8 +31,8 @@ matchit.workspace = true
 pin-project-lite.workspace = true
 
 # Parsers
-socketioxide-parser-common = { path = "../parser-common", version = "0.16" }
-socketioxide-parser-msgpack = { path = "../parser-msgpack", version = "0.16", optional = true }
+socketioxide-parser-common = { path = "../parser-common", version = "0.17" }
+socketioxide-parser-msgpack = { path = "../parser-msgpack", version = "0.17", optional = true }
 
 # Tracing
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
# socketioxide 0.17.0
* deps: bump `socketioxide-core` to 0.17
* feat: add [`SocketIo::on_fallback`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIo.html#method.on_fallback)
and [`Event`](https://docs.rs/socketioxide/latest/socketioxide/extract/struct.Event.html) extractor to add a fallback event handler and
dynamically extract the incoming event.
* MSRV: rust-version is now 1.86 with edition 2024

# socketioxide-core 0.17.0
* feat(*breaking*): remote-adapter packets are now refactored in the core crate. Any adapter implementation can use
it through the `remote-adapter` flag.
* MSRV: rust-version is now 1.86 with edition 2024

# socketioxide-mongodb 0.1.0
* Initial release!

# socketioxide-redis 0.3.0
* deps: bump `redis` to 0.30.
* deps: bump `socketioxide-core` to 0.17
* MSRV: rust-version is now 1.86 with edition 2024

# socketioxide-parser-msgpack 0.17
* deps: bump `socketioxide-core` to 0.17
* MSRV: rust-version is now 1.86 with edition 2024

# socketioxide-parser-common 0.17
* deps: bump `socketioxide-core` to 0.17
* MSRV: rust-version is now 1.86 with edition 2024

# engineioxide 0.17
* MSRV: rust-version is now 1.86 with edition 2024

# engineioxide-core 0.2.0
* MSRV: rust-version is now 1.86 with edition 2024