### PR TITLE
docs(changelog): backfill missing adapter changelog entries

### DIFF
--- a/crates/socketioxide-mongodb/CHANGELOG.md
+++ b/crates/socketioxide-mongodb/CHANGELOG.md
@@ -1,3 +1,6 @@
+# socketioxide-mongodb 0.1.4
+* deps: bump `socketioxide-core` to 0.19
+
 # socketioxide-mongodb 0.1.3
 * fix: rustdoc failed build
 

--- a/crates/socketioxide-postgres/CHANGELOG.md
+++ b/crates/socketioxide-postgres/CHANGELOG.md
@@ -1,2 +1,5 @@
+# socketioxide-postgres 0.1.1
+* deps: bump `socketioxide-core` to 0.19
+
 # socketioxide-postgres 0.1.0
 * Initial release!

--- a/crates/socketioxide-redis/CHANGELOG.md
+++ b/crates/socketioxide-redis/CHANGELOG.md
@@ -1,3 +1,6 @@
+# socketioxide-redis 0.4.2
+* deps: bump `socketioxide-core` to 0.19
+
 # socketioxide-redis 0.4.1
 * fix: race condition between ack timeout and adapter request timeout when broadcasting with acks.
 


### PR DESCRIPTION
## Summary

The `socketioxide-redis` 0.4.2, `socketioxide-mongodb` 0.1.4 and `socketioxide-postgres` 0.1.1 releases (published alongside the GHSA-55mf-67qm-4wpg security fix) bumped their versions to pick up `socketioxide-core` 0.19, but were released without a matching `CHANGELOG.md` entry — their changelogs still topped out at the previous version.

This adds the missing entries so each crate's changelog reflects its currently published version.

## Changes

- `socketioxide-redis`: add `0.4.2` entry (`deps: bump socketioxide-core to 0.19`)
- `socketioxide-mongodb`: add `0.1.4` entry (`deps: bump socketioxide-core to 0.19`)
- `socketioxide-postgres`: add `0.1.1` entry (`deps: bump socketioxide-core to 0.19`)

Docs-only change; no code or version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)