### PR TITLE
fix: rustdoc feature flags

### DIFF
--- a/crates/socketioxide-redis/src/drivers/mod.rs
+++ b/crates/socketioxide-redis/src/drivers/mod.rs
@@ -6,12 +6,10 @@ use tokio::sync::mpsc;
 
 /// A driver implementation for the [redis](docs.rs/redis) pub/sub backend.
 #[cfg(feature = "redis")]
-#[cfg_attr(docsrs, doc(cfg(feature = "redis")))]
 pub mod redis;
 
 /// A driver implementation for the [fred](docs.rs/fred) pub/sub backend.
 #[cfg(feature = "fred")]
-#[cfg_attr(docsrs, doc(cfg(feature = "fred")))]
 pub mod fred;
 
 pin_project! {

--- a/crates/socketioxide-redis/src/drivers/redis.rs
+++ b/crates/socketioxide-redis/src/drivers/redis.rs
@@ -37,7 +37,6 @@ pub struct RedisDriver {
 
 /// A driver implementation for the [redis](docs.rs/redis) pub/sub backend.
 #[cfg(feature = "redis-cluster")]
-#[cfg_attr(docsrs, doc(cfg(feature = "redis-cluster")))]
 #[derive(Clone)]
 pub struct ClusterDriver {
     handlers: Arc<RwLock<HandlerMap>>,
@@ -97,7 +96,6 @@ impl RedisDriver {
 #[cfg(feature = "redis-cluster")]
 impl ClusterDriver {
     /// Create a new redis driver from a redis cluster client.
-    #[cfg_attr(docsrs, doc(cfg(feature = "redis-cluster")))]
     pub async fn new(client: &redis::cluster::ClusterClient) -> Result<Self, redis::RedisError> {
         let handlers = Arc::new(RwLock::new(HashMap::new()));
         let handlers_clone = handlers.clone();
@@ -150,7 +148,6 @@ impl Driver for RedisDriver {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "redis-cluster")))]
 #[cfg(feature = "redis-cluster")]
 impl Driver for ClusterDriver {
     type Error = RedisError;

--- a/crates/socketioxide-redis/src/lib.rs
+++ b/crates/socketioxide-redis/src/lib.rs
@@ -289,12 +289,10 @@ pub struct RedisAdapterCtr<R> {
 #[cfg(feature = "redis")]
 impl RedisAdapterCtr<drivers::redis::RedisDriver> {
     /// Create a new adapter constructor with the [`redis`] driver and a default config.
-    #[cfg_attr(docsrs, doc(cfg(feature = "redis")))]
     pub async fn new_with_redis(client: &redis::Client) -> redis::RedisResult<Self> {
         Self::new_with_redis_config(client, RedisAdapterConfig::default()).await
     }
     /// Create a new adapter constructor with the [`redis`] driver and a custom config.
-    #[cfg_attr(docsrs, doc(cfg(feature = "redis")))]
     pub async fn new_with_redis_config(
         client: &redis::Client,
         config: RedisAdapterConfig,
@@ -306,7 +304,6 @@ impl RedisAdapterCtr<drivers::redis::RedisDriver> {
 #[cfg(feature = "redis-cluster")]
 impl RedisAdapterCtr<drivers::redis::ClusterDriver> {
     /// Create a new adapter constructor with the [`redis`] driver and a default config.
-    #[cfg_attr(docsrs, doc(cfg(feature = "redis-cluster")))]
     pub async fn new_with_cluster(
         client: &redis::cluster::ClusterClient,
     ) -> redis::RedisResult<Self> {
@@ -314,7 +311,6 @@ impl RedisAdapterCtr<drivers::redis::ClusterDriver> {
     }
 
     /// Create a new adapter constructor with the [`redis`] driver and a default config.
-    #[cfg_attr(docsrs, doc(cfg(feature = "redis-cluster")))]
     pub async fn new_with_cluster_config(
         client: &redis::cluster::ClusterClient,
         config: RedisAdapterConfig,
@@ -326,14 +322,12 @@ impl RedisAdapterCtr<drivers::redis::ClusterDriver> {
 #[cfg(feature = "fred")]
 impl RedisAdapterCtr<drivers::fred::FredDriver> {
     /// Create a new adapter constructor with the default [`fred`] driver and a default config.
-    #[cfg_attr(docsrs, doc(cfg(feature = "fred")))]
     pub async fn new_with_fred(
         client: fred::clients::SubscriberClient,
     ) -> fred::prelude::FredResult<Self> {
         Self::new_with_fred_config(client, RedisAdapterConfig::default()).await
     }
     /// Create a new adapter constructor with the default [`fred`] driver and a custom config.
-    #[cfg_attr(docsrs, doc(cfg(feature = "fred")))]
     pub async fn new_with_fred_config(
         client: fred::clients::SubscriberClient,
         config: RedisAdapterConfig,
@@ -355,17 +349,14 @@ impl<R: Driver> RedisAdapterCtr<R> {
 pub(crate) type ResponseHandlers = HashMap<Sid, mpsc::Sender<Vec<u8>>>;
 
 /// The redis adapter with the fred driver.
-#[cfg_attr(docsrs, doc(cfg(feature = "fred")))]
 #[cfg(feature = "fred")]
 pub type FredAdapter<E> = CustomRedisAdapter<E, drivers::fred::FredDriver>;
 
 /// The redis adapter with the redis driver.
-#[cfg_attr(docsrs, doc(cfg(feature = "redis")))]
 #[cfg(feature = "redis")]
 pub type RedisAdapter<E> = CustomRedisAdapter<E, drivers::redis::RedisDriver>;
 
 /// The redis adapter with the redis cluster driver.
-#[cfg_attr(docsrs, doc(cfg(feature = "redis-cluster")))]
 #[cfg(feature = "redis-cluster")]
 pub type ClusterAdapter<E> = CustomRedisAdapter<E, drivers::redis::ClusterDriver>;
 

--- a/crates/socketioxide/src/extract/extensions.rs
+++ b/crates/socketioxide/src/extract/extensions.rs
@@ -7,7 +7,6 @@ use crate::socket::{DisconnectReason, Socket};
 use socketioxide_core::Value;
 
 #[cfg(feature = "extensions")]
-#[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
 pub use extensions_extract::*;
 
 /// It was impossible to find the given extension.

--- a/crates/socketioxide/src/extract/mod.rs
+++ b/crates/socketioxide/src/extract/mod.rs
@@ -107,14 +107,12 @@ mod extensions;
 mod socket;
 
 #[cfg(feature = "state")]
-#[cfg_attr(docsrs, doc(cfg(feature = "state")))]
 mod state;
 
 pub use data::*;
 pub use extensions::*;
 pub use socket::*;
 #[cfg(feature = "state")]
-#[cfg_attr(docsrs, doc(cfg(feature = "state")))]
 pub use state::*;
 
 /// Private API.

--- a/crates/socketioxide/src/io.rs
+++ b/crates/socketioxide/src/io.rs
@@ -41,7 +41,6 @@ impl ParserConfig {
     }
 
     /// Use a [`MsgPackParser`] to parse incoming and outgoing socket.io packets
-    #[cfg_attr(docsrs, doc(cfg(feature = "msgpack")))]
     #[cfg(feature = "msgpack")]
     pub fn msgpack() -> Self {
         ParserConfig(Parser::MsgPack(MsgPackParser))
@@ -236,7 +235,6 @@ impl<A: Adapter> SocketIoBuilder<A> {
     /// You can set any number of states as long as they have different types.
     /// The state must be cloneable, therefore it is recommended to wrap it in an `Arc` if you want shared state.
     #[inline]
-    #[cfg_attr(docsrs, doc(cfg(feature = "state")))]
     #[cfg(feature = "state")]
     pub fn with_state<S: Clone + Send + Sync + 'static>(self, state: S) -> Self {
         self.state.set(state);

--- a/crates/socketioxide/src/lib.rs
+++ b/crates/socketioxide/src/lib.rs
@@ -335,7 +335,6 @@
 //! [`AckSender::send`]: extract::AckSender#method.send
 //! [`io`]: SocketIo
 
-#[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
 #[cfg(feature = "extensions")]
 pub mod extensions;
 

--- a/crates/socketioxide/src/socket.rs
+++ b/crates/socketioxide/src/socket.rs
@@ -298,7 +298,6 @@ pub struct Socket<A: Adapter = LocalAdapter> {
     ///
     /// **Note**: This is not the same data as the `extensions` field on the [`http::Request::extensions()`](http::Request) struct.
     /// If you want to extract extensions from the http request, you should use the [`HttpExtension`](crate::extract::HttpExtension) extractor.
-    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
     #[cfg(feature = "extensions")]
     pub extensions: Extensions,
     esocket: Arc<engineioxide::Socket<SocketData<A>>>,


### PR DESCRIPTION
Use `#![cfg_attr(docsrs, feature(doc_cfg))]` rather than legacy feature flag solutions.