### PR TITLE
fix(socketio): emit with ack race cond

### DIFF
--- a/crates/socketioxide/CHANGELOG.md
+++ b/crates/socketioxide/CHANGELOG.md
@@ -1,3 +1,6 @@
+# socketioxide 0.18.3
+* fix: race condition when emitting with acknowledgement.
+
 # socketioxide 0.18.2
 * deps: bump rand from 0.9.1 to 0.10.0
 

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide"
 description = "Socket IO server implementation in rust as a Tower Service."
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/socketioxide/src/socket.rs
+++ b/crates/socketioxide/src/socket.rs
@@ -748,25 +748,21 @@ impl<A: Adapter> Socket<A> {
 
         let ack = self.ack_counter.fetch_add(1, Ordering::SeqCst) + 1;
         packet.inner.set_ack_id(ack);
-        // insert hack channel before to avoid race condition
+        // insert ack channel before to avoid race condition
         self.ack_message.lock().unwrap().insert(ack, tx);
         permit.send(packet, self.parser);
         rx
     }
 
-    pub(crate) fn send_with_ack(&self, mut packet: Packet) -> Receiver<AckResult<Value>> {
-        let (tx, rx) = oneshot::channel();
-
-        let ack = self.ack_counter.fetch_add(1, Ordering::SeqCst) + 1;
-        packet.inner.set_ack_id(ack);
-        // insert hack channel before to avoid race condition
-        self.ack_message.lock().unwrap().insert(ack, tx);
-        if let Err(e) = self.send(packet) {
-            if let Some(tx) = self.ack_message.lock().unwrap().remove(&ack) {
-                tx.send(Err(AckError::Socket(e))).ok();
+    pub(crate) fn send_with_ack(&self, packet: Packet) -> Receiver<AckResult<Value>> {
+        match self.reserve() {
+            Ok(permit) => self.send_with_ack_permit(packet, permit),
+            Err(err) => {
+                let (tx, rx) = oneshot::channel();
+                tx.send(Err(AckError::Socket(err))).ok();
+                rx
             }
         }
-        rx
     }
 
     /// Called when the socket is gracefully disconnected from the server or the client

--- a/crates/socketioxide/src/socket.rs
+++ b/crates/socketioxide/src/socket.rs
@@ -748,8 +748,9 @@ impl<A: Adapter> Socket<A> {
 
         let ack = self.ack_counter.fetch_add(1, Ordering::SeqCst) + 1;
         packet.inner.set_ack_id(ack);
-        permit.send(packet, self.parser);
+        // insert hack channel before to avoid race condition
         self.ack_message.lock().unwrap().insert(ack, tx);
+        permit.send(packet, self.parser);
         rx
     }
 
@@ -758,11 +759,10 @@ impl<A: Adapter> Socket<A> {
 
         let ack = self.ack_counter.fetch_add(1, Ordering::SeqCst) + 1;
         packet.inner.set_ack_id(ack);
-        match self.send(packet) {
-            Ok(()) => {
-                self.ack_message.lock().unwrap().insert(ack, tx);
-            }
-            Err(e) => {
+        // insert hack channel before to avoid race condition
+        self.ack_message.lock().unwrap().insert(ack, tx);
+        if let Err(e) = self.send(packet) {
+            if let Some(tx) = self.ack_message.lock().unwrap().remove(&ack) {
                 tx.send(Err(AckError::Socket(e))).ok();
             }
         }


### PR DESCRIPTION
## Motivation
With env with high CPU preemption (like CIs) a race condition might occur when using `emit_with_ack` methods. The ack oneshot chan was inserted in the pending acks map only **after** the packet emission. With a potential interrupt and a fast enough system the ack response was received before the chan being inserted in the map. 

## Solution
Insert the oneshot ack response handler before emitting the packet.