### PR TITLE
feat(engineio): improve `engineioxide::OpenPacket` serde impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tokio = "1.47"
 tokio-tungstenite = "0.26"
 serde = { version = "1.0", features = ["derive"] }
-smallvec = { version = "1.15", features = ["union"] }
+smallvec = { version = "1.15", features = ["union", "serde"] }
 serde_json = "1.0"
 tower-layer = "0.3"
 tower-service = "0.3"

--- a/crates/engineioxide/src/service/parser.rs
+++ b/crates/engineioxide/src/service/parser.rs
@@ -1,5 +1,6 @@
 //! A Parser module to parse any `EngineIo` query
 
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{future::Future, str::FromStr, sync::Arc};
 
 use http::{Method, Request, Response};
@@ -148,12 +149,31 @@ impl FromStr for ProtocolVersion {
 }
 
 /// The type of `transport` used by the client.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum TransportType {
     /// Polling transport
     Polling = 0x01,
     /// Websocket transport
     Websocket = 0x02,
+}
+
+impl Serialize for TransportType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str((*self).into())
+    }
+}
+
+impl<'de> Deserialize<'de> for TransportType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
 }
 
 impl From<u8> for TransportType {


### PR DESCRIPTION
This PR fixes #547 

On another note, as per the contributing guide, I ran the test suite, which threw some errors.
I believe this cannot be related to my changes, I just thought I mention it here anyway:

```
~/engine.io-protocol/test-suite main ❯ npm test

> engine.io-protocol-test-suite@0.0.1 test
> mocha test-suite.js



  Engine.IO protocol
    handshake
      HTTP long-polling
        ✔ successfully opens a session
        ✔ fails with an invalid 'EIO' query parameter
        ✔ fails with an invalid 'transport' query parameter
        ✔ fails with an invalid request method
      WebSocket
        ✔ successfully opens a session
        ✔ fails with an invalid 'EIO' query parameter
        ✔ fails with an invalid 'transport' query parameter
    message
      HTTP long-polling
        1) sends and receives a payload containing one plain text packet
        2) sends and receives a payload containing several plain text packets
        3) sends and receives a payload containing plain text and binary packets
        ✔ closes the session upon invalid packet format
        4) closes the session upon duplicate poll requests
      WebSocket
        5) sends and receives a plain text packet
        ✔ sends and receives a binary packet
        ✔ closes the session upon invalid packet format
    heartbeat
      HTTP long-polling
        ✔ sends ping/pong packets (609ms)
        ✔ closes the session upon ping timeout (507ms)
      WebSocket
        ✔ sends ping/pong packets (606ms)
        ✔ closes the session upon ping timeout (207ms)
    close
      HTTP long-polling
        6) forcefully closes the session
      WebSocket
        ✔ forcefully closes the session
    upgrade
      7) successfully upgrades from HTTP long-polling to WebSocket
      8) ignores HTTP requests with same sid after upgrade
      9) ignores WebSocket connection with same sid after upgrade


  15 passing (2s)
  9 failing

  1) Engine.IO protocol
       message
         HTTP long-polling
           sends and receives a payload containing one plain text packet:

      AssertionError: expected '2\u001e4hello' to deeply equal '4hello'
      + expected - actual

      -24hello
      +4hello

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:210:32)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  2) Engine.IO protocol
       message
         HTTP long-polling
           sends and receives a payload containing several plain text packets:

      AssertionError: expected '2\u001e4test1\u001e4test2\u001e4test3' to deeply equal '4test1\u001e4test2\u001e4test3'
      + expected - actual

      -24test14test24test3
      +4test14test24test3

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:238:32)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  3) Engine.IO protocol
       message
         HTTP long-polling
           sends and receives a payload containing plain text and binary packets:

      AssertionError: expected '2\u001e4hello\u001ebAQIDBA==' to deeply equal '4hello\u001ebAQIDBA=='
      + expected - actual

      -24hellobAQIDBA==
      +4hellobAQIDBA==

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:266:32)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  4) Engine.IO protocol
       message
         HTTP long-polling
           closes the session upon duplicate poll requests:

      AssertionError: expected '2' to deeply equal '1'
      + expected - actual

      -2
      +1

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:305:28)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  5) Engine.IO protocol
       message
         WebSocket
           sends and receives a plain text packet:

      AssertionError: expected '2' to deeply equal '4hello'
      + expected - actual

      -2
      +4hello

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:332:25)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  6) Engine.IO protocol
       close
         HTTP long-polling
           forcefully closes the session:

      AssertionError: expected '2' to deeply equal '6'
      + expected - actual

      -2
      +6

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:459:32)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  7) Engine.IO protocol
       upgrade
         successfully upgrades from HTTP long-polling to WebSocket:

      AssertionError: expected '2' to deeply equal '4hello'
      + expected - actual

      -2
      +4hello

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:518:23)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  8) Engine.IO protocol
       upgrade
         ignores HTTP requests with same sid after upgrade:

      AssertionError: expected '2' to deeply equal '4hello'
      + expected - actual

      -2
      +4hello

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:542:23)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

  9) Engine.IO protocol
       upgrade
         ignores WebSocket connection with same sid after upgrade:

      AssertionError: expected '2' to deeply equal '4hello'
      + expected - actual

      -2
      +4hello

      at Context.<anonymous> (file:///home/tux/engine.io-protocol/test-suite/test-suite.js:566:23)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```