### PR TITLE
chore(deps): specify `tokio-util` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rmp = "0.8"
 # Dev deps
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["io"], default-features = false }
+tokio-util = { version = "0.7.18", features = ["io"], default-features = false }
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 axum = "0.8"
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/totodore/socketioxide/blob/main/CONTRIBUTING.md
-->

## Motivation

To address https://github.com/Totodore/socketioxide/issues/719, an older `tokio-util` version would break the build when `socketoxide` is used in another project.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Pin `tokio-util`'s version.