### PR TITLE
fix(engineio/v3): incorrect `NOOP` packet formating when upgrading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "engineioxide"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/crates/engineioxide/src/transport/polling/payload/mod.rs
+++ b/crates/engineioxide/src/transport/polling/payload/mod.rs
@@ -98,7 +98,7 @@ pub fn packet_encoder(
     {
         match protocol {
             ProtocolVersion::V4 => packet.into(),
-            ProtocolVersion::V3 if supports_binary => {
+            ProtocolVersion::V3 if supports_binary && packet.is_binary() => {
                 use bytes::BytesMut;
 
                 let size_hint = packet.get_size_hint(!supports_binary) + 2;

--- a/e2e/socketioxide/test-suites/v4.ts
+++ b/e2e/socketioxide/test-suites/v4.ts
@@ -155,7 +155,7 @@ describe("Engine.IO protocol", () => {
           `${WS_URL}/socket.io/?transport=websocket`,
         );
 
-        socket.on("error", () => {});
+        socket.on("error", () => { });
 
         waitForEvent(socket, "close");
 
@@ -163,7 +163,7 @@ describe("Engine.IO protocol", () => {
           `${WS_URL}/socket.io/?EIO=abc&transport=websocket`,
         );
 
-        socket2.on("error", () => {});
+        socket2.on("error", () => { });
 
         waitForEvent(socket2, "close");
       });
@@ -171,7 +171,7 @@ describe("Engine.IO protocol", () => {
       it("should fail with an invalid 'transport' query parameter", async () => {
         const socket = new WebSocketStream(`${WS_URL}/socket.io/?EIO=3`);
 
-        socket.on("error", () => {});
+        socket.on("error", () => { });
 
         waitForEvent(socket, "close");
 
@@ -179,7 +179,7 @@ describe("Engine.IO protocol", () => {
           `${WS_URL}/socket.io/?EIO=3&transport=abc`,
         );
 
-        socket2.on("error", () => {});
+        socket2.on("error", () => { });
         waitForEvent(socket2, "close");
       });
     });
@@ -326,6 +326,36 @@ describe("Engine.IO protocol", () => {
       // complete upgrade
       socket.send("5");
     });
+
+
+    it("should NOOP all polling requests while upgrading", async () => {
+      const sid = await initLongPollingSession();
+
+      const res = await fetch(`${POLLING_URL}/socket.io/?EIO=3&transport=polling&sid=${sid}`, {
+        method: "POST",
+        body: "1:2"
+      });
+      assert.deepStrictEqual(res.status, 200);
+      assert.deepStrictEqual(await res.text(), "ok");
+
+      const socket = new WebSocketStream(
+        `${WS_URL}/socket.io/?EIO=3&transport=websocket&sid=${sid}`,
+      );
+      await waitForEvent(socket, "open");
+      for (let i = 0; i < 5; i++) {
+        const res = await fetch(`${POLLING_URL}/socket.io/?EIO=3&transport=polling&sid=${sid}`);
+        assert.deepStrictEqual(res.status, 200);
+        const body = await res.text();
+        assert.deepStrictEqual(body, "1:6");
+      }
+
+      socket.send("2probe");
+      socket.send("5");
+
+      await waitForMessage(socket); // 3
+      await waitForMessage(socket); // 3probe
+    });
+
 
     it("should ignore HTTP requests with same sid after upgrade", async () => {
       const sid = await initLongPollingSession();

--- a/e2e/socketioxide/test-suites/v5.ts
+++ b/e2e/socketioxide/test-suites/v5.ts
@@ -157,14 +157,14 @@ describe("Engine.IO protocol", () => {
           `${WS_URL}/socket.io/?transport=websocket`,
         );
 
-        socket.on("error", () => {});
+        socket.on("error", () => { });
         waitForEvent(socket, "close");
 
         const socket2 = new WebSocketStream(
           `${WS_URL}/socket.io/?EIO=abc&transport=websocket`,
         );
 
-        socket2.on("error", () => {});
+        socket2.on("error", () => { });
 
         waitForEvent(socket2, "close");
       });
@@ -172,7 +172,7 @@ describe("Engine.IO protocol", () => {
       it("should fail with an invalid 'transport' query parameter", async () => {
         const socket = new WebSocketStream(`${WS_URL}/socket.io/?EIO=4`);
 
-        socket.on("error", () => {});
+        socket.on("error", () => { });
 
         waitForEvent(socket, "close");
 
@@ -180,7 +180,7 @@ describe("Engine.IO protocol", () => {
           `${WS_URL}/socket.io/?EIO=4&transport=abc`,
         );
 
-        socket2.on("error", () => {});
+        socket2.on("error", () => { });
 
         waitForEvent(socket2, "close");
       });
@@ -230,7 +230,7 @@ describe("Engine.IO protocol", () => {
 
         assert(
           pollResponse.status == 400 ||
-            (pollResponse.status == 200 && (await pollResponse.text()) == "1"),
+          (pollResponse.status == 200 && (await pollResponse.text()) == "1"),
         );
       });
     });
@@ -328,6 +328,28 @@ describe("Engine.IO protocol", () => {
       // complete upgrade
       socket.send("5");
     });
+
+
+    it("should NOOP all polling requests while upgrading", async () => {
+      const sid = await initLongPollingSession();
+
+      const socket = new WebSocketStream(
+        `${WS_URL}/socket.io/?EIO=4&transport=websocket&sid=${sid}`,
+      );
+      await waitForEvent(socket, "open");
+      for (let i = 0; i < 5; i++) {
+        const res = await fetch(`${POLLING_URL}/socket.io/?EIO=4&transport=polling&sid=${sid}`);
+        assert.deepStrictEqual(res.status, 200);
+        const body = await res.text();
+        assert.deepStrictEqual(body, "6");
+      }
+
+      socket.send("2probe");
+      socket.send("5");
+
+      await waitForMessage(socket); // 3probe
+    });
+
 
     it("should ignore HTTP requests with same sid after upgrade", async () => {
       const sid = await initLongPollingSession();


### PR DESCRIPTION
Fix a bug introduced in #554, the `NOOP` packet sent in case of polling request while upgrading was incorrectly encoded as binary for v3 sockets with binary supports.