### PR TITLE
feat(socketio): add utility methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "axum",
  "bytes",

--- a/crates/socketioxide/CHANGELOG.md
+++ b/crates/socketioxide/CHANGELOG.md
@@ -1,3 +1,8 @@
+# socketioxide 0.17.1
+* feat: add `SocketIo::nsps` to get a list of operators on all the current namespaces.
+* feat: add `BroadcastOperators::ns_path` to get the namespace path of the current namespace.
+* feat: implement `Debug + Clone` for `BroadcastOperators` to reuse it easily.
+
 # socketioxide 0.17.0
 * deps: bump `socketioxide-core` to 0.17
 * feat: add [`SocketIo::on_fallback`](https://docs.rs/socketioxide/latest/socketioxide/struct.SocketIo.html#method.on_fallback)

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide"
 description = "Socket IO server implementation in rust as a Tower Service."
-version = "0.17.0"
+version = "0.17.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/socketioxide/src/client.rs
+++ b/crates/socketioxide/src/client.rs
@@ -27,7 +27,7 @@ use crate::{
 
 pub struct Client<A: Adapter> {
     pub(crate) config: SocketIoConfig,
-    nsps: RwLock<HashMap<Str, Arc<Namespace<A>>>>,
+    pub(crate) nsps: RwLock<HashMap<Str, Arc<Namespace<A>>>>,
     router: RwLock<Router<NamespaceCtr<A>>>,
     adapter_state: A::State,
 

--- a/crates/socketioxide/src/io.rs
+++ b/crates/socketioxide/src/io.rs
@@ -414,6 +414,35 @@ impl<A: Adapter> SocketIo<A> {
         self.0.close().await;
     }
 
+    /// # Get all the namespaces to perform operations on.
+    ///
+    /// This will return a vector of [`BroadcastOperators`] for each namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use socketioxide::{SocketIo, extract::SocketRef};
+    /// let (_, io) = SocketIo::new_svc();
+    /// io.ns("/custom_ns", |socket: SocketRef| {
+    ///     println!("Socket connected on /custom_ns namespace with id: {}", socket.id);
+    /// });
+    ///
+    /// // Later in your code you can get all the namespaces
+    /// for ns in io.nsps() {
+    ///     assert_eq!(ns.name(), "/custom_ns");
+    /// }
+    /// ```
+    #[inline]
+    pub fn nsps(&self) -> Vec<BroadcastOperators<A>> {
+        let parser = self.0.parser();
+        self.0
+            .nsps
+            .read()
+            .unwrap()
+            .values()
+            .map(|ns| BroadcastOperators::new(ns.clone(), parser).broadcast())
+            .collect()
+    }
+
     // Chaining operators fns
 
     /// # Select a specific namespace to perform operations on.

--- a/crates/socketioxide/src/io.rs
+++ b/crates/socketioxide/src/io.rs
@@ -428,7 +428,7 @@ impl<A: Adapter> SocketIo<A> {
     ///
     /// // Later in your code you can get all the namespaces
     /// for ns in io.nsps() {
-    ///     assert_eq!(ns.name(), "/custom_ns");
+    ///     assert_eq!(ns.ns_path(), "/custom_ns");
     /// }
     /// ```
     #[inline]


### PR DESCRIPTION
* feat: add `SocketIo::nsps` to get a list of operators on all the current namespaces.
* feat: add `BroadcastOperators::ns_path` to get the namespace path of the current namespace.
* feat: implement `Debug + Clone` for `BroadcastOperators` to reuse it easily.
