### PR TITLE
fix(engineio): v3 packet header should have a size in utf-16 code points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-subscriber",
- "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "engineioxide"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "axum",
  "base64",

--- a/crates/engineioxide/CHANGELOG.md
+++ b/crates/engineioxide/CHANGELOG.md
@@ -1,3 +1,6 @@
+# engineioxide 0.17.5
+fix: v3 packet header in polling payload should have a size in utf-16 code points.
+
 # engineioxide 0.17.4
 * MSRV: rust-version is now 1.94
 * fix: issue [#731](https://github.com/Totodore/socketioxide/issues/731). Memory leak with unclaimed engine.io sessions whose WebSocket upgrade is started but never completed.

--- a/crates/engineioxide/Cargo.toml
+++ b/crates/engineioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engineioxide"
 description = "Engine IO server implementation as a Tower Service."
-version = "0.17.4"
+version = "0.17.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/engineioxide/Cargo.toml
+++ b/crates/engineioxide/Cargo.toml
@@ -47,7 +47,6 @@ tracing = { workspace = true, optional = true }
 # Engine.io V3 payload
 itoa = { workspace = true, optional = true }
 memchr = { version = "2.7", optional = true }
-unicode-segmentation = { version = "1.13", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "parking_lot"] }
@@ -57,7 +56,7 @@ criterion.workspace = true
 axum.workspace = true
 tokio-stream.workspace = true
 [features]
-v3 = ["memchr", "unicode-segmentation", "itoa"]
+v3 = ["memchr", "itoa"]
 tracing = ["dep:tracing"]
 __test_harness = []
 

--- a/crates/engineioxide/src/transport/polling/payload/decoder.rs
+++ b/crates/engineioxide/src/transport/polling/payload/decoder.rs
@@ -696,16 +696,6 @@ mod tests {
         assert_eq!(utf16_byte_offset("4𝕊", 10), None); // too short
     }
 
-    #[cfg(feature = "v3")]
-    #[test]
-    fn utf16_len_unit() {
-        assert_eq!(utf16_len(""), 0);
-        assert_eq!(utf16_len("abc"), 3);
-        assert_eq!(utf16_len("€f"), 2);
-        assert_eq!(utf16_len("𝕊"), 2);
-        assert_eq!(utf16_len("4𝕊"), 3);
-    }
-
     // (4) The header declares a 10 UTF-16 code unit packet but the body ends
     // after only 3 ("4ab"). The decoder must terminate (error or end-of-stream)
     // rather than spin forever waiting on data that will never arrive. This is

--- a/crates/engineioxide/src/transport/polling/payload/decoder.rs
+++ b/crates/engineioxide/src/transport/polling/payload/decoder.rs
@@ -222,13 +222,36 @@ where
     })
 }
 
+/// Return the byte offset in `s` reached after exactly `target` UTF-16 code units.
+/// Returns `None` if `s` has fewer UTF-16 code units than requested.
+#[cfg(feature = "v3")]
+fn utf16_byte_offset(s: &str, target: usize) -> Option<usize> {
+    if target == 0 {
+        return Some(0);
+    }
+    let mut count = 0usize;
+    for (i, ch) in s.char_indices() {
+        count += ch.len_utf16();
+        if count >= target {
+            // If a surrogate-pair char straddles the boundary (count > target),
+            // we still cut after the char — the length check below will reject it.
+            return Some(i + ch.len_utf8());
+        }
+    }
+    None
+}
+
+#[cfg(feature = "v3")]
+fn utf16_len(s: &str) -> usize {
+    s.encode_utf16().count()
+}
+
 #[cfg(feature = "v3")]
 pub fn v3_string_decoder(
     body: impl Body<Error = impl std::fmt::Debug> + Unpin,
     max_payload: u64,
 ) -> impl Stream<Item = Result<Packet, Error>> {
     use std::io::ErrorKind;
-    use unicode_segmentation::UnicodeSegmentation;
 
     use crate::transport::polling::payload::STRING_PACKET_SEPARATOR_V3;
 
@@ -238,7 +261,7 @@ pub fn v3_string_decoder(
 
     futures_util::stream::unfold(state, move |mut state| async move {
         let mut packet_buf: Vec<u8> = Vec::new();
-        let mut packet_graphemes_len: usize = 0;
+        let mut packet_utf16_len: usize = 0;
         loop {
             // Read data from the body stream into the buffer
             if !state.end_of_stream
@@ -255,7 +278,7 @@ pub fn v3_string_decoder(
             let mut reader = (&mut state.buffer).reader();
 
             // Read the packet length from the buffer
-            if packet_graphemes_len == 0 {
+            if packet_utf16_len == 0 {
                 loop {
                     let (done, used) = {
                         let remaining = reader.get_ref().remaining();
@@ -270,7 +293,7 @@ pub fn v3_string_decoder(
                         match memchr::memchr(STRING_PACKET_SEPARATOR_V3, &packet_buf) {
                             Some(i) => {
                                 // Extract the packet length from the available data
-                                packet_graphemes_len = match std::str::from_utf8(&packet_buf[..i])
+                                packet_utf16_len = match std::str::from_utf8(&packet_buf[..i])
                                     .map_err(|_| Error::InvalidPacketLength)
                                     .and_then(|s| {
                                         s.parse::<usize>().map_err(|_| Error::InvalidPacketLength)
@@ -295,7 +318,7 @@ pub fn v3_string_decoder(
                 }
             }
 
-            if packet_graphemes_len == 0 {
+            if packet_utf16_len == 0 {
                 continue; // No packet length, continue to read more data
             }
 
@@ -306,39 +329,33 @@ pub fn v3_string_decoder(
 
             let old_len = packet_buf.len();
             packet_buf.extend_from_slice(data);
+            let truncate_to = |s: &str| utf16_byte_offset(s, packet_utf16_len);
             let byte_read = match std::str::from_utf8(&packet_buf) {
-                Ok(fulldata) => {
-                    let i = fulldata
-                        .grapheme_indices(true)
-                        .nth(packet_graphemes_len)
-                        .map(|(i, _)| i);
-                    if let Some(i) = i {
+                Ok(fulldata) => match truncate_to(fulldata) {
+                    Some(i) => {
                         packet_buf.truncate(i);
                         packet_buf.len() - old_len
-                    } else {
-                        data.len()
                     }
-                }
+                    None => data.len(),
+                },
                 Err(e) => {
+                    // SAFETY: packet_buf is a valid utf8 string checkd above
                     let chunk =
                         unsafe { std::str::from_utf8_unchecked(&packet_buf[..e.valid_up_to()]) };
-                    let i = chunk
-                        .grapheme_indices(true)
-                        .nth(packet_graphemes_len)
-                        .map(|(i, _)| i);
-                    if let Some(i) = i {
-                        packet_buf.truncate(i);
-                        packet_buf.len() - old_len
-                    } else {
-                        data.len()
+                    match truncate_to(chunk) {
+                        Some(i) => {
+                            packet_buf.truncate(i);
+                            packet_buf.len() - old_len
+                        }
+                        None => data.len(),
                     }
                 }
             };
             reader.consume(byte_read);
 
-            // Check if the packet length matches the number of characters
+            // Check if the packet length matches the number of UTF-16 code units
             if let Ok(packet) = std::str::from_utf8(&packet_buf) {
-                if packet.graphemes(true).count() == packet_graphemes_len {
+                if utf16_len(packet) == packet_utf16_len {
                     // SAFETY: packet_buf is a valid utf8 string checkd above
                     let packet = unsafe { String::from_utf8_unchecked(packet_buf) };
                     let packet = Packet::parse(ProtocolVersion::V3, packet)
@@ -430,6 +447,26 @@ mod tests {
             let packet = payload.next().await.unwrap();
             assert!(matches!(packet, Err(Error::PayloadTooLarge)));
         }
+    }
+
+    #[cfg(feature = "v3")]
+    #[tokio::test]
+    async fn string_payload_v3_utf16_length() {
+        // The wire length is the number of UTF-16 code units (JS-style).
+        // Two packets: "4𝕊" → 3 UTF-16 code units ('4' + surrogate pair),
+        // then "4ab" → 3 UTF-16 code units.
+        let data = Full::new(Bytes::from("3:4𝕊3:4ab"));
+        let payload = v3_string_decoder(data, MAX_PAYLOAD);
+        futures_util::pin_mut!(payload);
+        assert!(matches!(
+            payload.next().await.unwrap().unwrap(),
+            Packet::Message(msg) if msg == "𝕊"
+        ));
+        assert!(matches!(
+            payload.next().await.unwrap().unwrap(),
+            Packet::Message(msg) if msg == "ab"
+        ));
+        assert!(payload.next().await.is_none());
     }
 
     #[cfg(feature = "v3")]

--- a/crates/engineioxide/src/transport/polling/payload/decoder.rs
+++ b/crates/engineioxide/src/transport/polling/payload/decoder.rs
@@ -325,20 +325,26 @@ pub fn v3_string_decoder(
             // Read bytes from the buffer until the packet length is reached
 
             // Read the next chunk of data from the chunk list
-            let data: &[u8] = reader.fill_buf().unwrap();
+            let data: &[u8] = reader.fill_buf().unwrap(); // fill_buf is infallible.
 
             let old_len = packet_buf.len();
             packet_buf.extend_from_slice(data);
             let truncate_to = |s: &str| utf16_byte_offset(s, packet_utf16_len);
+
+            // try to decode the packet buf, if there is still not enough data we consume
+            // everything and continue polling.
             let byte_read = match std::str::from_utf8(&packet_buf) {
                 Ok(fulldata) => match truncate_to(fulldata) {
                     Some(i) => {
                         packet_buf.truncate(i);
                         packet_buf.len() - old_len
                     }
-                    None => data.len(),
+                    None => data.len(), // not enough data, we consume everything
                 },
                 Err(e) => {
+                    // packet buf is in the middle of a char boundary. We get the available data and try to extract
+                    // packets.
+
                     // SAFETY: packet_buf is a valid utf8 string checkd above
                     let chunk =
                         unsafe { std::str::from_utf8_unchecked(&packet_buf[..e.valid_up_to()]) };
@@ -408,7 +414,6 @@ mod tests {
     async fn payload_stream_v4() {
         const DATA: &[u8] = "4foo\x1e4€f\x1e4fo".as_bytes();
         for i in 1..DATA.len() {
-            println!("payload stream v4 chunk size: {i}");
             let stream = StreamBody::new(futures_util::stream::iter(
                 DATA.chunks(i)
                     .map(Frame::data)
@@ -516,7 +521,6 @@ mod tests {
     async fn string_payload_stream_v3() {
         const DATA: &[u8] = "4:4foo3:4€f11:4baaaaaaaar".as_bytes();
         for i in 1..DATA.len() {
-            println!("payload stream v3 chunk size: {i}");
             let stream = StreamBody::new(futures_util::stream::iter(
                 DATA.chunks(i)
                     .map(Frame::data)
@@ -550,7 +554,6 @@ mod tests {
         const BINARY_PAYLOAD: &[u8] = &[1, 2, 3, 4];
 
         for i in 1..PAYLOAD.len() {
-            println!("payload stream v3 chunk size: {i}");
             let stream = StreamBody::new(futures_util::stream::iter(
                 PAYLOAD
                     .chunks(i)
@@ -617,5 +620,107 @@ mod tests {
             let packet = payload.next().await.unwrap();
             assert!(matches!(packet, Err(Error::PayloadTooLarge)));
         }
+    }
+
+    // (1) Same payload as `string_payload_v3_utf16_length`, but fed through the
+    // stream in chunks of every size. This exercises the `Err(valid_up_to())`
+    // path where the 4-byte `𝕊` (2 UTF-16 code units) is split across chunk
+    // boundaries, combined with the UTF-16 length accounting and truncation.
+    #[cfg(feature = "v3")]
+    #[tokio::test]
+    async fn string_payload_stream_v3_utf16_length() {
+        const DATA: &[u8] = "3:4𝕊3:4ab".as_bytes();
+        for i in 1..DATA.len() {
+            let stream = StreamBody::new(futures_util::stream::iter(
+                DATA.chunks(i)
+                    .map(Frame::data)
+                    .map(Ok::<_, std::convert::Infallible>),
+            ));
+            let payload = v3_string_decoder(stream, MAX_PAYLOAD);
+            futures_util::pin_mut!(payload);
+            assert!(matches!(
+                payload.next().await.unwrap().unwrap(),
+                Packet::Message(msg) if msg == "𝕊"
+            ));
+            assert!(matches!(
+                payload.next().await.unwrap().unwrap(),
+                Packet::Message(msg) if msg == "ab"
+            ));
+            assert!(payload.next().await.is_none());
+        }
+    }
+
+    // (2) The declared length cuts in the middle of a surrogate pair: the
+    // content "4𝕊" is 3 UTF-16 code units but the header declares 2, landing
+    // the boundary between the two code units of `𝕊`. `utf16_byte_offset` cuts
+    // after the whole char (count > target), so the UTF-16 length check must
+    // reject the packet rather than mis-decode it or loop forever.
+    #[cfg(feature = "v3")]
+    #[tokio::test]
+    async fn string_payload_v3_surrogate_straddle_rejected() {
+        let data = Full::new(Bytes::from("2:4𝕊"));
+        let payload = v3_string_decoder(data, MAX_PAYLOAD);
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            futures_util::pin_mut!(payload);
+            payload.next().await
+        })
+        .await
+        .expect("v3_string_decoder hung on surrogate-straddling length");
+        assert!(matches!(result, Some(Err(_)) | None));
+    }
+
+    // (3) Direct unit tests for the UTF-16 helpers.
+    #[cfg(feature = "v3")]
+    #[test]
+    fn utf16_byte_offset_unit() {
+        // target 0 always yields offset 0
+        assert_eq!(utf16_byte_offset("", 0), Some(0));
+        assert_eq!(utf16_byte_offset("abc", 0), Some(0));
+
+        // pure ASCII: 1 byte == 1 UTF-16 code unit
+        assert_eq!(utf16_byte_offset("abc", 2), Some(2));
+        assert_eq!(utf16_byte_offset("abc", 3), Some(3));
+        assert_eq!(utf16_byte_offset("abc", 5), None); // too short
+
+        // `€` is 3 UTF-8 bytes but a single UTF-16 code unit
+        assert_eq!(utf16_byte_offset("€", 1), Some(3));
+
+        // `𝕊` is 4 UTF-8 bytes and 2 UTF-16 code units
+        assert_eq!(utf16_byte_offset("𝕊", 2), Some(4));
+        // straddle: asking for 1 code unit still cuts after the whole char
+        assert_eq!(utf16_byte_offset("𝕊", 1), Some(4));
+
+        // mixed: '4' (1 unit) + `𝕊` (2 units)
+        assert_eq!(utf16_byte_offset("4𝕊", 3), Some(5));
+        assert_eq!(utf16_byte_offset("4𝕊", 2), Some(5)); // straddle past target
+        assert_eq!(utf16_byte_offset("4𝕊", 10), None); // too short
+    }
+
+    #[cfg(feature = "v3")]
+    #[test]
+    fn utf16_len_unit() {
+        assert_eq!(utf16_len(""), 0);
+        assert_eq!(utf16_len("abc"), 3);
+        assert_eq!(utf16_len("€f"), 2);
+        assert_eq!(utf16_len("𝕊"), 2);
+        assert_eq!(utf16_len("4𝕊"), 3);
+    }
+
+    // (4) The header declares a 10 UTF-16 code unit packet but the body ends
+    // after only 3 ("4ab"). The decoder must terminate (error or end-of-stream)
+    // rather than spin forever waiting on data that will never arrive. This is
+    // the string-side analog of `binary_payload_truncated_v3`.
+    #[cfg(feature = "v3")]
+    #[tokio::test]
+    async fn string_payload_truncated_v3() {
+        let data = Full::new(Bytes::from("10:4ab"));
+        let payload = v3_string_decoder(data, MAX_PAYLOAD);
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            futures_util::pin_mut!(payload);
+            payload.next().await
+        })
+        .await
+        .expect("v3_string_decoder hung on truncated packet");
+        assert!(matches!(result, Some(Err(_)) | None));
     }
 }

--- a/crates/engineioxide/src/transport/polling/payload/encoder.rs
+++ b/crates/engineioxide/src/transport/polling/payload/encoder.rs
@@ -160,9 +160,11 @@ pub fn v3_string_packet_encoder(packet: Packet, data: &mut bytes::BytesMut) {
     use crate::transport::polling::payload::STRING_PACKET_SEPARATOR_V3;
     use bytes::BufMut;
     let packet: String = packet.into();
+    // Engine.IO v3 length is the number of UTF-16 code units in the packet,
+    // matching the reference JS client/server which use `String.prototype.length`.
     let packet = format!(
         "{}{}{}",
-        packet.chars().count(),
+        packet.encode_utf16().count(),
         STRING_PACKET_SEPARATOR_V3 as char,
         packet
     );
@@ -343,6 +345,23 @@ mod tests {
             let Payload { data, .. } = v4_encoder(rx, MAX_PAYLOAD + 10).await.unwrap();
             assert_eq!(data, "4hello€".as_bytes());
         }
+    }
+
+    #[cfg(feature = "v3")]
+    #[tokio::test]
+    async fn encode_v3_string_payload_utf16_length() {
+        // Length must be the number of UTF-16 code units to match the
+        // engine.io v3 JS reference implementation. The message "4𝕊"
+        // (packet type '4' + non-BMP codepoint U+1D54A) has 2 codepoints
+        // but 3 UTF-16 code units.
+        const PAYLOAD: &str = "3:4𝕊";
+        let (tx, rx) = tokio::sync::mpsc::channel::<PacketBuf>(10);
+        let mutex = Mutex::new(PeekableReceiver::new(rx));
+        let rx = mutex.lock().await;
+        tx.try_send(smallvec::smallvec![Packet::Message("𝕊".into())])
+            .unwrap();
+        let Payload { data, .. } = v3_string_encoder(rx, MAX_PAYLOAD).await.unwrap();
+        assert_eq!(data, PAYLOAD.as_bytes());
     }
 
     #[cfg(feature = "v3")]

--- a/crates/engineioxide/src/transport/polling/payload/encoder.rs
+++ b/crates/engineioxide/src/transport/polling/payload/encoder.rs
@@ -160,11 +160,9 @@ pub fn v3_string_packet_encoder(packet: Packet, data: &mut bytes::BytesMut) {
     use crate::transport::polling::payload::STRING_PACKET_SEPARATOR_V3;
     use bytes::BufMut;
     let packet: String = packet.into();
-    // Engine.IO v3 length is the number of UTF-16 code units in the packet,
-    // matching the reference JS client/server which use `String.prototype.length`.
     let packet = format!(
         "{}{}{}",
-        packet.encode_utf16().count(),
+        packet.encode_utf16().count(), // The protocol uses in UTF16 code points for packet size because of JS
         STRING_PACKET_SEPARATOR_V3 as char,
         packet
     );


### PR DESCRIPTION
## fix(engineio): v3 packet header size should be UTF-16 code units

The engine.io v3 long-polling protocol prefixes each string packet with its length. The JS reference implementation computes that length with `String.prototype.length`, i.e. the number of **UTF-16 code units**. We were counting differently on both sides:

- **Encoder** counted `chars()` (Unicode scalar values)
- **Decoder** counted **graphemes** (via `unicode-segmentation`)

Both diverge from UTF-16 for non-BMP characters (emoji, math symbols, etc.) — e.g. `𝕊` is 1 char / 1 grapheme but **2** UTF-16 code units — so packets containing them got the wrong length and failed to round-trip.