### PR TITLE
docs(socketioxide): document accessing state from custom extractors

### DIFF
--- a/crates/socketioxide/src/extract/mod.rs
+++ b/crates/socketioxide/src/extract/mod.rs
@@ -35,6 +35,11 @@
 //! If you want to deserialize the [`Value`](socketioxide_core::Value) data you must manually call
 //! the `Data` extractor to deserialize it.
 //!
+//! Extractors are composable: inside your own extractor you can call the existing extractors
+//! (for example [`State`] to read shared state set with
+//! [`SocketIoBuilder::with_state`](crate::io::SocketIoBuilder)) rather than reaching into the
+//! socket internals. See the [`State`] documentation for a worked example.
+//!
 //! [`FromConnectParts`]: crate::handler::FromConnectParts
 //! [`FromMessageParts`]: crate::handler::FromMessageParts
 //! [`FromMessage`]: crate::handler::FromMessage

--- a/crates/socketioxide/src/extract/state.rs
+++ b/crates/socketioxide/src/extract/state.rs
@@ -35,6 +35,42 @@ use socketioxide_core::Value;
 ///     state.add_user();
 ///     println!("User count: {}", state.user_cnt.load(Ordering::SeqCst));
 /// });
+/// ```
+///
+/// ### Accessing the state from a custom extractor
+///
+/// Extractors are composable: rather than reaching into the socket internals,
+/// a custom extractor can simply call another extractor — such as [`State`] —
+/// inside its own implementation. Because [`State`] derefs to the inner value,
+/// no manual `get_state` plumbing is required.
+///
+/// ```
+/// # use socketioxide::handler::{FromConnectParts, Value};
+/// # use socketioxide::extract::State;
+/// # use socketioxide::adapter::Adapter;
+/// # use socketioxide::socket::Socket;
+/// # use socketioxide::SocketIo;
+/// # use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+/// /// A custom extractor that yields the index of the current connection,
+/// /// derived from a counter held in the shared application state.
+/// struct ConnIndex(usize);
+///
+/// impl<A: Adapter> FromConnectParts<A> for ConnIndex {
+///     type Error = std::convert::Infallible;
+///     fn from_connect_parts(s: &Arc<Socket<A>>, auth: &Option<Value>) -> Result<Self, Self::Error> {
+///         // Reuse the `State` extractor instead of calling `s.get_io().get_state()` directly.
+///         let idx = State::<Arc<AtomicUsize>>::from_connect_parts(s, auth)
+///             .map(|cnt| cnt.fetch_add(1, Ordering::SeqCst))
+///             .unwrap_or(0);
+///         Ok(ConnIndex(idx))
+///     }
+/// }
+///
+/// let (_, io) = SocketIo::builder()
+///     .with_state(Arc::new(AtomicUsize::new(0)))
+///     .build_svc();
+/// io.ns("/", async |idx: ConnIndex| println!("connection #{}", idx.0));
+/// ```
 pub struct State<T>(pub T);
 
 /// It was impossible to find the given state and therefore the handler won't be called.


### PR DESCRIPTION
Closes #374.

## Problem

The extractor docs explain how to implement custom extractors, but they do not show the pattern for accessing shared application state from inside one.

That leaves users to discover on their own that extractors are composable — for example, that a custom extractor can call `State::<T>::from_connect_parts(...)` or the equivalent message/disconnect extractor method internally.

## Changes

This is documentation-only. No API or runtime behavior changes.

- Adds a worked example to the `State` extractor docs showing a custom `ConnIndex` extractor that reads shared state set with `SocketIoBuilder::with_state`.
- Adds a short note to the extractor module docs explaining that extractors can compose existing extractors, and points readers to the new `State` example.

The example uses `State::<Arc<AtomicUsize>>` so it stays small while showing the useful pattern:

```rust
let idx = State::<Arc<AtomicUsize>>::from_connect_parts(s, auth)
    .map(|cnt| cnt.fetch_add(1, Ordering::SeqCst))
    .unwrap_or(0);
```

## Verification

```sh
cargo fmt --all -- --check
cargo test --doc -p socketioxide --all-features
RUSTDOCFLAGS="-D warnings" cargo doc -p socketioxide --all-features --no-deps
cargo clippy -p socketioxide --all-features --tests -- -D warnings
```

Result:

```text
cargo test --doc: 113 passed; 0 failed, plus 1 compile-fail doctest passed
cargo doc: finished with warnings denied
cargo clippy: finished with warnings denied
```

## Notes

The issue also mentions exporting `Value`/`Bytes` and tuple-based multi-extraction. I left those out intentionally because they are API/design questions rather than documentation gaps.

This PR only documents the currently-supported way to compose extractors and access shared state from a custom extractor.
