### PR TITLE
fix(ci): use redis bitnami legacy images

### DIFF
--- a/.github/workflows/adapter-ci/docker-compose.yml
+++ b/.github/workflows/adapter-ci/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       interval: 2s
       timeout: 5s
   redis-node-0:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0
     network_mode: host
     healthcheck:
       test: "redis-cli ping"
@@ -24,7 +24,7 @@ services:
       - REDIS_NODES=127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
 
   redis-node-1:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0
     network_mode: host
     healthcheck:
       test: "redis-cli ping"
@@ -40,7 +40,7 @@ services:
       - REDIS_NODES=127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
 
   redis-node-2:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0
     network_mode: host
     healthcheck:
       test: "redis-cli ping"
@@ -56,7 +56,7 @@ services:
       - REDIS_NODES=127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
 
   redis-node-3:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0
     network_mode: host
     healthcheck:
       test: "redis-cli ping"
@@ -72,7 +72,7 @@ services:
       - REDIS_NODES=127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
 
   redis-node-4:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0
     network_mode: host
     healthcheck:
       test: "redis-cli ping"
@@ -88,7 +88,7 @@ services:
       - REDIS_NODES=127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
 
   redis-node-5:
-    image: docker.io/bitnami/redis-cluster:7.0
+    image: docker.io/bitnamilegacy/redis-cluster:7.0
     network_mode: host
     healthcheck:
       test: "redis-cli ping"


### PR DESCRIPTION
## Motivation
Bitnami `redis-cluster` docker image are no longer available, switch to bitnami legacy repo.
