### PR TITLE
fix(adapter/postgres): add pg advisory lock when creating table to avoid concurrent error

### DIFF
--- a/crates/socketioxide-postgres/src/drivers/mod.rs
+++ b/crates/socketioxide-postgres/src/drivers/mod.rs
@@ -14,6 +14,11 @@ pub mod sqlx;
 #[cfg(feature = "tokio-postgres")]
 pub mod tokio_postgres;
 
+/// Fixed, application-wide 64-bit key for the transaction-scoped advisory lock
+/// taken around `CREATE TABLE IF NOT EXISTS` in every driver's [`Driver::init`].
+#[cfg(any(feature = "sqlx", feature = "tokio-postgres"))]
+pub(crate) const INIT_LOCK_KEY: i64 = 0x5_0C10_01DE;
+
 /// The driver trait can be used to support different LISTEN/NOTIFY backends.
 /// It must share handlers/connection between its clones.
 pub trait Driver: Clone + Send + Sync + 'static {

--- a/crates/socketioxide-postgres/src/drivers/sqlx.rs
+++ b/crates/socketioxide-postgres/src/drivers/sqlx.rs
@@ -7,7 +7,7 @@ use sqlx::{
     postgres::{PgListener, PgNotification},
 };
 
-use super::Driver;
+use super::{Driver, INIT_LOCK_KEY};
 
 pub use sqlx as sqlx_client;
 
@@ -32,6 +32,15 @@ impl Driver for SqlxDriver {
     type NotificationStream = BoxStream<'static, Self::Notification>;
 
     async fn init(&self, table: &str) -> Result<(), Self::Error> {
+        let mut tx = self.client.begin().await?;
+
+        // syslock to avoid concurrent CREATE TABLE issues when starting
+        // multiple node at the same time.
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(INIT_LOCK_KEY)
+            .execute(&mut *tx)
+            .await?;
+
         sqlx::query(AssertSqlSafe(format!(
             r#"CREATE TABLE IF NOT EXISTS "{table}" (
                 id BIGSERIAL UNIQUE,
@@ -39,8 +48,10 @@ impl Driver for SqlxDriver {
                 payload BYTEA
         )"#,
         )))
-        .execute(&self.client)
+        .execute(&mut *tx)
         .await?;
+
+        tx.commit().await?;
 
         Ok(())
     }

--- a/crates/socketioxide-postgres/src/drivers/tokio_postgres.rs
+++ b/crates/socketioxide-postgres/src/drivers/tokio_postgres.rs
@@ -9,7 +9,7 @@ use tokio_postgres::{AsyncMessage, Client, Config, Socket, tls::MakeTlsConnect};
 
 use crate::stream::ChanStream;
 
-use super::Driver;
+use super::{Driver, INIT_LOCK_KEY};
 
 pub use tokio_postgres as tokio_postgres_client;
 
@@ -87,15 +87,20 @@ impl Driver for TokioPostgresDriver {
     type NotificationStream = ChanStream<Self::Notification>;
 
     async fn init(&self, table: &str) -> Result<(), Self::Error> {
-        let st = &format!(
-            r#"CREATE TABLE IF NOT EXISTS "{table}" (
+        // syslock to avoid concurrent CREATE TABLE issues when starting
+        // multiple node at the same time.
+        let st = format!(
+            r#"BEGIN;
+            SELECT pg_advisory_xact_lock({INIT_LOCK_KEY});
+            CREATE TABLE IF NOT EXISTS "{table}" (
                 id BIGSERIAL UNIQUE,
                 created_at TIMESTAMPTZ DEFAULT NOW(),
                 payload BYTEA
-            )"#
+            );
+            COMMIT;"#
         );
 
-        self.client.execute(st, &[]).await?;
+        self.client.batch_execute(&st).await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

When several nodes share the same PostgreSQL database and start up concurrently (e.g. the `sqlx-e2e` adapter test, which spawns 3 servers at once), they all run `CREATE TABLE IF NOT EXISTS "socket_io_attachments"` at the same time during `Adapter::init`.

`CREATE TABLE IF NOT EXISTS` is **not** atomic in PostgreSQL: the concurrent creators all pass the existence check and then collide while inserting the table's implicit row-type into the system catalog. The losers fail with:

```
SQLSTATE 23505 — duplicate key value violates unique constraint "pg_type_typname_nsp_index"
Key (typname, typnamespace)=(socket_io_attachments, 2200) already exists.
```
CF: https://www.postgresql.org/message-id/CA+TgmoZAdYVtwBfp1FL2sMZbiHCWT4UPrzRLNnX1Nb30Ku3-gg@mail.gmail.com

## Solution

Serialize table creation behind a **transaction-scoped advisory lock** (`pg_advisory_xact_lock`) on a fixed, application-wide key shared by both drivers (`INIT_LOCK_KEY` in `drivers/mod.rs`). Only one node performs the create at a time; the others wait, then see the table already exists. The lock is released automatically on `COMMIT`/`ROLLBACK`, so there is nothing to clean up and no leaked-lock failure mode.

- **sqlx**: `PgPool::begin()` pins a single connection for the transaction, so the advisory lock and the `CREATE TABLE` run on the same backend (required, as the lock is connection/transaction scoped), then `commit()`.
- **tokio-postgres**: `Client::transaction()` needs `&mut Client`, but the driver holds an `Arc<Client>`, so the whole `BEGIN; pg_advisory_xact_lock(...); CREATE TABLE ...; COMMIT;` is sent as a single `batch_execute` simple-query batch on the one connection backing the client.
