### PR TITLE
chore(release): socketioxide v0.18.4 && engineioxide v0.17.4

### DIFF
--- a/crates/engineioxide/CHANGELOG.md
+++ b/crates/engineioxide/CHANGELOG.md
@@ -1,3 +1,14 @@
+# engineioxide 0.17.4
+* MSRV: rust-version is now 1.94
+* fix: issue [#731](https://github.com/Totodore/socketioxide/issues/731). Memory leak with unclaimed engine.io sessions whose WebSocket upgrade is started but never completed.
+* fix: missing packet separator when polling a parked v4 encoder.
+* fix: incorrectly merged binary/string packets when polling a parked v3 encoder.
+* fix: v3 encoded payload size is never re-computed for max payload size threshold.
+* fix: v3 decoder infinite loop with malformed packet
+* fix: base64 binary packet protocol mismatch with payload starting with `4`.
+* fix: fix potential panic in debug with malicious v3 packets.
+* fix: expect b64 query param to be equal to 1 or true to enable b64 encoding.
+
 # engineioxide 0.17.3
 * fix: issue [#719](https://github.com/Totodore/socketioxide/issues/719). Because of an unpinned dependency on `tokio-util`
 building engineioxide would fail with `tokio-util < 0.7.14`.

--- a/crates/engineioxide/Cargo.toml
+++ b/crates/engineioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engineioxide"
 description = "Engine IO server implementation as a Tower Service."
-version = "0.17.3"
+version = "0.17.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/socketioxide/CHANGELOG.md
+++ b/crates/socketioxide/CHANGELOG.md
@@ -1,3 +1,6 @@
+# socketioxide 0.18.4
+* docs: document accessing state from custom extractors
+
 # socketioxide 0.18.3
 * fix: race condition when emitting with acknowledgement.
 * feat: expose global configured ack timeout to adapter implementations

--- a/crates/socketioxide/CHANGELOG.md
+++ b/crates/socketioxide/CHANGELOG.md
@@ -1,5 +1,6 @@
 # socketioxide 0.18.4
 * docs: document accessing state from custom extractors
+* MSRV: rust-version is now 1.94
 
 # socketioxide 0.18.3
 * fix: race condition when emitting with acknowledgement.

--- a/crates/socketioxide/Cargo.toml
+++ b/crates/socketioxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "socketioxide"
 description = "Socket IO server implementation in rust as a Tower Service."
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
# socketioxide 0.18.4
* docs: document accessing state from custom extractors. Thanks @codeurge for the contribution.
* MSRV: rust-version is now 1.94

# engineioxide 0.17.4
* MSRV: rust-version is now 1.94
* fix: issue [#731](https://github.com/Totodore/socketioxide/issues/731). Memory leak with unclaimed engine.io sessions whose WebSocket upgrade is started but never completed. Thanks @BenLocal for the contribution
* fix: missing packet separator when polling a parked v4 encoder.
* fix: incorrectly merged binary/string packets when polling a parked v3 encoder.
* fix: v3 encoded payload size is never re-computed for max payload size threshold.
* fix: v3 decoder infinite loop with malformed packet
* fix: base64 binary packet protocol mismatch with payload starting with `4`.
* fix: fix potential panic in debug with malicious v3 packets.
* fix: expect b64 query param to be equal to 1 or true to enable b64 encoding.