### PR TITLE
fix(redis): expect a single ack count for targeted broadcast with ack

### DIFF
--- a/crates/socketioxide-redis/src/lib.rs
+++ b/crates/socketioxide-redis/src/lib.rs
@@ -506,7 +506,13 @@ impl<E: SocketEmitter, R: Driver> CoreAdapter<E> for CustomRedisAdapter<E, R> {
         let req = RequestOut::new(self.uid, RequestTypeOut::BroadcastWithAck(&packet), &opts);
         let req_id = req.id;
 
-        let remote_serv_cnt = self.server_count().await?.saturating_sub(1);
+        // When the request targets a specific server, only this server will answer,
+        // otherwise all the other servers will.
+        let remote_serv_cnt = if opts.server_id.is_none() {
+            self.server_count().await?.saturating_sub(1)
+        } else {
+            1
+        };
 
         let (tx, rx) = mpsc::channel(self.config.ack_response_buffer + remote_serv_cnt as usize);
         self.responses.lock().unwrap().insert(req_id, tx);

--- a/crates/socketioxide-redis/tests/sockets.rs
+++ b/crates/socketioxide-redis/tests/sockets.rs
@@ -168,3 +168,66 @@ pub async fn remote_socket_emit_with_ack() {
     assert_eq!(timeout_rcv!(&mut rx1), r#"421["test","hello"]"#);
     assert_eq!(timeout_rcv!(&mut rx2), r#"421["test","hello"]"#);
 }
+
+#[tokio::test]
+pub async fn remote_socket_emit_with_ack_targeted_terminates() {
+    // A targeted ack request is only sent to the server owning the socket, so
+    // the stream must terminate as soon as this server answered. It only
+    // manifests with 3+ servers, as with 2 servers the targeted count is
+    // equal to `server_count - 1`.
+    let [io1, io2, io3] = fixture::spawn_servers::<3>();
+
+    io1.ns("/", async || ()).await.unwrap();
+    io2.ns("/", async || ()).await.unwrap();
+    io3.ns("/", async || ()).await.unwrap();
+
+    let (_, mut rx1) = io1.new_dummy_sock("/", ()).await;
+    let (stx2, mut rx2) = io2.new_dummy_sock("/", ()).await;
+    let (stx3, mut rx3) = io3.new_dummy_sock("/", ()).await;
+
+    timeout_rcv!(&mut rx1); // connect packet
+    timeout_rcv!(&mut rx2); // connect packet
+    timeout_rcv!(&mut rx3); // connect packet
+
+    use futures_util::StreamExt;
+
+    let local_id = io1.config().server_id;
+    let io2_id = io2.config().server_id;
+    let mut tested = 0;
+    let sockets = io1.fetch_sockets().await.unwrap();
+    for socket in sockets {
+        // Only the remote sockets take the targeted network path.
+        if socket.data().server_id == local_id {
+            continue;
+        }
+        let (stx, rx) = if socket.data().server_id == io2_id {
+            (&stx2, &mut rx2)
+        } else {
+            (&stx3, &mut rx3)
+        };
+
+        let stream = socket
+            .emit_with_ack::<_, [String; 1]>("test", "hello")
+            .await
+            .unwrap();
+
+        // Make the remote client answer the ack.
+        let packet = timeout_rcv!(rx, 1000); // "42<ack_id>[\"test\",\"hello\"]"
+        let ack_id = &packet[2..packet.find('[').unwrap()];
+        stx.send(engineioxide::Packet::Message(
+            format!("3{ack_id}[\"oof\"]").into(),
+        ))
+        .await
+        .unwrap();
+
+        futures_util::pin_mut!(stream);
+        let ack = stream.next().await;
+        assert!(matches!(ack, Some((_, Ok(_)))), "expected the ack");
+        assert!(
+            futures_core::FusedStream::is_terminated(&stream),
+            "the ack stream should terminate right after the targeted ack"
+        );
+        tested += 1;
+    }
+    assert!(tested > 0, "expected remote sockets to be tested");
+}


### PR DESCRIPTION
Fixes a redis adapter bug i noticed while working on #774 (thanks for asking for a separate PR for it).

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/totodore/socketioxide/blob/main/CONTRIBUTING.md
-->

## Motivation

When `BroadcastOptions::server_id` is set (broadcasting to a remote socket), redis sends the ack request to that server only, but the expected ack count was always `server_count - 1`.
With 3+ servers only one server answers, so the ack stream does not terminate cleanly and waits for the request timeout instead.

With 2 servers the targeted count happens to be equal to `server_count - 1`, which is why this went unnoticed: the existing `remote_socket_emit_with_ack` test never awaits the acks.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

`get_res` already handles a targeted request this way, so I mirrored it in `broadcast_with_ack`:

```rust
let remote_serv_cnt = if opts.server_id.is_none() {
    self.server_count().await?.saturating_sub(1)
} else {
    1
};
```

Added
     `remote_socket_emit_with_ack_targeted_terminates` in `crates/socketioxide-redis/tests/sockets.rs`: spawns 3 servers, emits with ack to the remote sockets (echoing the acks from the fake clients) and asserts the stream is terminated right after the ack. It fails before the fix and passes after.
No behavior or wire format change for the non targeted case.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
