### PR TITLE
fix(ci): rollback to 1.89

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -43,9 +43,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: nightly
 
       - name: Install cargo-udeps
         uses: taiki-e/install-action@cargo-udeps


### PR DESCRIPTION
Rollback to 1.89 in CI until 1.91 release. 

Related to #603 