### PR TITLE
feat(socketio): remove sync handlers

### DIFF
--- a/crates/socketioxide-mongodb/tests/broadcast.rs
+++ b/crates/socketioxide-mongodb/tests/broadcast.rs
@@ -88,7 +88,7 @@ pub async fn broadcast_with_ack() {
     let [io1, io2] = fixture::spawn_servers();
 
     io1.ns("/", handler).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let ((_tx1, mut rx1), (tx2, mut rx2)) =
         tokio::join!(io1.new_dummy_sock("/", ()), io2.new_dummy_sock("/", ()));
@@ -127,7 +127,7 @@ pub async fn broadcast_with_ack_timeout() {
     let [io1, io2] = fixture::spawn_buggy_servers(TIMEOUT);
 
     io1.ns("/", handler).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let now = std::time::Instant::now();
     let ((_tx1, mut rx1), (_tx2, mut rx2)) =

--- a/crates/socketioxide-mongodb/tests/local.rs
+++ b/crates/socketioxide-mongodb/tests/local.rs
@@ -14,8 +14,8 @@ macro_rules! assert_now {
 async fn test_local_fns() {
     let [io1, io2] = fixture::spawn_servers();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;

--- a/crates/socketioxide-mongodb/tests/rooms.rs
+++ b/crates/socketioxide-mongodb/tests/rooms.rs
@@ -7,7 +7,8 @@ mod fixture;
 #[tokio::test]
 pub async fn all_rooms() {
     let [io1, io2, io3] = fixture::spawn_servers();
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();
     io2.ns("/", handler(&["room2", "room3"])).await.unwrap();
@@ -39,7 +40,8 @@ pub async fn all_rooms() {
 pub async fn all_rooms_timeout() {
     const TIMEOUT: Duration = Duration::from_millis(50);
     let [io1, io2, io3] = fixture::spawn_buggy_servers(TIMEOUT);
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();
     io2.ns("/", handler(&["room2", "room3"])).await.unwrap();
@@ -71,7 +73,7 @@ pub async fn all_rooms_timeout() {
 }
 #[tokio::test]
 pub async fn add_sockets() {
-    let handler = |room: &'static str| move |socket: SocketRef<_>| socket.join(room);
+    let handler = |room: &'static str| async move |socket: SocketRef<_>| socket.join(room);
     let [io1, io2] = fixture::spawn_servers();
 
     io1.ns("/", handler("room1")).await.unwrap();
@@ -93,7 +95,8 @@ pub async fn add_sockets() {
 
 #[tokio::test]
 pub async fn del_sockets() {
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
     let [io1, io2] = fixture::spawn_servers();
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();

--- a/crates/socketioxide-mongodb/tests/sockets.rs
+++ b/crates/socketioxide-mongodb/tests/sockets.rs
@@ -49,9 +49,9 @@ fn create_expected_sockets<const N: usize, A: Adapter>(
 pub async fn fetch_sockets() {
     let [io1, io2, io3] = fixture::spawn_servers::<3>();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
-    io3.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
+    io3.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;
@@ -77,7 +77,8 @@ pub async fn fetch_sockets() {
 #[tokio::test]
 pub async fn fetch_sockets_with_rooms() {
     let [io1, io2, io3] = fixture::spawn_servers::<3>();
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();
     io2.ns("/", handler(&["room2", "room3"])).await.unwrap();
@@ -106,8 +107,8 @@ pub async fn fetch_sockets_timeout() {
     const TIMEOUT: Duration = Duration::from_millis(50);
     let [io1, io2] = fixture::spawn_buggy_servers(TIMEOUT);
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;
@@ -124,8 +125,8 @@ pub async fn fetch_sockets_timeout() {
 pub async fn remote_socket_emit() {
     let [io1, io2] = fixture::spawn_servers();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;
@@ -146,8 +147,8 @@ pub async fn remote_socket_emit() {
 pub async fn remote_socket_emit_with_ack() {
     let [io1, io2] = fixture::spawn_servers();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;

--- a/crates/socketioxide-redis/tests/broadcast.rs
+++ b/crates/socketioxide-redis/tests/broadcast.rs
@@ -88,7 +88,7 @@ pub async fn broadcast_with_ack() {
     let [io1, io2] = fixture::spawn_servers();
 
     io1.ns("/", handler).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let ((_tx1, mut rx1), (tx2, mut rx2)) =
         tokio::join!(io1.new_dummy_sock("/", ()), io2.new_dummy_sock("/", ()));
@@ -126,7 +126,7 @@ pub async fn broadcast_with_ack_timeout() {
     let [io1, io2] = fixture::spawn_buggy_servers(TIMEOUT);
 
     io1.ns("/", handler).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let now = std::time::Instant::now();
     let ((_tx1, mut rx1), (_tx2, mut rx2)) =

--- a/crates/socketioxide-redis/tests/local.rs
+++ b/crates/socketioxide-redis/tests/local.rs
@@ -14,8 +14,8 @@ macro_rules! assert_now {
 async fn test_local_fns() {
     let [io1, io2] = fixture::spawn_servers();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;

--- a/crates/socketioxide-redis/tests/rooms.rs
+++ b/crates/socketioxide-redis/tests/rooms.rs
@@ -7,7 +7,8 @@ mod fixture;
 #[tokio::test]
 pub async fn all_rooms() {
     let [io1, io2, io3] = fixture::spawn_servers();
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();
     io2.ns("/", handler(&["room2", "room3"])).await.unwrap();
@@ -39,7 +40,8 @@ pub async fn all_rooms() {
 pub async fn all_rooms_timeout() {
     const TIMEOUT: Duration = Duration::from_millis(50);
     let [io1, io2, io3] = fixture::spawn_buggy_servers(TIMEOUT);
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();
     io2.ns("/", handler(&["room2", "room3"])).await.unwrap();
@@ -70,7 +72,7 @@ pub async fn all_rooms_timeout() {
 }
 #[tokio::test]
 pub async fn add_sockets() {
-    let handler = |room: &'static str| move |socket: SocketRef<_>| socket.join(room);
+    let handler = |room: &'static str| async move |socket: SocketRef<_>| socket.join(room);
     let [io1, io2] = fixture::spawn_servers();
 
     io1.ns("/", handler("room1")).await.unwrap();
@@ -92,7 +94,8 @@ pub async fn add_sockets() {
 
 #[tokio::test]
 pub async fn del_sockets() {
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
     let [io1, io2] = fixture::spawn_servers();
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();

--- a/crates/socketioxide-redis/tests/sockets.rs
+++ b/crates/socketioxide-redis/tests/sockets.rs
@@ -49,9 +49,9 @@ fn create_expected_sockets<const N: usize, A: Adapter>(
 pub async fn fetch_sockets() {
     let [io1, io2, io3] = fixture::spawn_servers::<3>();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
-    io3.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
+    io3.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;
@@ -77,7 +77,8 @@ pub async fn fetch_sockets() {
 #[tokio::test]
 pub async fn fetch_sockets_with_rooms() {
     let [io1, io2, io3] = fixture::spawn_servers::<3>();
-    let handler = |rooms: &'static [&'static str]| move |socket: SocketRef<_>| socket.join(rooms);
+    let handler =
+        |rooms: &'static [&'static str]| async move |socket: SocketRef<_>| socket.join(rooms);
 
     io1.ns("/", handler(&["room1", "room2"])).await.unwrap();
     io2.ns("/", handler(&["room2", "room3"])).await.unwrap();
@@ -106,8 +107,8 @@ pub async fn fetch_sockets_timeout() {
     const TIMEOUT: Duration = Duration::from_millis(50);
     let [io1, io2] = fixture::spawn_buggy_servers(TIMEOUT);
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;
@@ -124,8 +125,8 @@ pub async fn fetch_sockets_timeout() {
 pub async fn remote_socket_emit() {
     let [io1, io2] = fixture::spawn_servers();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;
@@ -146,8 +147,8 @@ pub async fn remote_socket_emit() {
 pub async fn remote_socket_emit_with_ack() {
     let [io1, io2] = fixture::spawn_servers();
 
-    io1.ns("/", || ()).await.unwrap();
-    io2.ns("/", || ()).await.unwrap();
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
 
     let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
     let (_, mut rx2) = io2.new_dummy_sock("/", ()).await;

--- a/crates/socketioxide/docs/operators/broadcast.md
+++ b/crates/socketioxide/docs/operators/broadcast.md
@@ -15,5 +15,5 @@ async fn handler(io: SocketIo, socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/disconnect.md
+++ b/crates/socketioxide/docs/operators/disconnect.md
@@ -11,7 +11,7 @@ async fn handler(socket: SocketRef) {
     socket.within("room1").within("room3").except("room2").disconnect().await.unwrap();
 }
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```
 
 # Example from the io struct
@@ -22,5 +22,5 @@ async fn handler(socket: SocketRef, io: SocketIo) {
     io.within("room1").within("room3").except("room2").disconnect().await.unwrap();
 }
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/emit.md
+++ b/crates/socketioxide/docs/operators/emit.md
@@ -33,7 +33,7 @@ If you want to emit generic data that may contain binary, use [`rmpv::Value`] in
 # use socketioxide::{SocketIo, extract::*};
 # use serde_json::Value;
 # use std::sync::Arc;
-fn handler(socket: SocketRef, Data(data): Data::<Value>) {
+async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
     // Emit a test message to the client
     socket.emit("test", &data).ok();
     // Emit a test message with multiple arguments to the client
@@ -44,7 +44,7 @@ fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |socket: SocketRef| socket.on("test", handler));
+io.ns("/", async |socket: SocketRef| socket.on("test", handler));
 ```
 
 # Single-socket binary example with the `bytes` crate
@@ -53,7 +53,7 @@ io.ns("/", |socket: SocketRef| socket.on("test", handler));
 # use serde_json::Value;
 # use std::sync::Arc;
 # use bytes::Bytes;
-fn handler(socket: SocketRef, Data(data): Data::<(String, Bytes, Bytes)>) {
+async fn handler(socket: SocketRef, Data(data): Data::<(String, Bytes, Bytes)>) {
     // Emit a test message to the client
     socket.emit("test", &data).ok();
     // Emit a test message with multiple arguments to the client
@@ -64,7 +64,7 @@ fn handler(socket: SocketRef, Data(data): Data::<(String, Bytes, Bytes)>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |socket: SocketRef| socket.on("test", handler));
+io.ns("/", async |socket: SocketRef| socket.on("test", handler));
 ```
 
 # Broadcast example
@@ -90,5 +90,5 @@ async fn handler(socket: SocketRef, Data(data): Data::<(String, Bytes, Bytes)>) 
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/emit_with_ack.md
+++ b/crates/socketioxide/docs/operators/emit_with_ack.md
@@ -45,7 +45,7 @@ async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |socket: SocketRef| socket.on("test", handler));
+io.ns("/", async |socket: SocketRef| socket.on("test", handler));
 ```
 
 # Single-socket example with custom acknowledgment timeout
@@ -63,7 +63,7 @@ async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |socket: SocketRef| socket.on("test", handler));
+io.ns("/", async |socket: SocketRef| socket.on("test", handler));
 ```
 
 # Broadcast example
@@ -93,5 +93,5 @@ async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/except.md
+++ b/crates/socketioxide/docs/operators/except.md
@@ -11,9 +11,9 @@ async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |socket: SocketRef| {
-    socket.on("register1", |s: SocketRef| s.join("room1"));
-    socket.on("register2", |s: SocketRef| s.join("room2"));
+io.ns("/", async |socket: SocketRef| {
+    socket.on("register1", async |s: SocketRef| s.join("room1"));
+    socket.on("register2", async |s: SocketRef| s.join("room2"));
     socket.on("test", handler);
 });
 ```

--- a/crates/socketioxide/docs/operators/join.md
+++ b/crates/socketioxide/docs/operators/join.md
@@ -14,5 +14,5 @@ async fn handler(socket: SocketRef) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/leave.md
+++ b/crates/socketioxide/docs/operators/leave.md
@@ -12,5 +12,5 @@ async fn handler(socket: SocketRef) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/local.md
+++ b/crates/socketioxide/docs/operators/local.md
@@ -12,5 +12,5 @@ async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/sockets.md
+++ b/crates/socketioxide/docs/operators/sockets.md
@@ -18,5 +18,5 @@ async fn handler(socket: SocketRef) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/timeout.md
+++ b/crates/socketioxide/docs/operators/timeout.md
@@ -28,5 +28,5 @@ async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/to.md
+++ b/crates/socketioxide/docs/operators/to.md
@@ -27,5 +27,5 @@ async fn handler(socket: SocketRef, io: SocketIo, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/docs/operators/within.md
+++ b/crates/socketioxide/docs/operators/within.md
@@ -23,5 +23,5 @@ async fn handler(socket: SocketRef, Data(data): Data::<Value>) {
 }
 
 let (_, io) = SocketIo::new_svc();
-io.ns("/", |s: SocketRef| s.on("test", handler));
+io.ns("/", async |s: SocketRef| s.on("test", handler));
 ```

--- a/crates/socketioxide/src/client.rs
+++ b/crates/socketioxide/src/client.rs
@@ -440,14 +440,15 @@ mod test {
             Default::default(),
         );
         let client = Arc::new(client);
-        client.clone().add_ns("/".into(), || {});
+        client.clone().add_ns("/".into(), async || ());
         client
     }
 
     #[tokio::test]
     async fn get_ns() {
         let client = create_client();
-        let ns = Namespace::new(Str::from("/"), || {}, &client.adapter_state, &client.config);
+        let ns = Str::from("/");
+        let ns = Namespace::new(ns, async || (), &client.adapter_state, &client.config);
         client.nsps.write().unwrap().insert(Str::from("/"), ns);
         assert!(client.get_ns("/").is_some());
     }

--- a/crates/socketioxide/src/extract/mod.rs
+++ b/crates/socketioxide/src/extract/mod.rs
@@ -95,7 +95,7 @@
 //!     }
 //! }
 //!
-//! fn handler(user_id: UserId) {
+//! async fn handler(user_id: UserId) {
 //!     println!("User id: {}", user_id.0);
 //! }
 //! let (svc, io) = SocketIo::new_svc();

--- a/crates/socketioxide/src/extract/state.rs
+++ b/crates/socketioxide/src/extract/state.rs
@@ -31,7 +31,7 @@ use socketioxide_core::Value;
 ///     }
 /// }
 /// let (_, io) = SocketIo::builder().with_state(MyAppData::default()).build_svc();
-/// io.ns("/", |socket: SocketRef, state: State<MyAppData>| {
+/// io.ns("/", async |socket: SocketRef, state: State<MyAppData>| {
 ///     state.add_user();
 ///     println!("User count: {}", state.user_cnt.load(Ordering::SeqCst));
 /// });

--- a/crates/socketioxide/src/handler/connect.rs
+++ b/crates/socketioxide/src/handler/connect.rs
@@ -4,7 +4,7 @@
 //! You can also implement the [`FromConnectParts`] trait for your own types.
 //! See the [`extract`](crate::extract) module doc for more details on available extractors.
 //!
-//! Handlers can be _optionally_ async.
+//! Handlers _must_ be async.
 //!
 //! # Middlewares
 //! [`ConnectHandlers`](ConnectHandler) can have middlewares, they are called before the connection
@@ -18,22 +18,9 @@
 //! Middlewares can be sync or async and can be chained.
 //! They are defined with the [`ConnectMiddleware`] trait which is automatically implemented for any
 //! closure with up to 16 arguments with the following signature:
-//! * `FnOnce(*args) -> Result<(), E> where E: Display`
 //! * `async FnOnce(*args) -> Result<(), E> where E: Display`
 //!
 //! Arguments must implement the [`FromConnectParts`] trait in the exact same way than handlers.
-//!
-//! ## Example with sync closures
-//! ```rust
-//! # use socketioxide::SocketIo;
-//! # use socketioxide::extract::*;
-//! let (svc, io) = SocketIo::new_svc();
-//! // Here the handler is sync,
-//! // if there is a serialization error, the handler is not called
-//! io.ns("/nsp", move |io: SocketIo, s: SocketRef, Data(auth): Data<String>| {
-//!     println!("Socket connected on /nsp namespace with id: {} and data: {}", s.id, auth);
-//! });
-//! ```
 //!
 //! ## Example with async closures
 //! ```rust
@@ -73,7 +60,7 @@
 //! # use socketioxide::handler::ConnectHandler;
 //! # use socketioxide::extract::*;
 //! # use socketioxide::SocketIo;
-//! fn handler(s: SocketRef) {
+//! async fn handler(s: SocketRef) {
 //!     println!("socket connected on / namespace with id: {}", s.id);
 //! }
 //!
@@ -86,7 +73,7 @@
 //! }
 //! impl std::error::Error for AuthError {}
 //!
-//! fn middleware(s: SocketRef, Data(token): Data<String>) -> Result<(), AuthError> {
+//! async fn middleware(s: SocketRef, Data(token): Data<String>) -> Result<(), AuthError> {
 //!     println!("second middleware called");
 //!     if token != "secret" {
 //!         Err(AuthError)
@@ -95,7 +82,6 @@
 //!     }
 //! }
 //!
-//! // Middlewares can be sync or async
 //! async fn other_middleware(s: SocketRef) -> Result<(), AuthError> {
 //!     println!("first middleware called");
 //!     if s.req_parts().uri.query().map(|q| q.contains("secret")).unwrap_or_default() {
@@ -164,7 +150,7 @@ pub trait FromConnectParts<A: Adapter>: Sized {
 /// * See the [`extract`](crate::extract) module doc for more details on available extractors.
 #[diagnostic::on_unimplemented(
     note = "This function is not a ConnectMiddleware. Check that:
-* It is a clonable sync or async `FnOnce` that returns `Result<(), E> where E: Display`.
+* It is a clonable async `FnOnce` that returns `Result<(), E> where E: Display`.
 * All its arguments are valid connect extractors.
 * If you use a custom adapter, it must be generic over the adapter type.
 See `https://docs.rs/socketioxide/latest/socketioxide/extract/index.html` for details.\n",
@@ -191,7 +177,7 @@ pub trait ConnectMiddleware<A: Adapter, T>: Sized + Clone + Send + Sync + 'stati
 /// * See the [`extract`](crate::extract) module doc for more details on available extractors.
 #[diagnostic::on_unimplemented(
     note = "This function is not a ConnectHandler. Check that:
-* It is a clonable sync or async `FnOnce` that returns nothing.
+* It is a clonable async `FnOnce` that returns nothing.
 * All its arguments are valid connect extractors.
 * If you use a custom adapter, it must be generic over the adapter type.
 See `https://docs.rs/socketioxide/latest/socketioxide/extract/index.html` for details.\n",
@@ -219,7 +205,7 @@ pub trait ConnectHandler<A: Adapter, T>: Sized + Clone + Send + Sync + 'static {
     /// # use socketioxide::handler::ConnectHandler;
     /// # use socketioxide::extract::*;
     /// # use socketioxide::SocketIo;
-    /// fn handler(s: SocketRef) {
+    /// async fn handler(s: SocketRef) {
     ///     println!("socket connected on / namespace with id: {}", s.id);
     /// }
     ///
@@ -232,7 +218,7 @@ pub trait ConnectHandler<A: Adapter, T>: Sized + Clone + Send + Sync + 'static {
     /// }
     /// impl std::error::Error for AuthError {}
     ///
-    /// fn middleware(s: SocketRef, Data(token): Data<String>) -> Result<(), AuthError> {
+    /// async fn middleware(s: SocketRef, Data(token): Data<String>) -> Result<(), AuthError> {
     ///     println!("second middleware called");
     ///     if token != "secret" {
     ///         Err(AuthError)
@@ -241,7 +227,6 @@ pub trait ConnectHandler<A: Adapter, T>: Sized + Clone + Send + Sync + 'static {
     ///     }
     /// }
     ///
-    /// // Middlewares can be sync or async
     /// async fn other_middleware(s: SocketRef) -> Result<(), AuthError> {
     ///     println!("first middleware called");
     ///     if s.req_parts().uri.query().map(|q| q.contains("secret")).unwrap_or_default() {
@@ -408,20 +393,13 @@ where
     }
 }
 
-mod private {
-    #[derive(Debug, Copy, Clone)]
-    pub enum Sync {}
-    #[derive(Debug, Copy, Clone)]
-    pub enum Async {}
-}
-
 macro_rules! impl_handler_async {
     (
         [$($ty:ident),*]
     ) => {
         #[allow(non_snake_case, unused)]
         #[diagnostic::do_not_recommend]
-        impl<A, F, Fut, $($ty,)*> ConnectHandler<A, (private::Async, $($ty,)*)> for F
+        impl<A, F, Fut, $($ty,)*> ConnectHandler<A, ($($ty,)*)> for F
         where
             F: FnOnce($($ty,)*) -> Fut + Send + Sync + Clone + 'static,
             Fut: Future<Output = ()> + Send + 'static,
@@ -442,37 +420,6 @@ macro_rules! impl_handler_async {
 
                 let fut = (self.clone())($($ty,)*);
                 tokio::spawn(fut);
-
-            }
-        }
-    };
-}
-
-macro_rules! impl_handler {
-    (
-        [$($ty:ident),*]
-    ) => {
-        #[allow(non_snake_case, unused)]
-        #[diagnostic::do_not_recommend]
-        impl<A, F, $($ty,)*> ConnectHandler<A, (private::Sync, $($ty,)*)> for F
-        where
-            F: FnOnce($($ty,)*) + Send + Sync + Clone + 'static,
-            A: Adapter,
-            $( $ty: FromConnectParts<A> + Send, )*
-        {
-            fn call(&self, s: Arc<Socket<A>>, auth: Option<Value>) {
-                $(
-                    let $ty = match $ty::from_connect_parts(&s, &auth) {
-                        Ok(v) => v,
-                        Err(_e) => {
-                            #[cfg(feature = "tracing")]
-                            tracing::error!("Error while extracting data: {}", _e);
-                            return;
-                        },
-                    };
-                )*
-
-                (self.clone())($($ty,)*);
             }
         }
     };
@@ -484,7 +431,7 @@ macro_rules! impl_middleware_async {
     ) => {
         #[allow(non_snake_case, unused)]
         #[diagnostic::do_not_recommend]
-        impl<A, F, Fut, E, $($ty,)*> ConnectMiddleware<A, (private::Async, $($ty,)*)> for F
+        impl<A, F, Fut, E, $($ty,)*> ConnectMiddleware<A, ($($ty,)*)> for F
         where
             F: FnOnce($($ty,)*) -> Fut + Send + Sync + Clone + 'static,
             Fut: Future<Output = Result<(), E>> + Send + 'static,
@@ -521,48 +468,6 @@ macro_rules! impl_middleware_async {
     };
 }
 
-macro_rules! impl_middleware {
-    (
-        [$($ty:ident),*]
-    ) => {
-        #[allow(non_snake_case, unused)]
-        #[diagnostic::do_not_recommend]
-        impl<A, F, E, $($ty,)*> ConnectMiddleware<A, (private::Sync, $($ty,)*)> for F
-        where
-            F: FnOnce($($ty,)*) -> Result<(), E> + Send + Sync + Clone + 'static,
-            A: Adapter,
-            E: std::fmt::Display + Send + 'static,
-            $( $ty: FromConnectParts<A> + Send, )*
-        {
-            async fn call<'a>(
-                &'a self,
-                s: Arc<Socket<A>>,
-                auth: &'a Option<Value>,
-            ) -> MiddlewareRes {
-                $(
-                    let $ty = match $ty::from_connect_parts(&s, auth) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            #[cfg(feature = "tracing")]
-                            tracing::error!("Error while extracting data: {}", e);
-                            return Err(Box::new(e) as _);
-                        },
-                    };
-                )*
-
-                let res = (self.clone())($($ty,)*);
-                if let Err(e) = res {
-                    #[cfg(feature = "tracing")]
-                    tracing::trace!("middleware returned error: {}", e);
-                    Err(Box::new(e) as _)
-                } else {
-                    Ok(())
-                }
-            }
-        }
-    };
-}
-
 #[rustfmt::skip]
 macro_rules! all_the_tuples {
     ($name:ident) => {
@@ -587,7 +492,4 @@ macro_rules! all_the_tuples {
 }
 
 all_the_tuples!(impl_handler_async);
-all_the_tuples!(impl_handler);
-
 all_the_tuples!(impl_middleware_async);
-all_the_tuples!(impl_middleware);

--- a/crates/socketioxide/src/lib.rs
+++ b/crates/socketioxide/src/lib.rs
@@ -94,15 +94,15 @@
 //!     let (layer, io) = SocketIo::new_layer();
 //!
 //!     // Register a handler for the default namespace
-//!     io.ns("/", |s: SocketRef| {
+//!     io.ns("/", async |s: SocketRef| {
 //!         // For each "message" event received, send a "message-back" event with the "Hello World!" event
-//!         s.on("message", |s: SocketRef| {
+//!         s.on("message", async |s: SocketRef| {
 //!             s.emit("message-back", "Hello World!").ok();
 //!         });
 //!     });
 //!
 //!     let app = axum::Router::new()
-//!     .route("/", get(|| async { "Hello, World!" }))
+//!     .route("/", get(async || "Hello, World!"))
 //!     .layer(layer);
 //!
 //!     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
@@ -317,14 +317,14 @@
 //! #### Write this:
 //! ```
 //! # use socketioxide::{SocketIo, adapter::Adapter, extract::SocketRef};
-//! fn my_handler<A: Adapter>(s: SocketRef<A>, io: SocketIo<A>) { }
+//! async fn my_handler<A: Adapter>(s: SocketRef<A>, io: SocketIo<A>) { }
 //! let (layer, io) = SocketIo::new_layer();
 //! io.ns("/", my_handler);
 //! ```
 //! #### Instead of that:
 //! ```
 //! # use socketioxide::{SocketIo, adapter::Adapter, extract::SocketRef};
-//! fn my_handler(s: SocketRef, io: SocketIo) { }
+//! async fn my_handler(s: SocketRef, io: SocketIo) { }
 //! let (layer, io) = SocketIo::new_layer();
 //! io.ns("/", my_handler);
 //! ```

--- a/crates/socketioxide/src/ns.rs
+++ b/crates/socketioxide/src/ns.rs
@@ -381,7 +381,7 @@ impl SocketEmitter for Emitter {
 #[cfg(feature = "__test_harness")]
 impl Namespace<crate::adapter::LocalAdapter> {
     pub fn new_dummy<const S: usize>(sockets: [Sid; S]) -> Arc<Self> {
-        let ns = Namespace::new("/".into(), || {}, &(), &SocketIoConfig::default());
+        let ns = Namespace::new("/".into(), async || (), &(), &SocketIoConfig::default());
         for sid in sockets {
             ns.sockets
                 .write()

--- a/crates/socketioxide/src/socket.rs
+++ b/crates/socketioxide/src/socket.rs
@@ -334,7 +334,7 @@ impl<A: Adapter> Socket<A> {
     ///
     /// _It is recommended for code clarity to define your handler as top level function rather than closures._
     ///
-    /// # Simple example with a sync closure and a sync fn:
+    /// # Simple example with an async closure and an async fn:
     /// ```
     /// # use socketioxide::{SocketIo, extract::*};
     /// # use serde::{Serialize, Deserialize};
@@ -343,21 +343,21 @@ impl<A: Adapter> Socket<A> {
     ///     name: String,
     ///     age: u8,
     /// }
-    /// fn handler(socket: SocketRef, Data(data): Data::<MyData>) {
+    /// async fn handler(socket: SocketRef, Data(data): Data::<MyData>) {
     ///     println!("Received a test message {:?}", data);
     ///     socket.emit("test-test", &MyData { name: "Test".to_string(), age: 8 }).ok(); // Emit a message to the client
     /// }
     ///
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |socket: SocketRef| {
+    /// io.ns("/", async |socket: SocketRef| {
     ///     // Register a handler for the "test" event and extract the data as a `MyData` struct
     ///     // With the Data extractor, the handler is called only if the data can be deserialized as a `MyData` struct
     ///     // If you want to manage errors yourself you can use the TryData extractor
-    ///     socket.on("test", |socket: SocketRef, Data::<MyData>(data)| {
+    ///     socket.on("test", async |socket: SocketRef, Data::<MyData>(data)| {
     ///         println!("Received a test message {:?}", data);
     ///         socket.emit("test-test", &MyData { name: "Test".to_string(), age: 8 }).ok(); // Emit a message to the client
     ///     });
-    ///     // Do the same thing but with a sync function
+    ///     // Do the same thing but with an async function
     ///     socket.on("test_2", handler);
     /// });
     ///
@@ -381,7 +381,7 @@ impl<A: Adapter> Socket<A> {
     /// }
     ///
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |socket: SocketRef| {
+    /// io.ns("/", async |socket: SocketRef| {
     ///     // Register an async handler for the "test" event and extract the data as a `MyData` struct
     ///     // Extract the binary payload as a `Vec<Bytes>` with the Bin extractor.
     ///     // It should be the last extractor because it consumes the request
@@ -419,12 +419,12 @@ impl<A: Adapter> Socket<A> {
     /// # use socketioxide::{SocketIo, extract::*};
     /// # use serde::{Serialize, Deserialize};
     /// # use serde_json::Value;
-    /// fn fallback_handler(socket: SocketRef, Event(event): Event, Data(data): Data::<Value>) {
+    /// async fn fallback_handler(socket: SocketRef, Event(event): Event, Data(data): Data::<Value>) {
     ///     println!("Received an {event} event with message {:?}", data);
     /// }
     ///
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |socket: SocketRef| {
+    /// io.ns("/", async |socket: SocketRef| {
     ///     // Register a fallback handler.
     ///     // In our example it will be always called as there is no other handler.
     ///     socket.on_fallback(fallback_handler);
@@ -459,7 +459,7 @@ impl<A: Adapter> Socket<A> {
     /// # use serde_json::Value;
     /// # use std::sync::Arc;
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |socket: SocketRef| {
+    /// io.ns("/", async |socket: SocketRef| {
     ///     socket.on("test", async |socket: SocketRef| {
     ///         // Close the current socket
     ///         socket.disconnect().ok();
@@ -543,7 +543,7 @@ impl<A: Adapter> Socket<A> {
     /// }
     ///
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |s: SocketRef| s.on("test", handler));
+    /// io.ns("/", async |s: SocketRef| s.on("test", handler));
     /// ```
     pub fn join(&self, rooms: impl RoomParam) {
         self.ns.adapter.get_local().add_all(self.id, rooms)
@@ -560,7 +560,7 @@ impl<A: Adapter> Socket<A> {
     /// }
     ///
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |s: SocketRef| s.on("test", handler));
+    /// io.ns("/", async |s: SocketRef| s.on("test", handler));
     /// ```
     pub fn leave(&self, rooms: impl RoomParam) {
         self.ns.adapter.get_local().del(self.id, rooms)
@@ -671,7 +671,7 @@ impl<A: Adapter> Socket<A> {
     /// # use socketioxide::{SocketIo, TransportType, extract::*};
     ///
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |socket: SocketRef, transport: TransportType| {
+    /// io.ns("/", async |socket: SocketRef, transport: TransportType| {
     ///     assert_eq!(socket.transport_type(), transport);
     /// });
     pub fn transport_type(&self) -> crate::TransportType {
@@ -686,7 +686,7 @@ impl<A: Adapter> Socket<A> {
     /// # use socketioxide::{SocketIo, ProtocolVersion, extract::*};
     ///
     /// let (_, io) = SocketIo::new_svc();
-    /// io.ns("/", |socket: SocketRef, v: ProtocolVersion| {
+    /// io.ns("/", async |socket: SocketRef, v: ProtocolVersion| {
     ///     assert_eq!(socket.protocol(), v);
     /// });
     pub fn protocol(&self) -> crate::ProtocolVersion {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "engineioxide"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "engineioxide-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2161,11 +2161,10 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438a4e5f8e9aa246d6f3666d6978441bf1b37d5f417b50c4dd220be09f5fcc17"
+checksum = "0bc1ea653e0b2e097db3ebb5b7f678be339620b8041f66b30a308c1d45d36a7f"
 dependencies = [
- "arc-swap",
  "bytes",
  "cfg-if",
  "combine",
@@ -2964,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide"
-version = "0.16.2"
+version = "0.17.1"
 dependencies = [
  "bytes",
  "engineioxide",
@@ -2989,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-core"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3020,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-parser-common"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3031,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-parser-msgpack"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "rmp",
@@ -3042,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "socketioxide-redis"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "fred",
@@ -3315,9 +3314,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",

--- a/examples/angular-todomvc/src/main.rs
+++ b/examples/angular-todomvc/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_state(Todos::default())
         .build_layer();
 
-    io.ns("/", |s: SocketRef, State(Todos(todos))| {
+    io.ns("/", async |s: SocketRef, State(Todos(todos))| {
         info!("New connection: {}", s.id);
 
         let todos = todos.lock().unwrap().clone();

--- a/examples/axum-echo-tls/axum_echo-tls.rs
+++ b/examples/axum-echo-tls/axum_echo-tls.rs
@@ -10,19 +10,22 @@ use socketioxide::{
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+async fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
     info!(ns = socket.ns(), ?socket.id, "Socket.IO connected");
     socket.emit("auth", &data).ok();
 
-    socket.on("message", |socket: SocketRef, Data::<Value>(data)| {
+    socket.on("message", async |socket: SocketRef, Data::<Value>(data)| {
         info!(?data, "Received event");
         socket.emit("message-back", &data).ok();
     });
 
-    socket.on("message-with-ack", |Data::<Value>(data), ack: AckSender| {
-        info!(?data, "Received event");
-        ack.send(&data).ok();
-    });
+    socket.on(
+        "message-with-ack",
+        async |Data::<Value>(data), ack: AckSender| {
+            info!(?data, "Received event");
+            ack.send(&data).ok();
+        },
+    );
 }
 
 #[tokio::main]

--- a/examples/axum-echo/axum_echo.rs
+++ b/examples/axum-echo/axum_echo.rs
@@ -7,19 +7,22 @@ use socketioxide::{
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+async fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
     info!(ns = socket.ns(), ?socket.id, "Socket.IO connected");
     socket.emit("auth", &data).ok();
 
-    socket.on("message", |socket: SocketRef, Data::<Value>(data)| {
+    socket.on("message", async |socket: SocketRef, Data::<Value>(data)| {
         info!(?data, "Received event:");
         socket.emit("message-back", &data).ok();
     });
 
-    socket.on("message-with-ack", |Data::<Value>(data), ack: AckSender| {
-        info!(?data, "Received event");
-        ack.send(&data).ok();
-    });
+    socket.on(
+        "message-with-ack",
+        async |Data::<Value>(data), ack: AckSender| {
+            info!(?data, "Received event");
+            ack.send(&data).ok();
+        },
+    );
 }
 
 #[tokio::main]

--- a/examples/background-task/src/main.rs
+++ b/examples/background-task/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (layer, io) = SocketIo::new_layer();
 
-    io.ns("/", |s: SocketRef, Data::<Value>(data)| {
+    io.ns("/", async |s: SocketRef, Data::<Value>(data)| {
         info!("Received: {:?}", data);
         s.emit("welcome", &data).ok();
     });

--- a/examples/basic-crud-application/src/main.rs
+++ b/examples/basic-crud-application/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_state(Todos::default())
         .build_layer();
 
-    io.ns("/", |s: SocketRef| {
+    io.ns("/", async |s: SocketRef| {
         s.on("todo:create", handlers::todo::create);
         s.on("todo:read", handlers::todo::read);
         s.on("todo:update", handlers::todo::update);

--- a/examples/hyper-echo/hyper_echo.rs
+++ b/examples/hyper-echo/hyper_echo.rs
@@ -11,19 +11,22 @@ use tokio::net::TcpListener;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+async fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
     info!(ns = socket.ns(), ?socket.id, "Socket.IO connected");
     socket.emit("auth", &data).ok();
 
-    socket.on("message", |socket: SocketRef, Data::<Value>(data)| {
+    socket.on("message", async |socket: SocketRef, Data::<Value>(data)| {
         info!(?data, "Received event");
         socket.emit("message-back", &data).ok();
     });
 
-    socket.on("message-with-ack", |Data::<Value>(data), ack: AckSender| {
-        info!(?data, "Received event");
-        ack.send(&data).ok();
-    });
+    socket.on(
+        "message-with-ack",
+        async |Data::<Value>(data), ack: AckSender| {
+            info!(?data, "Received event");
+            ack.send(&data).ok();
+        },
+    );
 }
 
 #[tokio::main]

--- a/examples/mongodb-whiteboard/src/mongodb.rs
+++ b/examples/mongodb-whiteboard/src/mongodb.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     async fn on_drawing<A: Adapter>(s: SocketRef<A>, Data(data): Data<Value>) {
         s.broadcast().emit("drawing", &data).await.ok();
     }
-    fn on_connect<A: Adapter>(s: SocketRef<A>) {
+    async fn on_connect<A: Adapter>(s: SocketRef<A>) {
         s.on("drawing", on_drawing);
     }
     io.ns("/", on_connect).await?;

--- a/examples/mongodb-whiteboard/src/mongodb_capped.rs
+++ b/examples/mongodb-whiteboard/src/mongodb_capped.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     async fn on_drawing<A: Adapter>(s: SocketRef<A>, Data(data): Data<Value>) {
         s.broadcast().emit("drawing", &data).await.ok();
     }
-    fn on_connect<A: Adapter>(s: SocketRef<A>) {
+    async fn on_connect<A: Adapter>(s: SocketRef<A>) {
         s.on("drawing", on_drawing);
     }
     io.ns("/", on_connect).await?;

--- a/examples/redis-whiteboard/src/fred.rs
+++ b/examples/redis-whiteboard/src/fred.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     async fn on_drawing<A: Adapter>(s: SocketRef<A>, Data(data): Data<Value>) {
         s.broadcast().emit("drawing", &data).await.ok();
     }
-    fn on_connect<A: Adapter>(s: SocketRef<A>) {
+    async fn on_connect<A: Adapter>(s: SocketRef<A>) {
         s.on("drawing", on_drawing);
     }
     io.ns("/", on_connect).await?;

--- a/examples/redis-whiteboard/src/redis.rs
+++ b/examples/redis-whiteboard/src/redis.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     async fn on_drawing<A: Adapter>(s: SocketRef<A>, Data(data): Data<Value>) {
         s.broadcast().emit("drawing", &data).await.ok();
     }
-    fn on_connect<A: Adapter>(s: SocketRef<A>) {
+    async fn on_connect<A: Adapter>(s: SocketRef<A>) {
         s.on("drawing", on_drawing);
     }
     io.ns("/", on_connect).await?;

--- a/examples/redis-whiteboard/src/redis_cluster.rs
+++ b/examples/redis-whiteboard/src/redis_cluster.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     async fn on_drawing<A: Adapter>(s: SocketRef<A>, Data(data): Data<Value>) {
         s.broadcast().emit("drawing", &data).await.ok();
     }
-    fn on_connect<A: Adapter>(s: SocketRef<A>) {
+    async fn on_connect<A: Adapter>(s: SocketRef<A>) {
         s.on("drawing", on_drawing);
     }
     io.ns("/", on_connect).await?;

--- a/examples/salvo-echo/salvo_echo.rs
+++ b/examples/salvo-echo/salvo_echo.rs
@@ -10,19 +10,22 @@ use tower_http::cors::CorsLayer;
 use tracing::info;
 use tracing_subscriber::FmtSubscriber;
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+async fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
     info!(ns = socket.ns(), ?socket.id, "Socket.IO connected");
     socket.emit("auth", &data).ok();
 
-    socket.on("message", |socket: SocketRef, Data::<Value>(data)| {
+    socket.on("message", async |socket: SocketRef, Data::<Value>(data)| {
         info!(?data, "Received event");
         socket.emit("message-back", &data).ok();
     });
 
-    socket.on("message-with-ack", |Data::<Value>(data), ack: AckSender| {
-        info!(?data, "Received event");
-        ack.send(&data).ok();
-    });
+    socket.on(
+        "message-with-ack",
+        async |Data::<Value>(data), ack: AckSender| {
+            info!(?data, "Received event");
+            ack.send(&data).ok();
+        },
+    );
 }
 
 #[handler]

--- a/examples/viz-echo/viz_echo.rs
+++ b/examples/viz-echo/viz_echo.rs
@@ -7,19 +7,22 @@ use tracing::{error, info};
 use tracing_subscriber::FmtSubscriber;
 use viz::{handler::ServiceHandler, serve, Result, Router};
 
-fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
+async fn on_connect(socket: SocketRef, Data(data): Data<Value>) {
     info!(ns = socket.ns(), ?socket.id, "Socket.IO connected");
     socket.emit("auth", &data).ok();
 
-    socket.on("message", |socket: SocketRef, Data::<Value>(data)| {
+    socket.on("message", async |socket: SocketRef, Data::<Value>(data)| {
         info!(?data, "Received event");
         socket.emit("message-back", &data).ok();
     });
 
-    socket.on("message-with-ack", |Data::<Value>(data), ack: AckSender| {
-        info!(?data, "Received event");
-        ack.send(&data).ok();
-    });
+    socket.on(
+        "message-with-ack",
+        async |Data::<Value>(data), ack: AckSender| {
+            info!(?data, "Received event");
+            ack.send(&data).ok();
+        },
+    );
 }
 
 #[tokio::main]

--- a/examples/webrtc-node-app/src/main.rs
+++ b/examples/webrtc-node-app/src/main.rs
@@ -34,27 +34,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_parser(ParserConfig::msgpack())
         .build_layer();
 
-    io.ns("/", |s: SocketRef| {
-        s.on(
-            "join",
-            async |s: SocketRef, Data(room_id): Data<String>| {
-                let socket_cnt = s.within(room_id.clone()).sockets().len();
-                if socket_cnt == 0 {
-                    tracing::info!(
-                        "creating room {room_id} and emitting room_created socket event"
-                    );
-                    s.join(room_id.clone());
-                    s.emit("room_created", &room_id).unwrap();
-                } else if socket_cnt == 1 {
-                    tracing::info!("joining room {room_id} and emitting room_joined socket event");
-                    s.join(room_id.clone());
-                    s.emit("room_joined", &room_id).unwrap();
-                } else {
-                    tracing::info!("Can't join room {room_id}, emitting full_room socket event");
-                    s.emit("full_room", &room_id).ok();
-                }
-            },
-        );
+    io.ns("/", async |s: SocketRef| {
+        s.on("join", async |s: SocketRef, Data(room_id): Data<String>| {
+            let socket_cnt = s.within(room_id.clone()).sockets().len();
+            if socket_cnt == 0 {
+                tracing::info!("creating room {room_id} and emitting room_created socket event");
+                s.join(room_id.clone());
+                s.emit("room_created", &room_id).unwrap();
+            } else if socket_cnt == 1 {
+                tracing::info!("joining room {room_id} and emitting room_joined socket event");
+                s.join(room_id.clone());
+                s.emit("room_joined", &room_id).unwrap();
+            } else {
+                tracing::info!("Can't join room {room_id}, emitting full_room socket event");
+                s.emit("full_room", &room_id).ok();
+            }
+        });
 
         s.on(
             "start_call",

--- a/examples/whiteboard/src/main.rs
+++ b/examples/whiteboard/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_parser(ParserConfig::msgpack())
         .build_layer();
 
-    io.ns("/", |s: SocketRef| {
+    io.ns("/", async |s: SocketRef| {
         s.on("drawing", async |s: SocketRef, Data::<Value>(data)| {
             s.broadcast().emit("drawing", &data).await.unwrap();
         });


### PR DESCRIPTION
## Motivation
Until now it was possible to specify either `sync` or `async` connect/message/disconnect handlers. It is kind of nice but there are two issues with this:
* Handlers cost a lot at compile times (it's the majority of the compilation cost of socketioxide).
* I see that many users don't get that they can have async handlers and respawn a new task in the handlers.
 
## Solution
Completely remove the sync handlers, forcing everyone to use the async versions. This reduce the cold build time by approximately 45%.

With `cargo build --timings --all-features -r` on the whiteboard example:

![image](https://github.com/user-attachments/assets/2c455902-906e-4182-ad32-8abeb5d4c4b3)
Vs
![image](https://github.com/user-attachments/assets/8aedb907-9b0c-44a8-85ee-1c0879bd7769)
